### PR TITLE
Add project vision and architecture decision records

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,38 @@
-# majordomo
-My information and property manager. Takes on all the grunt work.
+# Majordomo
+
+A service-based personal information and property management system. Majordomo acts as the head of household — it knows where everything is, who sold it, and who is supposed to fix it.
+
+## Vision
+
+Majordomo bridges the gap between digital data (PIM) and physical assets (property management) through a modular, service-oriented architecture. Rather than treating belongings as static inventory, Majordomo orchestrates the relationships between people, things, and time.
+
+An item isn't just a "thing you own" — it's a nexus of relationships: the vendor who sold it, the technician who maintains it, and the future you who needs it to work.
+
+## Architecture
+
+Majordomo is built as a collection of independent services, each named after a role within a traditional estate household:
+
+| Service | Role | Responsibility |
+|---------|------|----------------|
+| **The Steward** | Property Service | Manages physical assets, their current state, and documentation (manuals, receipts) |
+| **The Concierge** | Contact Service | Manages relationships — vendors, maintenance professionals, and sellers |
+| **The Herald** | Calendar/Notification Service | Handles scheduling — service dates, reminders, warranty expirations |
+| **The Ledger** | Finance Service | Tracks costs from purchase price to lifetime maintenance spend |
+
+The **Majordomo** itself is the orchestration layer that ties these services together.
+
+Additional services can be introduced over time (e.g., "The Gardener" for landscaping, "The Archivist" for digital documents) without breaking the naming or architectural model.
+
+## Key Concepts
+
+- **Service-based**: Each domain is an independent service that can be developed, deployed, and scaled on its own
+- **Relationship-first**: The system models connections between people, assets, and events — not just static records
+- **Lifecycle-aware**: Assets are tracked from acquisition through maintenance to eventual replacement
+
+## Status
+
+Early development. Architecture decisions are being recorded in `doc/adr/`.
+
+## License
+
+See [LICENSE](LICENSE).

--- a/doc/adr/0001-record-architecture-decisions.md
+++ b/doc/adr/0001-record-architecture-decisions.md
@@ -1,0 +1,19 @@
+# 1. Record architecture decisions
+
+Date: 2026-03-24
+
+## Status
+
+Accepted
+
+## Context
+
+We need to record the architectural decisions made on this project.
+
+## Decision
+
+We will use Architecture Decision Records, as [described by Michael Nygard](http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions).
+
+## Consequences
+
+See Michael Nygard's article, linked above. For a lightweight ADR toolset, see Nat Pryce's [adr-tools](https://github.com/npryce/adr-tools).

--- a/doc/adr/0002-adopt-service-based-architecture-with-household-staff-naming-convention.md
+++ b/doc/adr/0002-adopt-service-based-architecture-with-household-staff-naming-convention.md
@@ -1,0 +1,34 @@
+# 2. Adopt service-based architecture with household staff naming convention
+
+Date: 2026-03-24
+
+## Status
+
+Accepted
+
+## Context
+
+Majordomo combines personal information management (PIM) with physical property management. These domains span contacts, calendars, asset tracking, maintenance scheduling, and financial records. Building this as a monolith would tightly couple concerns that naturally evolve at different rates and have different scaling characteristics.
+
+The project name "Majordomo" — the head of a household — suggests a thematic naming convention that maps naturally to a service-based architecture where each service plays a distinct household role.
+
+## Decision
+
+We will build Majordomo as a collection of independent services, each responsible for a single domain. The orchestration layer is "Majordomo" itself, and each service is named after a traditional estate household role:
+
+- **The Steward** (Property Service) — manages physical assets, their state, and documentation (manuals, receipts)
+- **The Concierge** (Contact Service) — manages relationships with vendors, maintenance professionals, and sellers
+- **The Herald** (Calendar/Notification Service) — handles scheduling, reminders, and warranty expirations
+- **The Ledger** (Finance Service) — tracks costs from purchase price to lifetime maintenance spend
+
+New services follow this naming convention (e.g., "The Gardener" for landscaping, "The Archivist" for document management).
+
+Services communicate through well-defined interfaces. Each service can be developed, tested, and deployed independently.
+
+## Consequences
+
+- Each service can be added incrementally — we do not need all services on day one.
+- Services can be built with different technologies if appropriate, though consistency is preferred.
+- The naming convention makes the system intuitive and keeps architectural discussions grounded in clear metaphors.
+- Cross-service operations (e.g., scheduling a maintenance event that involves a contact, an asset, and a calendar entry) require coordination through the orchestration layer, adding complexity compared to a monolith.
+- Service boundaries must be carefully defined to avoid tight coupling or excessive inter-service chatter.

--- a/doc/adr/0003-use-strict-test-driven-development.md
+++ b/doc/adr/0003-use-strict-test-driven-development.md
@@ -1,0 +1,36 @@
+# 3. Use strict test-driven development
+
+Date: 2026-03-24
+
+## Status
+
+Accepted
+
+## Context
+
+Majordomo is a service-based system where services interact across well-defined boundaries. Confidence in correctness at both the unit and integration level is critical. We need a development discipline that keeps design emergent, prevents speculative complexity, and produces a reliable test suite as a byproduct of normal work.
+
+## Decision
+
+We will follow strict TDD using the red-green-refactor cycle:
+
+1. **Red** — Write one failing unit test that describes the next small increment of behavior.
+2. **Green** — Write the minimum code to make that test pass.
+3. **Commit** — Commit the passing test and implementation together.
+4. **Refactor** — Improve the design (remove duplication, clarify names, extract abstractions) while keeping all tests green. Commit again if changes were made.
+
+Rules:
+
+- No production code is written without a failing test driving it.
+- Only one test is added at a time. Do not write a batch of tests up front.
+- The green step does the simplest thing that works — no anticipatory design.
+- Refactoring is where design emerges. It is not optional, but it must not change behavior.
+- Each red-green and refactor cycle produces its own commit, keeping the history bisectable and reviewable.
+
+## Consequences
+
+- The codebase will have high test coverage as a natural side effect, not as a separate effort.
+- Commits will be small and focused, making code review and git bisect effective.
+- Design emerges from real requirements rather than speculation, reducing unnecessary abstraction.
+- The discipline requires practice and can feel slow at first, but prevents costly rework later.
+- Developers must resist the urge to write code ahead of tests or to batch multiple behaviors into one cycle.

--- a/doc/adr/0004-use-hexagonal-architecture-for-services.md
+++ b/doc/adr/0004-use-hexagonal-architecture-for-services.md
@@ -1,0 +1,33 @@
+# 4. Use hexagonal architecture for services
+
+Date: 2026-03-24
+
+## Status
+
+Accepted
+
+## Context
+
+Each Majordomo service (Steward, Concierge, Herald, Ledger) must be independently developable and testable (see ADR-0002). We also practice strict TDD (see ADR-0003), which requires that core business logic be testable without external dependencies like databases, HTTP servers, or third-party APIs.
+
+We need an internal structure for each service that enforces a clear separation between domain logic and infrastructure concerns.
+
+## Decision
+
+Each service will follow hexagonal architecture (ports and adapters), as described by Alistair Cockburn.
+
+The structure has three layers:
+
+- **Domain** — Pure business logic and domain models. No dependencies on frameworks, databases, or external services. This is where TDD lives most naturally.
+- **Ports** — Interfaces that define how the domain interacts with the outside world. Inbound ports (driving) describe what the application can do. Outbound ports (driven) describe what the application needs from external systems.
+- **Adapters** — Concrete implementations of ports. Inbound adapters (e.g., REST controllers, CLI handlers, message consumers) translate external requests into domain operations. Outbound adapters (e.g., database repositories, API clients, message producers) fulfill the domain's infrastructure needs.
+
+Dependencies always point inward: adapters depend on ports, ports depend on the domain. The domain depends on nothing.
+
+## Consequences
+
+- Domain logic is fully testable with fast, isolated unit tests — no mocks of infrastructure required at the domain level.
+- Adapters can be swapped without changing business logic (e.g., replacing a SQL repository with an in-memory one for testing, or switching from REST to gRPC).
+- Each service has a consistent internal structure, making it easier to navigate and onboard to any service in the system.
+- The port/adapter boundary adds some boilerplate (interfaces, adapter classes) that may feel heavy for very simple services.
+- Aligns well with TDD: tests drive the domain design through ports, and adapters are integration-tested separately.

--- a/doc/adr/0005-use-java-25.md
+++ b/doc/adr/0005-use-java-25.md
@@ -1,0 +1,31 @@
+# 5. Use Java 25
+
+Date: 2026-03-24
+
+## Status
+
+Accepted
+
+## Context
+
+Majordomo is a greenfield project with no legacy compatibility constraints. We are free to choose the latest Java version and take advantage of modern language features and runtime improvements.
+
+Java 25 is the current release, offering virtual threads (Project Loom), pattern matching, record patterns, sealed classes, and other features that reduce boilerplate and improve readability.
+
+## Decision
+
+We will use Java 25 as the platform for all Majordomo services.
+
+We will adopt modern language features where they improve clarity:
+
+- **Records** for immutable data carriers (DTOs, domain value objects)
+- **Sealed classes** for constrained type hierarchies in domain models
+- **Pattern matching** (switch expressions, record patterns) for cleaner control flow
+- **Virtual threads** for scalable concurrent I/O without reactive complexity
+
+## Consequences
+
+- Access to the latest language features keeps code concise and idiomatic.
+- Virtual threads simplify concurrent service-to-service communication without requiring a reactive framework.
+- All developers must be on Java 25; older JDKs will not compile the codebase.
+- We will need to track the next LTS release and plan a migration when appropriate.

--- a/doc/adr/0006-use-latest-spring-boot.md
+++ b/doc/adr/0006-use-latest-spring-boot.md
@@ -1,0 +1,34 @@
+# 6. Use latest Spring Boot
+
+Date: 2026-03-24
+
+## Status
+
+Accepted
+
+## Context
+
+Each Majordomo service needs a framework for dependency injection, configuration, HTTP/REST support, and integration with infrastructure (databases, messaging, metrics). We need a framework that is well-supported, widely understood, and compatible with Java 25 and hexagonal architecture (see ADR-0004, ADR-0005).
+
+## Decision
+
+We will use the latest stable release of Spring Boot as the application framework for all services.
+
+Spring Boot provides:
+
+- Auto-configuration and convention-over-configuration for fast service setup
+- Spring Web for REST adapters (inbound) and RestClient/WebClient for outbound adapters
+- Spring Data for repository adapters
+- Actuator for health checks, metrics, and operational endpoints
+- Native support for virtual threads (Java 25)
+- Micrometer integration for Prometheus metrics (see ADR-0009)
+
+We will stay on the latest stable release and upgrade promptly when new versions are available.
+
+## Consequences
+
+- Rapid bootstrapping of new services with minimal configuration.
+- Large ecosystem of starters and integrations reduces custom infrastructure code.
+- The Spring community and documentation make onboarding straightforward.
+- Spring Boot's opinions may occasionally conflict with hexagonal architecture purity; adapters should wrap Spring concerns rather than letting Spring annotations leak into the domain layer.
+- Staying on the latest release requires regular dependency updates, but avoids accumulating upgrade debt.

--- a/doc/adr/0007-use-slf4j-for-logging.md
+++ b/doc/adr/0007-use-slf4j-for-logging.md
@@ -1,0 +1,27 @@
+# 7. Use SLF4J for logging
+
+Date: 2026-03-24
+
+## Status
+
+Accepted
+
+## Context
+
+A service-based system needs consistent, structured logging across all services for debugging, auditing, and operational visibility. The logging API should be decoupled from the logging implementation so that the backend can be changed without modifying application code.
+
+## Decision
+
+We will use SLF4J as the logging API across all Majordomo services.
+
+- All application code logs through the SLF4J API (`org.slf4j.Logger`).
+- The logging backend (Logback, Log4j2, etc.) is chosen per deployment and configured via the adapter layer, not the domain.
+- Spring Boot's default Logback backend is acceptable unless a specific need arises to switch.
+- Structured logging (key-value pairs, MDC for correlation IDs) will be used to support log aggregation and searchability.
+
+## Consequences
+
+- Logging calls are implementation-agnostic — switching backends requires only a dependency and configuration change.
+- Consistent logging API across all services simplifies debugging and log analysis.
+- Domain code can use SLF4J without taking a dependency on any infrastructure framework.
+- Developers must avoid using `System.out.println` or framework-specific logging APIs directly.

--- a/doc/adr/0008-use-grafana-for-observability-dashboards.md
+++ b/doc/adr/0008-use-grafana-for-observability-dashboards.md
@@ -1,0 +1,27 @@
+# 8. Use Grafana for observability dashboards
+
+Date: 2026-03-24
+
+## Status
+
+Accepted
+
+## Context
+
+With multiple independent services, we need centralized visibility into system health, performance, and behavior. Dashboards should surface metrics from all services in one place and support alerting when things go wrong.
+
+## Decision
+
+We will use Grafana as the dashboard and visualization layer for observability across all Majordomo services.
+
+- Grafana will consume metrics from Prometheus (see ADR-0009) as its primary data source.
+- Each service will have a standard dashboard covering key indicators: request rate, error rate, latency, and resource utilization.
+- Dashboards will be defined as code (JSON/YAML provisioning) and version-controlled alongside the services they describe.
+- Grafana alerting will be used for operational notifications.
+
+## Consequences
+
+- Single pane of glass for the health of all services.
+- Dashboards-as-code ensures they are reproducible, reviewable, and versioned.
+- Grafana is widely adopted and has strong community support for Spring Boot and Prometheus integrations.
+- Adds an infrastructure dependency that must be deployed and maintained alongside the services.

--- a/doc/adr/0009-use-prometheus-for-metrics-collection.md
+++ b/doc/adr/0009-use-prometheus-for-metrics-collection.md
@@ -1,0 +1,27 @@
+# 9. Use Prometheus for metrics collection
+
+Date: 2026-03-24
+
+## Status
+
+Accepted
+
+## Context
+
+Each Majordomo service produces operational metrics (request counts, latencies, error rates, JVM stats). We need a metrics collection system that integrates naturally with Spring Boot and feeds data to Grafana (see ADR-0008) for visualization and alerting.
+
+## Decision
+
+We will use Prometheus as the metrics collection and storage system for all Majordomo services.
+
+- Each Spring Boot service exposes a `/actuator/prometheus` endpoint via Micrometer and the Prometheus registry.
+- Prometheus scrapes these endpoints on a regular interval.
+- Custom application metrics (e.g., assets tracked, maintenance events scheduled) are registered through Micrometer's API, keeping application code decoupled from Prometheus specifics.
+- Prometheus is the primary data source for Grafana dashboards and alerts.
+
+## Consequences
+
+- Pull-based scraping is simple to configure and does not require services to know about the metrics backend.
+- Micrometer provides a vendor-neutral metrics API — switching from Prometheus to another backend (e.g., OpenTelemetry Collector) requires only a registry change.
+- Spring Boot Actuator + Micrometer provides JVM, HTTP, and database metrics out of the box with minimal configuration.
+- Prometheus must be deployed and configured with scrape targets for each service; service discovery or static config is needed as services scale.


### PR DESCRIPTION
## Summary

- Updated README with project vision, service architecture table (Steward, Concierge, Herald, Ledger), and key concepts
- Initialized ADR directory with 9 architecture decision records:
  - ADR 0001: Record architecture decisions
  - ADR 0002: Service-based architecture with household staff naming
  - ADR 0003: Strict TDD (red-green-commit-refactor)
  - ADR 0004: Hexagonal architecture (ports and adapters)
  - ADR 0005: Java 25
  - ADR 0006: Latest Spring Boot
  - ADR 0007: SLF4J for logging
  - ADR 0008: Grafana for observability dashboards
  - ADR 0009: Prometheus for metrics collection

## Test plan

- [ ] Review README for accuracy and completeness
- [ ] Verify ADR cross-references are correct
- [ ] Confirm ADR numbering is sequential

🤖 Generated with [Claude Code](https://claude.com/claude-code)