### PR TITLE
Add ADR 0010: human review and branch-based workflow

### DIFF
--- a/doc/adr/0010-require-human-review-and-branch-based-development-workflow.md
+++ b/doc/adr/0010-require-human-review-and-branch-based-development-workflow.md
@@ -1,0 +1,36 @@
+# 10. Require human review and branch-based development workflow
+
+Date: 2026-03-24
+
+## Status
+
+Accepted
+
+## Context
+
+Majordomo development may involve AI-assisted code generation. Regardless of how code is produced, only robsartin is accountable for what lands in the codebase. We need a workflow that ensures every change is intentionally reviewed and approved before it reaches main.
+
+## Decision
+
+All code committed to this repository must be either written or reviewed by robsartin. No code reaches main without explicit human approval.
+
+The development workflow is:
+
+1. **Branch** — All work happens on a fresh branch created from main. No commits directly to main.
+2. **Develop** — Commits are made to the feature branch following strict TDD (see ADR-0003).
+3. **Pull Request** — When work is complete, a merge PR is submitted against main.
+4. **Review** — robsartin reviews and approves the PR before merging.
+5. **Merge** — The PR is merged to main. The feature branch is deleted.
+
+Rules:
+
+- No direct pushes to main.
+- No merging without a PR.
+- AI-generated code is treated the same as any other contribution — it must be reviewed and approved by robsartin.
+
+## Consequences
+
+- Main is always in a known-good, reviewed state.
+- Every change has a PR as its audit trail, linking the diff to its review and approval.
+- AI tooling can accelerate development without reducing accountability — robsartin remains the gatekeeper.
+- Solo development with mandatory PRs adds a small amount of process overhead, but the review step catches issues before they reach main.


### PR DESCRIPTION
## Summary

- Adds ADR 0010 requiring all code be written or reviewed by robsartin before reaching main
- Establishes branch-based workflow: fresh branch from main, develop with TDD, submit merge PR, review, merge
- AI-generated code is held to the same review standard as any other contribution

## Test plan

- [ ] Review ADR content for accuracy
- [ ] Merge after PR #1 to maintain ADR numbering sequence

🤖 Generated with [Claude Code](https://claude.com/claude-code)