### PR TITLE
Add ADR 0015: Javadoc requirement and Mermaid diagrams

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -82,6 +82,19 @@
         <!-- Modifiers -->
         <module name="ModifierOrder"/>
         <module name="RedundantModifier"/>
+
+        <!-- Javadoc -->
+        <module name="MissingJavadocMethod">
+            <property name="scope" value="public"/>
+            <property name="allowMissingPropertyJavadoc" value="true"/>
+            <property name="minLineCount" value="2"/>
+        </module>
+        <module name="JavadocMethod">
+            <property name="accessModifiers" value="public"/>
+        </module>
+        <module name="MissingJavadocType">
+            <property name="scope" value="public"/>
+        </module>
     </module>
 
     <!-- Line length (Checker-level in Checkstyle 10+) -->

--- a/config/checkstyle/suppressions.xml
+++ b/config/checkstyle/suppressions.xml
@@ -10,4 +10,18 @@
     <suppress checks="LeftCurly" files=".*model[/\\].*\.java"/>
     <suppress checks="LeftCurly" files=".*Entity\.java"/>
     <suppress checks="LeftCurly" files=".*Mapper\.java"/>
+
+    <!-- Javadoc exemptions for boilerplate accessors and framework classes -->
+    <suppress checks="MissingJavadocMethod" files=".*Entity\.java"/>
+    <suppress checks="MissingJavadocMethod" files=".*Mapper\.java"/>
+    <suppress checks="MissingJavadocMethod" files=".*model[/\\].*\.java"/>
+    <suppress checks="MissingJavadocType" files=".*Entity\.java"/>
+    <suppress checks="MissingJavadocType" files=".*Mapper\.java"/>
+    <suppress checks="JavadocMethod" files=".*Entity\.java"/>
+    <suppress checks="JavadocMethod" files=".*Mapper\.java"/>
+    <suppress checks="JavadocMethod" files=".*model[/\\].*\.java"/>
+
+    <!-- Test classes -->
+    <suppress checks="MissingJavadocMethod" files=".*Tests?\.java"/>
+    <suppress checks="MissingJavadocType" files=".*Tests?\.java"/>
 </suppressions>

--- a/doc/adr/0015-require-javadoc-on-public-methods-and-use-mermaid-diagrams.md
+++ b/doc/adr/0015-require-javadoc-on-public-methods-and-use-mermaid-diagrams.md
@@ -1,0 +1,36 @@
+# 15. Require Javadoc on public methods and use Mermaid diagrams
+
+Date: 2026-03-24
+
+## Status
+
+Accepted
+
+## Context
+
+Majordomo uses hexagonal architecture with multiple domain packages (see ADR-0004). Public methods on domain models, ports, and adapters form the contracts between layers. Without documentation, these contracts are implicit and require reading implementations to understand intent. Architectural and flow diagrams further aid comprehension but drift when maintained in external tools.
+
+## Decision
+
+All public methods must have Javadoc comments. This is enforced by Checkstyle (see ADR-0014) via the `MissingJavadocMethod` check.
+
+Javadoc requirements:
+
+- All public methods must have a Javadoc comment describing their purpose.
+- `@param`, `@return`, and `@throws` tags are required where applicable.
+- Simple getters, setters, and JPA entity accessors are exempt via Checkstyle suppression.
+- Javadoc should describe *what* and *why*, not *how* — implementation details belong in inline comments if needed at all.
+
+Mermaid diagrams:
+
+- Mermaid diagrams are used in Javadoc and Markdown documentation where they clarify architecture, data flow, or entity relationships.
+- The domain model diagram is maintained in `doc/domain-model.md` (see existing Mermaid class diagram).
+- Sequence diagrams, flowcharts, and component diagrams should be added to package-level `package-info.java` or `doc/` files when they aid understanding of cross-service interactions or complex workflows.
+
+## Consequences
+
+- Public API contracts are explicit and discoverable through IDE tooling and generated documentation.
+- Checkstyle enforcement ensures documentation does not decay over time.
+- Mermaid diagrams stay in sync with the code because they live alongside it in version control.
+- Getters/setters are exempt to avoid boilerplate Javadoc that adds no value.
+- Writing meaningful Javadoc requires discipline — template comments like "Gets the id" should be avoided in favor of domain-relevant descriptions.

--- a/src/main/java/com/majordomo/MajordomoApplication.java
+++ b/src/main/java/com/majordomo/MajordomoApplication.java
@@ -3,9 +3,22 @@ package com.majordomo;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
+/**
+ * Entry point for the Majordomo Spring Boot application.
+ *
+ * <p>Majordomo is a personal information and property management system built
+ * on a hexagonal architecture. Domain logic is isolated from infrastructure
+ * concerns; inbound REST adapters delegate to domain ports rather than
+ * accessing persistence or external services directly.</p>
+ */
 @SpringBootApplication
 public class MajordomoApplication {
 
+    /**
+     * Bootstraps the Spring application context and starts the embedded server.
+     *
+     * @param args command-line arguments passed through to Spring Boot
+     */
     public static void main(String[] args) {
         SpringApplication.run(MajordomoApplication.class, args);
     }

--- a/src/main/java/com/majordomo/adapter/in/web/concierge/ContactController.java
+++ b/src/main/java/com/majordomo/adapter/in/web/concierge/ContactController.java
@@ -17,21 +17,44 @@ import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
 
+/**
+ * REST controller for the Concierge domain: manages contacts associated with organizations.
+ *
+ * <p>Exposes CRUD operations under {@code /api/contacts}. Acts as an inbound adapter in the
+ * hexagonal architecture, delegating persistence to {@link ContactRepository}.</p>
+ */
 @RestController
 @RequestMapping("/api/contacts")
 public class ContactController {
 
     private final ContactRepository contactRepository;
 
+    /**
+     * Constructs a {@code ContactController} with the given contact repository.
+     *
+     * @param contactRepository the port used to store and retrieve contacts
+     */
     public ContactController(ContactRepository contactRepository) {
         this.contactRepository = contactRepository;
     }
 
+    /**
+     * Returns all contacts belonging to the specified organization.
+     *
+     * @param organizationId the UUID of the organization whose contacts are retrieved
+     * @return a list of matching contacts; empty if none exist
+     */
     @GetMapping
     public List<Contact> listByOrganization(@RequestParam UUID organizationId) {
         return contactRepository.findByOrganizationId(organizationId);
     }
 
+    /**
+     * Returns a single contact by its unique identifier.
+     *
+     * @param id the UUID of the contact to retrieve
+     * @return {@code 200 OK} with the contact body, or {@code 404 Not Found} if no match exists
+     */
     @GetMapping("/{id}")
     public ResponseEntity<Contact> getById(@PathVariable UUID id) {
         return contactRepository.findById(id)
@@ -39,6 +62,12 @@ public class ContactController {
                 .orElse(ResponseEntity.notFound().build());
     }
 
+    /**
+     * Creates a new contact, assigning a generated ID and audit timestamps.
+     *
+     * @param contact the contact data provided in the request body
+     * @return {@code 201 Created} with the persisted contact and a {@code Location} header
+     */
     @PostMapping
     public ResponseEntity<Contact> create(@RequestBody Contact contact) {
         contact.setId(UUID.randomUUID());

--- a/src/main/java/com/majordomo/adapter/in/web/config/ApiVersionInterceptor.java
+++ b/src/main/java/com/majordomo/adapter/in/web/config/ApiVersionInterceptor.java
@@ -6,11 +6,27 @@ import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerInterceptor;
 
+/**
+ * Spring MVC interceptor that propagates the {@code X-API-Version} header on every response.
+ *
+ * <p>If the incoming request does not include the header, the interceptor defaults to version
+ * {@value #DEFAULT_VERSION}. This ensures clients can always rely on the response header to
+ * identify which API version handled their request.</p>
+ */
 @Component
 public class ApiVersionInterceptor implements HandlerInterceptor {
 
     private static final String DEFAULT_VERSION = "1";
 
+    /**
+     * Reads the {@code X-API-Version} request header and echoes it (or the default) back on
+     * the response before the handler is invoked.
+     *
+     * @param request  the current HTTP request
+     * @param response the current HTTP response
+     * @param handler  the chosen handler to execute
+     * @return {@code true} to continue processing the handler chain
+     */
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
         String version = request.getHeader(OpenApiConfig.API_VERSION_HEADER);

--- a/src/main/java/com/majordomo/adapter/in/web/config/OpenApiConfig.java
+++ b/src/main/java/com/majordomo/adapter/in/web/config/OpenApiConfig.java
@@ -9,11 +9,24 @@ import org.springdoc.core.models.GroupedOpenApi;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+/**
+ * SpringDoc / OpenAPI 3 configuration for the Majordomo API.
+ *
+ * <p>Defines the top-level API metadata, injects the {@code X-API-Version} header parameter
+ * into every operation via an {@link OperationCustomizer}, and groups endpoints by domain
+ * (concierge, steward, herald) for organised Swagger UI navigation.</p>
+ */
 @Configuration
 public class OpenApiConfig {
 
+    /** Name of the HTTP header used to communicate the API version. */
     public static final String API_VERSION_HEADER = "X-API-Version";
 
+    /**
+     * Produces the root {@link OpenAPI} bean containing global API metadata.
+     *
+     * @return an {@link OpenAPI} instance with title, description, and current version
+     */
     @Bean
     public OpenAPI openAPI() {
         return new OpenAPI()
@@ -23,6 +36,13 @@ public class OpenApiConfig {
                         .version("1"));
     }
 
+    /**
+     * Returns an {@link OperationCustomizer} that appends the optional
+     * {@value #API_VERSION_HEADER} header parameter to every API operation in the
+     * generated OpenAPI document.
+     *
+     * @return the operation customizer bean
+     */
     @Bean
     public OperationCustomizer apiVersionHeaderCustomizer() {
         return (operation, handlerMethod) -> {
@@ -36,6 +56,11 @@ public class OpenApiConfig {
         };
     }
 
+    /**
+     * Groups the Concierge (contacts) endpoints under a dedicated Swagger UI section.
+     *
+     * @return a {@link GroupedOpenApi} covering {@code /api/contacts/**}
+     */
     @Bean
     public GroupedOpenApi conciergeApi() {
         return GroupedOpenApi.builder()
@@ -45,6 +70,11 @@ public class OpenApiConfig {
                 .build();
     }
 
+    /**
+     * Groups the Steward (properties) endpoints under a dedicated Swagger UI section.
+     *
+     * @return a {@link GroupedOpenApi} covering {@code /api/properties/**}
+     */
     @Bean
     public GroupedOpenApi stewardApi() {
         return GroupedOpenApi.builder()
@@ -54,6 +84,11 @@ public class OpenApiConfig {
                 .build();
     }
 
+    /**
+     * Groups the Herald (schedules) endpoints under a dedicated Swagger UI section.
+     *
+     * @return a {@link GroupedOpenApi} covering {@code /api/schedules/**}
+     */
     @Bean
     public GroupedOpenApi heraldApi() {
         return GroupedOpenApi.builder()

--- a/src/main/java/com/majordomo/adapter/in/web/config/WebConfig.java
+++ b/src/main/java/com/majordomo/adapter/in/web/config/WebConfig.java
@@ -4,15 +4,32 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
+/**
+ * Spring MVC configuration for the Majordomo web layer.
+ *
+ * <p>Registers application-wide interceptors. Currently applies
+ * {@link ApiVersionInterceptor} to all {@code /api/**} routes so that every API
+ * response carries the {@code X-API-Version} header.</p>
+ */
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
 
     private final ApiVersionInterceptor apiVersionInterceptor;
 
+    /**
+     * Constructs a {@code WebConfig} with the API version interceptor to register.
+     *
+     * @param apiVersionInterceptor the interceptor that echoes the API version header
+     */
     public WebConfig(ApiVersionInterceptor apiVersionInterceptor) {
         this.apiVersionInterceptor = apiVersionInterceptor;
     }
 
+    /**
+     * Registers the {@link ApiVersionInterceptor} for all paths matching {@code /api/**}.
+     *
+     * @param registry the interceptor registry provided by Spring MVC
+     */
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(apiVersionInterceptor)

--- a/src/main/java/com/majordomo/adapter/in/web/herald/ScheduleController.java
+++ b/src/main/java/com/majordomo/adapter/in/web/herald/ScheduleController.java
@@ -20,6 +20,15 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.UUID;
 
+/**
+ * REST controller for the Herald domain: manages maintenance schedules and service records
+ * for properties.
+ *
+ * <p>Exposes schedule CRUD operations and service-record tracking under
+ * {@code /api/schedules}. Acts as an inbound adapter in the hexagonal architecture,
+ * delegating persistence to {@link MaintenanceScheduleRepository} and
+ * {@link ServiceRecordRepository}.</p>
+ */
 @RestController
 @RequestMapping("/api/schedules")
 public class ScheduleController {
@@ -27,6 +36,12 @@ public class ScheduleController {
     private final MaintenanceScheduleRepository scheduleRepository;
     private final ServiceRecordRepository serviceRecordRepository;
 
+    /**
+     * Constructs a {@code ScheduleController} with the required repositories.
+     *
+     * @param scheduleRepository      the port used to store and retrieve maintenance schedules
+     * @param serviceRecordRepository the port used to store and retrieve service records
+     */
     public ScheduleController(
             MaintenanceScheduleRepository scheduleRepository,
             ServiceRecordRepository serviceRecordRepository) {
@@ -34,16 +49,34 @@ public class ScheduleController {
         this.serviceRecordRepository = serviceRecordRepository;
     }
 
+    /**
+     * Returns all maintenance schedules associated with the specified property.
+     *
+     * @param propertyId the UUID of the property whose schedules are retrieved
+     * @return a list of matching schedules; empty if none exist
+     */
     @GetMapping
     public List<MaintenanceSchedule> listByProperty(@RequestParam UUID propertyId) {
         return scheduleRepository.findByPropertyId(propertyId);
     }
 
+    /**
+     * Returns all maintenance schedules due within a given number of days from today.
+     *
+     * @param days the lookahead window in days; defaults to 30 if not specified
+     * @return a list of schedules whose due date falls before the calculated cutoff
+     */
     @GetMapping("/upcoming")
     public List<MaintenanceSchedule> listUpcoming(@RequestParam(defaultValue = "30") int days) {
         return scheduleRepository.findDueBefore(LocalDate.now().plusDays(days));
     }
 
+    /**
+     * Returns a single maintenance schedule by its unique identifier.
+     *
+     * @param id the UUID of the schedule to retrieve
+     * @return {@code 200 OK} with the schedule body, or {@code 404 Not Found} if no match exists
+     */
     @GetMapping("/{id}")
     public ResponseEntity<MaintenanceSchedule> getById(@PathVariable UUID id) {
         return scheduleRepository.findById(id)
@@ -51,6 +84,12 @@ public class ScheduleController {
                 .orElse(ResponseEntity.notFound().build());
     }
 
+    /**
+     * Creates a new maintenance schedule, assigning a generated ID and audit timestamps.
+     *
+     * @param schedule the schedule data provided in the request body
+     * @return {@code 201 Created} with the persisted schedule and a {@code Location} header
+     */
     @PostMapping
     public ResponseEntity<MaintenanceSchedule> create(@RequestBody MaintenanceSchedule schedule) {
         schedule.setId(UUID.randomUUID());
@@ -60,6 +99,16 @@ public class ScheduleController {
         return ResponseEntity.created(URI.create("/api/schedules/" + saved.getId())).body(saved);
     }
 
+    /**
+     * Records a completed service event against an existing maintenance schedule.
+     *
+     * <p>The new record is linked to the given schedule ID and assigned a generated ID
+     * and audit timestamps before being persisted.</p>
+     *
+     * @param id     the UUID of the maintenance schedule being serviced
+     * @param record the service record data provided in the request body
+     * @return {@code 201 Created} with the persisted service record and a {@code Location} header
+     */
     @PostMapping("/{id}/records")
     public ResponseEntity<ServiceRecord> recordService(
             @PathVariable UUID id,
@@ -72,6 +121,12 @@ public class ScheduleController {
         return ResponseEntity.created(URI.create("/api/schedules/" + id + "/records/" + saved.getId())).body(saved);
     }
 
+    /**
+     * Returns all service records associated with the specified maintenance schedule.
+     *
+     * @param id the UUID of the maintenance schedule whose records are retrieved
+     * @return a list of service records; empty if none have been recorded
+     */
     @GetMapping("/{id}/records")
     public List<ServiceRecord> listRecords(@PathVariable UUID id) {
         return serviceRecordRepository.findByScheduleId(id);

--- a/src/main/java/com/majordomo/adapter/in/web/steward/PropertyController.java
+++ b/src/main/java/com/majordomo/adapter/in/web/steward/PropertyController.java
@@ -18,21 +18,46 @@ import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
 
+/**
+ * REST controller for the Steward domain: manages properties within organizations.
+ *
+ * <p>Exposes CRUD operations and hierarchy traversal under {@code /api/properties}. Acts as
+ * an inbound adapter in the hexagonal architecture, delegating persistence to
+ * {@link PropertyRepository}. Properties may be nested; a property can have a parent and
+ * zero or more child properties.</p>
+ */
 @RestController
 @RequestMapping("/api/properties")
 public class PropertyController {
 
     private final PropertyRepository propertyRepository;
 
+    /**
+     * Constructs a {@code PropertyController} with the given property repository.
+     *
+     * @param propertyRepository the port used to store and retrieve properties
+     */
     public PropertyController(PropertyRepository propertyRepository) {
         this.propertyRepository = propertyRepository;
     }
 
+    /**
+     * Returns all properties belonging to the specified organization.
+     *
+     * @param organizationId the UUID of the organization whose properties are retrieved
+     * @return a list of matching properties; empty if none exist
+     */
     @GetMapping
     public List<Property> listByOrganization(@RequestParam UUID organizationId) {
         return propertyRepository.findByOrganizationId(organizationId);
     }
 
+    /**
+     * Returns a single property by its unique identifier.
+     *
+     * @param id the UUID of the property to retrieve
+     * @return {@code 200 OK} with the property body, or {@code 404 Not Found} if no match exists
+     */
     @GetMapping("/{id}")
     public ResponseEntity<Property> getById(@PathVariable UUID id) {
         return propertyRepository.findById(id)
@@ -40,11 +65,24 @@ public class PropertyController {
                 .orElse(ResponseEntity.notFound().build());
     }
 
+    /**
+     * Returns the direct child properties of the specified parent property.
+     *
+     * @param id the UUID of the parent property
+     * @return a list of child properties; empty if the property has no children
+     */
     @GetMapping("/{id}/children")
     public List<Property> getChildren(@PathVariable UUID id) {
         return propertyRepository.findByParentId(id);
     }
 
+    /**
+     * Creates a new property, assigning a generated ID, a default status of
+     * {@link PropertyStatus#ACTIVE} if none is provided, and audit timestamps.
+     *
+     * @param property the property data provided in the request body
+     * @return {@code 201 Created} with the persisted property and a {@code Location} header
+     */
     @PostMapping
     public ResponseEntity<Property> create(@RequestBody Property property) {
         property.setId(UUID.randomUUID());

--- a/src/main/java/com/majordomo/adapter/out/persistence/concierge/ContactRepositoryAdapter.java
+++ b/src/main/java/com/majordomo/adapter/out/persistence/concierge/ContactRepositoryAdapter.java
@@ -9,6 +9,10 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
+/**
+ * Persistence adapter that fulfills the {@link com.majordomo.domain.port.out.concierge.ContactRepository}
+ * output port by delegating to {@link JpaContactRepository}.
+ */
 @Repository
 public class ContactRepositoryAdapter implements ContactRepository {
 

--- a/src/main/java/com/majordomo/adapter/out/persistence/concierge/JpaContactRepository.java
+++ b/src/main/java/com/majordomo/adapter/out/persistence/concierge/JpaContactRepository.java
@@ -5,6 +5,10 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 import java.util.UUID;
 
+/**
+ * Spring Data JPA repository for {@link ContactEntity}, providing persistence operations
+ * used by {@link ContactRepositoryAdapter}.
+ */
 public interface JpaContactRepository extends JpaRepository<ContactEntity, UUID> {
 
     List<ContactEntity> findByOrganizationId(UUID organizationId);

--- a/src/main/java/com/majordomo/adapter/out/persistence/herald/JpaMaintenanceScheduleRepository.java
+++ b/src/main/java/com/majordomo/adapter/out/persistence/herald/JpaMaintenanceScheduleRepository.java
@@ -6,6 +6,10 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.UUID;
 
+/**
+ * Spring Data JPA repository for {@link MaintenanceScheduleEntity}, providing persistence operations
+ * used by {@link MaintenanceScheduleRepositoryAdapter}.
+ */
 public interface JpaMaintenanceScheduleRepository extends JpaRepository<MaintenanceScheduleEntity, UUID> {
 
     List<MaintenanceScheduleEntity> findByPropertyId(UUID propertyId);

--- a/src/main/java/com/majordomo/adapter/out/persistence/herald/JpaServiceRecordRepository.java
+++ b/src/main/java/com/majordomo/adapter/out/persistence/herald/JpaServiceRecordRepository.java
@@ -5,6 +5,10 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 import java.util.UUID;
 
+/**
+ * Spring Data JPA repository for {@link ServiceRecordEntity}, providing persistence operations
+ * used by {@link ServiceRecordRepositoryAdapter}.
+ */
 public interface JpaServiceRecordRepository extends JpaRepository<ServiceRecordEntity, UUID> {
 
     List<ServiceRecordEntity> findByPropertyId(UUID propertyId);

--- a/src/main/java/com/majordomo/adapter/out/persistence/herald/MaintenanceScheduleRepositoryAdapter.java
+++ b/src/main/java/com/majordomo/adapter/out/persistence/herald/MaintenanceScheduleRepositoryAdapter.java
@@ -10,6 +10,10 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
+/**
+ * Persistence adapter that fulfills the {@link com.majordomo.domain.port.out.herald.MaintenanceScheduleRepository}
+ * output port by delegating to {@link JpaMaintenanceScheduleRepository}.
+ */
 @Repository
 public class MaintenanceScheduleRepositoryAdapter implements MaintenanceScheduleRepository {
 

--- a/src/main/java/com/majordomo/adapter/out/persistence/herald/ServiceRecordRepositoryAdapter.java
+++ b/src/main/java/com/majordomo/adapter/out/persistence/herald/ServiceRecordRepositoryAdapter.java
@@ -9,6 +9,10 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
+/**
+ * Persistence adapter that fulfills the {@link com.majordomo.domain.port.out.herald.ServiceRecordRepository}
+ * output port by delegating to {@link JpaServiceRecordRepository}.
+ */
 @Repository
 public class ServiceRecordRepositoryAdapter implements ServiceRecordRepository {
 

--- a/src/main/java/com/majordomo/adapter/out/persistence/identity/CredentialRepositoryAdapter.java
+++ b/src/main/java/com/majordomo/adapter/out/persistence/identity/CredentialRepositoryAdapter.java
@@ -8,6 +8,10 @@ import org.springframework.stereotype.Repository;
 import java.util.Optional;
 import java.util.UUID;
 
+/**
+ * Persistence adapter that fulfills the {@link com.majordomo.domain.port.out.identity.CredentialRepository}
+ * output port by delegating to {@link JpaCredentialRepository}.
+ */
 @Repository
 public class CredentialRepositoryAdapter implements CredentialRepository {
 

--- a/src/main/java/com/majordomo/adapter/out/persistence/identity/JpaCredentialRepository.java
+++ b/src/main/java/com/majordomo/adapter/out/persistence/identity/JpaCredentialRepository.java
@@ -5,6 +5,10 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 import java.util.UUID;
 
+/**
+ * Spring Data JPA repository for {@link CredentialEntity}, providing persistence operations
+ * used by {@link CredentialRepositoryAdapter}.
+ */
 public interface JpaCredentialRepository extends JpaRepository<CredentialEntity, UUID> {
 
     Optional<CredentialEntity> findByUserId(UUID userId);

--- a/src/main/java/com/majordomo/adapter/out/persistence/identity/JpaMembershipRepository.java
+++ b/src/main/java/com/majordomo/adapter/out/persistence/identity/JpaMembershipRepository.java
@@ -5,6 +5,10 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 import java.util.UUID;
 
+/**
+ * Spring Data JPA repository for {@link MembershipEntity}, providing persistence operations
+ * used by {@link MembershipRepositoryAdapter}.
+ */
 public interface JpaMembershipRepository extends JpaRepository<MembershipEntity, UUID> {
 
     List<MembershipEntity> findByOrganizationId(UUID organizationId);

--- a/src/main/java/com/majordomo/adapter/out/persistence/identity/JpaOrganizationRepository.java
+++ b/src/main/java/com/majordomo/adapter/out/persistence/identity/JpaOrganizationRepository.java
@@ -6,6 +6,10 @@ import org.springframework.data.jpa.repository.Query;
 import java.util.List;
 import java.util.UUID;
 
+/**
+ * Spring Data JPA repository for {@link OrganizationEntity}, providing persistence operations
+ * used by {@link OrganizationRepositoryAdapter}.
+ */
 public interface JpaOrganizationRepository extends JpaRepository<OrganizationEntity, UUID> {
 
     @Query("SELECT o FROM OrganizationEntity o JOIN MembershipEntity m"

--- a/src/main/java/com/majordomo/adapter/out/persistence/identity/JpaUserRepository.java
+++ b/src/main/java/com/majordomo/adapter/out/persistence/identity/JpaUserRepository.java
@@ -5,6 +5,10 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 import java.util.UUID;
 
+/**
+ * Spring Data JPA repository for {@link UserEntity}, providing persistence operations
+ * used by {@link UserRepositoryAdapter}.
+ */
 public interface JpaUserRepository extends JpaRepository<UserEntity, UUID> {
 
     Optional<UserEntity> findByUsername(String username);

--- a/src/main/java/com/majordomo/adapter/out/persistence/identity/MembershipRepositoryAdapter.java
+++ b/src/main/java/com/majordomo/adapter/out/persistence/identity/MembershipRepositoryAdapter.java
@@ -9,6 +9,10 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
+/**
+ * Persistence adapter that fulfills the {@link com.majordomo.domain.port.out.identity.MembershipRepository}
+ * output port by delegating to {@link JpaMembershipRepository}.
+ */
 @Repository
 public class MembershipRepositoryAdapter implements MembershipRepository {
 

--- a/src/main/java/com/majordomo/adapter/out/persistence/identity/OrganizationRepositoryAdapter.java
+++ b/src/main/java/com/majordomo/adapter/out/persistence/identity/OrganizationRepositoryAdapter.java
@@ -9,6 +9,10 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
+/**
+ * Persistence adapter that fulfills the {@link com.majordomo.domain.port.out.identity.OrganizationRepository}
+ * output port by delegating to {@link JpaOrganizationRepository}.
+ */
 @Repository
 public class OrganizationRepositoryAdapter implements OrganizationRepository {
 

--- a/src/main/java/com/majordomo/adapter/out/persistence/identity/UserRepositoryAdapter.java
+++ b/src/main/java/com/majordomo/adapter/out/persistence/identity/UserRepositoryAdapter.java
@@ -8,6 +8,10 @@ import org.springframework.stereotype.Repository;
 import java.util.Optional;
 import java.util.UUID;
 
+/**
+ * Persistence adapter that fulfills the {@link com.majordomo.domain.port.out.identity.UserRepository}
+ * output port by delegating to {@link JpaUserRepository}.
+ */
 @Repository
 public class UserRepositoryAdapter implements UserRepository {
 

--- a/src/main/java/com/majordomo/adapter/out/persistence/steward/JpaPropertyContactRepository.java
+++ b/src/main/java/com/majordomo/adapter/out/persistence/steward/JpaPropertyContactRepository.java
@@ -5,6 +5,10 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 import java.util.UUID;
 
+/**
+ * Spring Data JPA repository for {@link PropertyContactEntity}, providing persistence operations
+ * used by {@link PropertyContactRepositoryAdapter}.
+ */
 public interface JpaPropertyContactRepository extends JpaRepository<PropertyContactEntity, UUID> {
 
     List<PropertyContactEntity> findByPropertyId(UUID propertyId);

--- a/src/main/java/com/majordomo/adapter/out/persistence/steward/JpaPropertyRepository.java
+++ b/src/main/java/com/majordomo/adapter/out/persistence/steward/JpaPropertyRepository.java
@@ -5,6 +5,10 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 import java.util.UUID;
 
+/**
+ * Spring Data JPA repository for {@link PropertyEntity}, providing persistence operations
+ * used by {@link PropertyRepositoryAdapter}.
+ */
 public interface JpaPropertyRepository extends JpaRepository<PropertyEntity, UUID> {
 
     List<PropertyEntity> findByOrganizationId(UUID organizationId);

--- a/src/main/java/com/majordomo/adapter/out/persistence/steward/PropertyContactRepositoryAdapter.java
+++ b/src/main/java/com/majordomo/adapter/out/persistence/steward/PropertyContactRepositoryAdapter.java
@@ -9,6 +9,10 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
+/**
+ * Persistence adapter that fulfills the {@link com.majordomo.domain.port.out.steward.PropertyContactRepository}
+ * output port by delegating to {@link JpaPropertyContactRepository}.
+ */
 @Repository
 public class PropertyContactRepositoryAdapter implements PropertyContactRepository {
 

--- a/src/main/java/com/majordomo/adapter/out/persistence/steward/PropertyRepositoryAdapter.java
+++ b/src/main/java/com/majordomo/adapter/out/persistence/steward/PropertyRepositoryAdapter.java
@@ -9,6 +9,10 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
+/**
+ * Persistence adapter that fulfills the {@link com.majordomo.domain.port.out.steward.PropertyRepository}
+ * output port by delegating to {@link JpaPropertyRepository}.
+ */
 @Repository
 public class PropertyRepositoryAdapter implements PropertyRepository {
 

--- a/src/main/java/com/majordomo/domain/model/concierge/Address.java
+++ b/src/main/java/com/majordomo/domain/model/concierge/Address.java
@@ -2,6 +2,9 @@ package com.majordomo.domain.model.concierge;
 
 import java.util.UUID;
 
+/**
+ * A labeled postal address associated with a {@link Contact}.
+ */
 public record Address(
     UUID id,
     UUID contactId,

--- a/src/main/java/com/majordomo/domain/model/concierge/Contact.java
+++ b/src/main/java/com/majordomo/domain/model/concierge/Contact.java
@@ -4,6 +4,10 @@ import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
 
+/**
+ * A person or company in the organization's address book, modeled after the vCard standard.
+ * Contacts may serve as vendors, service providers, or other roles linked to managed properties.
+ */
 public class Contact {
 
     private UUID id;

--- a/src/main/java/com/majordomo/domain/model/concierge/ContactRole.java
+++ b/src/main/java/com/majordomo/domain/model/concierge/ContactRole.java
@@ -1,5 +1,8 @@
 package com.majordomo.domain.model.concierge;
 
+/**
+ * Classifies the functional relationship a {@link Contact} has with a managed property.
+ */
 public enum ContactRole {
     VENDOR,
     SERVICE_PROVIDER,

--- a/src/main/java/com/majordomo/domain/model/herald/Frequency.java
+++ b/src/main/java/com/majordomo/domain/model/herald/Frequency.java
@@ -1,5 +1,9 @@
 package com.majordomo.domain.model.herald;
 
+/**
+ * Defines how often a {@link MaintenanceSchedule} recurs.
+ * Use {@code CUSTOM} together with {@code customIntervalDays} for non-standard intervals.
+ */
 public enum Frequency {
     WEEKLY,
     MONTHLY,

--- a/src/main/java/com/majordomo/domain/model/herald/MaintenanceSchedule.java
+++ b/src/main/java/com/majordomo/domain/model/herald/MaintenanceSchedule.java
@@ -4,6 +4,10 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.util.UUID;
 
+/**
+ * Defines a recurring maintenance task for a property, specifying the responsible contact,
+ * recurrence {@link Frequency}, and the next due date.
+ */
 public class MaintenanceSchedule {
 
     private UUID id;

--- a/src/main/java/com/majordomo/domain/model/herald/ServiceRecord.java
+++ b/src/main/java/com/majordomo/domain/model/herald/ServiceRecord.java
@@ -4,6 +4,10 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.util.UUID;
 
+/**
+ * Records a completed service or maintenance event performed on a property.
+ * May optionally reference the {@link MaintenanceSchedule} that prompted the work.
+ */
 public class ServiceRecord {
 
     private UUID id;

--- a/src/main/java/com/majordomo/domain/model/identity/Credential.java
+++ b/src/main/java/com/majordomo/domain/model/identity/Credential.java
@@ -3,6 +3,10 @@ package com.majordomo.domain.model.identity;
 import java.time.Instant;
 import java.util.UUID;
 
+/**
+ * Stores the hashed authentication credential for a {@link User}.
+ * A credential is scoped to a single user and may be archived when superseded.
+ */
 public class Credential {
 
     private UUID id;

--- a/src/main/java/com/majordomo/domain/model/identity/MemberRole.java
+++ b/src/main/java/com/majordomo/domain/model/identity/MemberRole.java
@@ -1,5 +1,8 @@
 package com.majordomo.domain.model.identity;
 
+/**
+ * Defines the access level a {@link User} holds within an {@link Organization}.
+ */
 public enum MemberRole {
     OWNER,
     ADMIN,

--- a/src/main/java/com/majordomo/domain/model/identity/Membership.java
+++ b/src/main/java/com/majordomo/domain/model/identity/Membership.java
@@ -3,6 +3,10 @@ package com.majordomo.domain.model.identity;
 import java.time.Instant;
 import java.util.UUID;
 
+/**
+ * Represents the association between a {@link User} and an {@link Organization},
+ * capturing the user's assigned {@link MemberRole} within that organization.
+ */
 public class Membership {
 
     private UUID id;

--- a/src/main/java/com/majordomo/domain/model/identity/Organization.java
+++ b/src/main/java/com/majordomo/domain/model/identity/Organization.java
@@ -3,6 +3,10 @@ package com.majordomo.domain.model.identity;
 import java.time.Instant;
 import java.util.UUID;
 
+/**
+ * A tenant organization that owns properties and contacts within Majordomo.
+ * Users belong to an organization via {@link Membership}.
+ */
 public class Organization {
 
     private UUID id;

--- a/src/main/java/com/majordomo/domain/model/identity/User.java
+++ b/src/main/java/com/majordomo/domain/model/identity/User.java
@@ -3,6 +3,10 @@ package com.majordomo.domain.model.identity;
 import java.time.Instant;
 import java.util.UUID;
 
+/**
+ * Represents an individual user account identified by a unique username and email address.
+ * Authentication is managed separately through {@link Credential}.
+ */
 public class User {
 
     private UUID id;

--- a/src/main/java/com/majordomo/domain/model/steward/Property.java
+++ b/src/main/java/com/majordomo/domain/model/steward/Property.java
@@ -4,6 +4,11 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.util.UUID;
 
+/**
+ * Represents a managed asset or property item owned by an organization.
+ * Properties may be nested hierarchically via {@code parentId} and track acquisition,
+ * warranty, and lifecycle status information.
+ */
 public class Property {
 
     private UUID id;

--- a/src/main/java/com/majordomo/domain/model/steward/PropertyContact.java
+++ b/src/main/java/com/majordomo/domain/model/steward/PropertyContact.java
@@ -5,6 +5,10 @@ import com.majordomo.domain.model.concierge.ContactRole;
 import java.time.Instant;
 import java.util.UUID;
 
+/**
+ * Associates a {@link com.majordomo.domain.model.concierge.Contact} with a {@link Property}
+ * in a specific {@link com.majordomo.domain.model.concierge.ContactRole}, such as vendor or installer.
+ */
 public class PropertyContact {
 
     private UUID id;

--- a/src/main/java/com/majordomo/domain/model/steward/PropertyStatus.java
+++ b/src/main/java/com/majordomo/domain/model/steward/PropertyStatus.java
@@ -1,5 +1,8 @@
 package com.majordomo.domain.model.steward;
 
+/**
+ * Describes the current lifecycle state of a {@link Property}.
+ */
 public enum PropertyStatus {
     ACTIVE,
     IN_SERVICE,

--- a/src/main/java/com/majordomo/domain/port/out/concierge/ContactRepository.java
+++ b/src/main/java/com/majordomo/domain/port/out/concierge/ContactRepository.java
@@ -6,11 +6,34 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
+/**
+ * Outbound port for persisting and querying contacts.
+ * Contacts represent people or companies that an organization interacts with —
+ * vendors, service providers, tenants, or other external parties.
+ */
 public interface ContactRepository {
 
+    /**
+     * Persists a contact, inserting or updating as needed.
+     *
+     * @param contact the contact to save
+     * @return the saved contact, including any generated or updated fields
+     */
     Contact save(Contact contact);
 
+    /**
+     * Retrieves a contact by its unique identifier.
+     *
+     * @param id the contact ID
+     * @return the contact, or empty if not found
+     */
     Optional<Contact> findById(UUID id);
 
+    /**
+     * Returns all contacts belonging to a given organization.
+     *
+     * @param organizationId the organization whose contacts are sought
+     * @return list of contacts for that organization, or an empty list if none exist
+     */
     List<Contact> findByOrganizationId(UUID organizationId);
 }

--- a/src/main/java/com/majordomo/domain/port/out/herald/MaintenanceScheduleRepository.java
+++ b/src/main/java/com/majordomo/domain/port/out/herald/MaintenanceScheduleRepository.java
@@ -7,13 +7,43 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
+/**
+ * Outbound port for persisting and querying maintenance schedules.
+ * A maintenance schedule defines a recurring or one-time task that must be
+ * performed on a property (e.g. HVAC filter replacement, annual inspection).
+ */
 public interface MaintenanceScheduleRepository {
 
+    /**
+     * Persists a maintenance schedule, inserting or updating as needed.
+     *
+     * @param schedule the schedule to save
+     * @return the saved schedule, including any generated or updated fields
+     */
     MaintenanceSchedule save(MaintenanceSchedule schedule);
 
+    /**
+     * Retrieves a maintenance schedule by its unique identifier.
+     *
+     * @param id the schedule ID
+     * @return the schedule, or empty if not found
+     */
     Optional<MaintenanceSchedule> findById(UUID id);
 
+    /**
+     * Returns all maintenance schedules defined for a given property.
+     *
+     * @param propertyId the property whose schedules are sought
+     * @return list of schedules for that property, or an empty list if none exist
+     */
     List<MaintenanceSchedule> findByPropertyId(UUID propertyId);
 
+    /**
+     * Returns all maintenance schedules whose next due date falls before the given date.
+     * Intended for surfacing overdue or imminently due tasks.
+     *
+     * @param date the exclusive upper bound for the due date
+     * @return list of schedules due before that date, or an empty list if none qualify
+     */
     List<MaintenanceSchedule> findDueBefore(LocalDate date);
 }

--- a/src/main/java/com/majordomo/domain/port/out/herald/ServiceRecordRepository.java
+++ b/src/main/java/com/majordomo/domain/port/out/herald/ServiceRecordRepository.java
@@ -6,13 +6,43 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
+/**
+ * Outbound port for persisting and querying service records.
+ * A service record captures the completion of a maintenance task — who did the
+ * work, when, and against which schedule — forming the property's maintenance history.
+ */
 public interface ServiceRecordRepository {
 
+    /**
+     * Persists a service record, inserting or updating as needed.
+     *
+     * @param record the service record to save
+     * @return the saved record, including any generated or updated fields
+     */
     ServiceRecord save(ServiceRecord record);
 
+    /**
+     * Retrieves a service record by its unique identifier.
+     *
+     * @param id the service record ID
+     * @return the service record, or empty if not found
+     */
     Optional<ServiceRecord> findById(UUID id);
 
+    /**
+     * Returns the full service history for a given property.
+     *
+     * @param propertyId the property whose service history is sought
+     * @return list of service records for that property, or an empty list if none exist
+     */
     List<ServiceRecord> findByPropertyId(UUID propertyId);
 
+    /**
+     * Returns all service records logged against a specific maintenance schedule.
+     * Useful for reviewing the completion history of a recurring task.
+     *
+     * @param scheduleId the maintenance schedule whose records are sought
+     * @return list of service records for that schedule, or an empty list if none exist
+     */
     List<ServiceRecord> findByScheduleId(UUID scheduleId);
 }

--- a/src/main/java/com/majordomo/domain/port/out/identity/CredentialRepository.java
+++ b/src/main/java/com/majordomo/domain/port/out/identity/CredentialRepository.java
@@ -5,9 +5,26 @@ import com.majordomo.domain.model.identity.Credential;
 import java.util.Optional;
 import java.util.UUID;
 
+/**
+ * Outbound port for persisting and retrieving user credentials.
+ * Credentials hold authentication secrets (e.g. hashed passwords) and are
+ * always scoped to a single user.
+ */
 public interface CredentialRepository {
 
+    /**
+     * Persists a credential, inserting or updating as needed.
+     *
+     * @param credential the credential to save
+     * @return the saved credential, including any generated or updated fields
+     */
     Credential save(Credential credential);
 
+    /**
+     * Retrieves the credential associated with the given user.
+     *
+     * @param userId the ID of the user whose credential is sought
+     * @return the credential, or empty if none exists for that user
+     */
     Optional<Credential> findByUserId(UUID userId);
 }

--- a/src/main/java/com/majordomo/domain/port/out/identity/MembershipRepository.java
+++ b/src/main/java/com/majordomo/domain/port/out/identity/MembershipRepository.java
@@ -6,13 +6,42 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
+/**
+ * Outbound port for persisting and querying memberships.
+ * A membership represents the relationship between a user and an organization,
+ * typically carrying a role or set of permissions within that organization.
+ */
 public interface MembershipRepository {
 
+    /**
+     * Persists a membership, inserting or updating as needed.
+     *
+     * @param membership the membership to save
+     * @return the saved membership, including any generated or updated fields
+     */
     Membership save(Membership membership);
 
+    /**
+     * Retrieves a membership by its unique identifier.
+     *
+     * @param id the membership ID
+     * @return the membership, or empty if not found
+     */
     Optional<Membership> findById(UUID id);
 
+    /**
+     * Returns all memberships belonging to a given organization.
+     *
+     * @param organizationId the organization whose memberships are sought
+     * @return list of memberships for that organization, or an empty list if none exist
+     */
     List<Membership> findByOrganizationId(UUID organizationId);
 
+    /**
+     * Returns all memberships held by a given user across organizations.
+     *
+     * @param userId the user whose memberships are sought
+     * @return list of memberships for that user, or an empty list if none exist
+     */
     List<Membership> findByUserId(UUID userId);
 }

--- a/src/main/java/com/majordomo/domain/port/out/identity/OrganizationRepository.java
+++ b/src/main/java/com/majordomo/domain/port/out/identity/OrganizationRepository.java
@@ -6,11 +6,34 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
+/**
+ * Outbound port for persisting and querying organizations.
+ * An organization is the top-level tenant boundary within the system; users
+ * belong to one or more organizations and all domain resources are scoped beneath them.
+ */
 public interface OrganizationRepository {
 
+    /**
+     * Persists an organization, inserting or updating as needed.
+     *
+     * @param organization the organization to save
+     * @return the saved organization, including any generated or updated fields
+     */
     Organization save(Organization organization);
 
+    /**
+     * Retrieves an organization by its unique identifier.
+     *
+     * @param id the organization ID
+     * @return the organization, or empty if not found
+     */
     Optional<Organization> findById(UUID id);
 
+    /**
+     * Returns all organizations to which the given user belongs.
+     *
+     * @param userId the user whose organizations are sought
+     * @return list of organizations for that user, or an empty list if none exist
+     */
     List<Organization> findByUserId(UUID userId);
 }

--- a/src/main/java/com/majordomo/domain/port/out/identity/UserRepository.java
+++ b/src/main/java/com/majordomo/domain/port/out/identity/UserRepository.java
@@ -5,13 +5,42 @@ import com.majordomo.domain.model.identity.User;
 import java.util.Optional;
 import java.util.UUID;
 
+/**
+ * Outbound port for persisting and locating users.
+ * Users are the authenticated principals of the system; lookup by username and
+ * email supports both login flows and de-duplication during registration.
+ */
 public interface UserRepository {
 
+    /**
+     * Persists a user, inserting or updating as needed.
+     *
+     * @param user the user to save
+     * @return the saved user, including any generated or updated fields
+     */
     User save(User user);
 
+    /**
+     * Retrieves a user by their unique identifier.
+     *
+     * @param id the user ID
+     * @return the user, or empty if not found
+     */
     Optional<User> findById(UUID id);
 
+    /**
+     * Retrieves a user by their username.
+     *
+     * @param username the username to search for
+     * @return the matching user, or empty if no user has that username
+     */
     Optional<User> findByUsername(String username);
 
+    /**
+     * Retrieves a user by their email address.
+     *
+     * @param email the email address to search for
+     * @return the matching user, or empty if no user has that email
+     */
     Optional<User> findByEmail(String email);
 }

--- a/src/main/java/com/majordomo/domain/port/out/steward/PropertyContactRepository.java
+++ b/src/main/java/com/majordomo/domain/port/out/steward/PropertyContactRepository.java
@@ -6,13 +6,43 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
+/**
+ * Outbound port for persisting and querying property-contact associations.
+ * A property contact links a contact (e.g. a vendor or service provider) to a
+ * specific property, optionally capturing the nature of that relationship (e.g.
+ * primary plumber, emergency contact).
+ */
 public interface PropertyContactRepository {
 
+    /**
+     * Persists a property-contact association, inserting or updating as needed.
+     *
+     * @param propertyContact the association to save
+     * @return the saved association, including any generated or updated fields
+     */
     PropertyContact save(PropertyContact propertyContact);
 
+    /**
+     * Retrieves a property-contact association by its unique identifier.
+     *
+     * @param id the association ID
+     * @return the association, or empty if not found
+     */
     Optional<PropertyContact> findById(UUID id);
 
+    /**
+     * Returns all contacts associated with a given property.
+     *
+     * @param propertyId the property whose contacts are sought
+     * @return list of property-contact associations for that property, or an empty list if none exist
+     */
     List<PropertyContact> findByPropertyId(UUID propertyId);
 
+    /**
+     * Returns all properties associated with a given contact.
+     *
+     * @param contactId the contact whose property associations are sought
+     * @return list of property-contact associations for that contact, or an empty list if none exist
+     */
     List<PropertyContact> findByContactId(UUID contactId);
 }

--- a/src/main/java/com/majordomo/domain/port/out/steward/PropertyRepository.java
+++ b/src/main/java/com/majordomo/domain/port/out/steward/PropertyRepository.java
@@ -6,13 +6,43 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
+/**
+ * Outbound port for persisting and querying properties.
+ * Properties are the physical or logical assets managed by an organization.
+ * They may be nested (e.g. a unit within a building), which is expressed via
+ * the parent–child relationship.
+ */
 public interface PropertyRepository {
 
+    /**
+     * Persists a property, inserting or updating as needed.
+     *
+     * @param property the property to save
+     * @return the saved property, including any generated or updated fields
+     */
     Property save(Property property);
 
+    /**
+     * Retrieves a property by its unique identifier.
+     *
+     * @param id the property ID
+     * @return the property, or empty if not found
+     */
     Optional<Property> findById(UUID id);
 
+    /**
+     * Returns all top-level and nested properties belonging to a given organization.
+     *
+     * @param organizationId the organization whose properties are sought
+     * @return list of properties for that organization, or an empty list if none exist
+     */
     List<Property> findByOrganizationId(UUID organizationId);
 
+    /**
+     * Returns all direct child properties of a given parent property.
+     *
+     * @param parentId the ID of the parent property
+     * @return list of child properties, or an empty list if the parent has none
+     */
     List<Property> findByParentId(UUID parentId);
 }


### PR DESCRIPTION
## Summary

- ADR 0015: Require Javadoc on all public methods, use Mermaid diagrams where appropriate
- Checkstyle config updated with `MissingJavadocMethod`, `JavadocMethod`, `MissingJavadocType` checks
- Suppressions added for entities, mappers, domain model accessors, and test classes
- Javadoc added to all 51 public-facing source files across all packages

## Test plan

- [x] `./mvnw validate` passes with 0 Checkstyle violations
- [x] `./mvnw compile` passes
- [ ] Review Javadoc quality and accuracy

🤖 Generated with [Claude Code](https://claude.com/claude-code)