### PR TITLE
Seed default user via Flyway migration

### DIFF
--- a/src/main/resources/db/migration/V2__seed_default_user.sql
+++ b/src/main/resources/db/migration/V2__seed_default_user.sql
@@ -1,0 +1,37 @@
+-- V2: Seed default user Rob Sartin
+
+INSERT INTO users (id, username, email, created_at, updated_at)
+VALUES (
+    '019606a0-0000-7000-8000-000000000001',
+    'robsartin',
+    'rob.sartin@gmail.com',
+    now(),
+    now()
+);
+
+INSERT INTO credentials (id, user_id, hashed_password, created_at, updated_at)
+VALUES (
+    '019606a0-0000-7000-8000-000000000002',
+    '019606a0-0000-7000-8000-000000000001',
+    '$2a$10$6t00FGN9bsAczx5/czYSnu2pHhqWycVfG5lNR2lURHGsH5RsdGX1q',
+    now(),
+    now()
+);
+
+INSERT INTO organizations (id, name, created_at, updated_at)
+VALUES (
+    '019606a0-0000-7000-8000-000000000003',
+    'Personal',
+    now(),
+    now()
+);
+
+INSERT INTO memberships (id, user_id, organization_id, role, created_at, updated_at)
+VALUES (
+    '019606a0-0000-7000-8000-000000000004',
+    '019606a0-0000-7000-8000-000000000001',
+    '019606a0-0000-7000-8000-000000000003',
+    'OWNER',
+    now(),
+    now()
+);

--- a/src/test/java/com/majordomo/SeedUserTest.java
+++ b/src/test/java/com/majordomo/SeedUserTest.java
@@ -1,0 +1,21 @@
+package com.majordomo;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Verifies the BCrypt hash used in V2 migration matches the expected password.
+ */
+class SeedUserTest {
+
+    /** The seeded password must match the BCrypt hash in V2__seed_default_user.sql. */
+    @Test
+    void seededPasswordMatchesBcryptHash() {
+        var encoder = new BCryptPasswordEncoder();
+        // The hash from V2__seed_default_user.sql
+        String hash = "$2a$10$6t00FGN9bsAczx5/czYSnu2pHhqWycVfG5lNR2lURHGsH5RsdGX1q";
+        assertTrue(encoder.matches("xyzzyPLAN9", hash));
+    }
+}


### PR DESCRIPTION
## Summary
- Adds Flyway `V2__seed_default_user.sql` migration that seeds user `robsartin` (rob.sartin@gmail.com) with a BCrypt-hashed password, a "Personal" organization, and an OWNER membership linking them
- Adds `SeedUserTest` that verifies the BCrypt hash in the migration matches the expected password

## Test plan
- [x] `./mvnw compile` succeeds
- [x] `./mvnw test` passes all 5 tests (including new `SeedUserTest`)
- [ ] Run app with PostgreSQL and verify `robsartin` can log in with the seeded password

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)