### PR TITLE
Update documentation for authentication system

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,23 @@ Additional services can be introduced over time (e.g., "The Gardener" for landsc
 - **Relationship-first**: The system models connections between people, assets, and events — not just static records
 - **Lifecycle-aware**: Assets are tracked from acquisition through maintenance to eventual replacement
 
+## Authentication
+
+Majordomo uses Spring Security for authentication with form-based login at `/login`. Passwords
+are hashed using Argon2id, the Password Hashing Competition winner, providing strong resistance
+to GPU and ASIC attacks.
+
+The authentication layer follows the hexagonal architecture: `AuthenticationService` implements
+Spring Security's `UserDetailsService` interface, bridging Spring Security to the domain's
+`UserRepository` and `CredentialRepository` ports. Spring Security concerns remain in the
+adapter layer — the domain model has no dependency on Spring Security.
+
+OAuth2 support (Google, GitHub, etc.) via Spring Security OAuth2 Client is planned for the
+future. The `Credential` table is separated from the `User` table to accommodate multiple
+authentication methods per user.
+
+For detailed developer documentation, see [doc/authentication.md](doc/authentication.md).
+
 ## Status
 
 Early development. Architecture decisions are being recorded in `doc/adr/`.

--- a/doc/authentication.md
+++ b/doc/authentication.md
@@ -1,0 +1,54 @@
+# Authentication
+
+## Overview
+
+Majordomo uses Spring Security for authentication. The current implementation supports
+form-based username/password login. OAuth2 support (Google, etc.) is planned for the future
+(see ADR-0016).
+
+## Architecture
+
+Authentication follows the hexagonal architecture:
+
+- **Inbound adapter**: `LoginController` serves the login page; Spring Security handles POST /login
+- **Application service**: `AuthenticationService` implements Spring Security's `UserDetailsService`
+- **Outbound ports**: `UserRepository.findByUsername()` and `CredentialRepository.findByUserId()`
+
+Spring Security concerns stay in the adapter layer. The domain model knows nothing about
+Spring Security.
+
+## Password Hashing
+
+Passwords are hashed with Argon2id via Spring Security's `Argon2PasswordEncoder`. Argon2id is
+the Password Hashing Competition winner, resistant to GPU/ASIC attacks with configurable
+memory cost.
+
+## Login Flow
+
+1. User visits `/login` (GET) — `LoginController` returns the Thymeleaf login form
+2. User submits credentials (POST /login) — Spring Security intercepts
+3. Spring Security calls `AuthenticationService.loadUserByUsername()`
+4. `AuthenticationService` loads the `User` and `Credential` via domain ports
+5. Spring Security verifies the password against the Argon2id hash
+6. On success, redirects to `/`; on failure, redirects to `/login?error`
+
+## Adding Users
+
+Currently users are seeded via Flyway migrations. The default user:
+
+- Username: `robsartin`
+- Email: `rob.sartin@gmail.com`
+
+To add a new user, create a Flyway migration that inserts into `users`, `credentials`,
+`organizations`, and `memberships` tables. Use `Argon2PasswordEncoder` to generate the
+password hash.
+
+## Future: OAuth2
+
+The system is designed to support OAuth2 providers (Google, GitHub, etc.) via Spring Security
+OAuth2 Client. The `Credential` table separation from `User` allows multiple authentication
+methods per user. When OAuth2 is added:
+
+- A new `OAuthLink` entity or additional credential types will map external identities to users
+- Existing form login will continue to work alongside OAuth2
+- The `AuthenticationService` pattern extends naturally to the OAuth2 flow

--- a/doc/domain-model.md
+++ b/doc/domain-model.md
@@ -169,3 +169,28 @@ classDiagram
     Organization "1" --> "*" Property
     Organization "1" --> "*" Contact
 ```
+
+## Authentication Sequence
+
+```mermaid
+sequenceDiagram
+    participant Browser
+    participant LoginController
+    participant SpringSecurity
+    participant AuthService as AuthenticationService
+    participant UserRepo as UserRepository
+    participant CredRepo as CredentialRepository
+
+    Browser->>LoginController: GET /login
+    LoginController-->>Browser: login.html (form)
+
+    Browser->>SpringSecurity: POST /login (username, password)
+    SpringSecurity->>AuthService: loadUserByUsername(username)
+    AuthService->>UserRepo: findByUsername(username)
+    UserRepo-->>AuthService: User
+    AuthService->>CredRepo: findByUserId(user.id)
+    CredRepo-->>AuthService: Credential (Argon2id hash)
+    AuthService-->>SpringSecurity: UserDetails
+    SpringSecurity->>SpringSecurity: verify password against hash
+    SpringSecurity-->>Browser: 302 Redirect to /
+```


### PR DESCRIPTION
## Summary

- Add authentication login sequence diagram (Mermaid) to `doc/domain-model.md` after the class diagram
- Add "Authentication" section to `README.md` covering form login, Argon2id hashing, hexagonal architecture bridge, and future OAuth2 plans
- Add `doc/authentication.md` as detailed developer documentation covering architecture, password hashing, login flow, adding users, and future OAuth2

Closes #11

## Test plan

- [ ] Verify Mermaid sequence diagram renders correctly on GitHub in `doc/domain-model.md`
- [ ] Verify README Authentication section reads clearly and links to `doc/authentication.md`
- [ ] Verify `doc/authentication.md` content is accurate against the implemented auth system
- [ ] Confirm `./mvnw validate` passes (0 Checkstyle violations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)