### PR TITLE
Consolidate password hashing to Argon2id, remove BCrypt

### DIFF
--- a/doc/adr/0016-use-spring-security-with-form-login-extensible-to-oauth2.md
+++ b/doc/adr/0016-use-spring-security-with-form-login-extensible-to-oauth2.md
@@ -18,7 +18,7 @@ We will use Spring Security as the authentication framework.
 
 Initial implementation:
 - Form-based login at `/login` (GET returns page, POST authenticates)
-- BCrypt for password hashing via Spring Security's `PasswordEncoder`
+- Argon2id for password hashing via Spring Security's `PasswordEncoder`
 - A `UserDetailsService` implementation bridges Spring Security to the hexagonal domain ports (`UserRepository`, `CredentialRepository`)
 - The root URL `/` is publicly accessible; `/api/**` requires authentication
 - Swagger UI endpoints remain accessible for development
@@ -33,6 +33,6 @@ Future OAuth2:
 - Spring Security is the industry standard for Java web security, with extensive documentation and community support.
 - Form login is simple to implement and test.
 - The `UserDetailsService` abstraction keeps Spring Security concerns in the adapter layer — the domain knows nothing about Spring Security.
-- BCrypt is deliberately slow, protecting against brute-force attacks on the credential store.
+- Argon2id is memory-hard and deliberately slow, protecting against brute-force and GPU-based attacks on the credential store.
 - OAuth2 can be added later as an additional authentication method without changing the existing login flow.
 - Session management adds server-side state; stateless JWT tokens may be considered for API-only clients in the future.

--- a/src/main/resources/db/migration/V2__seed_default_user.sql
+++ b/src/main/resources/db/migration/V2__seed_default_user.sql
@@ -13,7 +13,7 @@ INSERT INTO credentials (id, user_id, hashed_password, created_at, updated_at)
 VALUES (
     '019606a0-0000-7000-8000-000000000002',
     '019606a0-0000-7000-8000-000000000001',
-    '$2a$10$6t00FGN9bsAczx5/czYSnu2pHhqWycVfG5lNR2lURHGsH5RsdGX1q',
+    '$argon2id$v=19$m=16384,t=2,p=1$7ZDV8a9vfQ5iasgoHzUA7g$PUcR8b7h3I9Ti4sf+8tAfSxvr4+XLwyGF9dmso1eui0',
     now(),
     now()
 );

--- a/src/main/resources/db/migration/V3__update_seed_password_argon2id.sql
+++ b/src/main/resources/db/migration/V3__update_seed_password_argon2id.sql
@@ -1,5 +1,0 @@
--- V3: Update seed user password hash from BCrypt to Argon2id
-UPDATE credentials
-SET hashed_password = '$argon2id$v=19$m=16384,t=2,p=1$7ZDV8a9vfQ5iasgoHzUA7g$PUcR8b7h3I9Ti4sf+8tAfSxvr4+XLwyGF9dmso1eui0',
-    updated_at = now()
-WHERE user_id = '019606a0-0000-7000-8000-000000000001';

--- a/src/test/java/com/majordomo/SeedUserTest.java
+++ b/src/test/java/com/majordomo/SeedUserTest.java
@@ -6,15 +6,15 @@ import org.springframework.security.crypto.argon2.Argon2PasswordEncoder;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * Verifies the Argon2id hash used in V3 migration matches the expected password.
+ * Verifies the Argon2id hash used in V2 migration matches the expected password.
  */
 class SeedUserTest {
 
-    /** The seeded password must match the Argon2id hash in V3 migration. */
+    /** The seeded password must match the Argon2id hash in V2 migration. */
     @Test
     void seededPasswordMatchesArgon2idHash() {
         var encoder = Argon2PasswordEncoder.defaultsForSpringSecurity_v5_8();
-        // The hash from V3__update_seed_password_argon2id.sql
+        // The hash from V2__seed_default_user.sql
         String hash = "$argon2id$v=19$m=16384,t=2,p=1"
                 + "$7ZDV8a9vfQ5iasgoHzUA7g"
                 + "$PUcR8b7h3I9Ti4sf+8tAfSxvr4+XLwyGF9dmso1eui0";


### PR DESCRIPTION
## Summary

- Merged V2 and V3 Flyway migrations: V2 now seeds the default user with an Argon2id hash directly, eliminating the separate V3 update step
- Deleted `V3__update_seed_password_argon2id.sql` (no longer needed since V2 contains the correct hash)
- Removed all BCrypt references from the codebase, including ADR-0016

## Details

This is safe to consolidate because there is no production database yet — no existing Flyway history depends on V3.

## Test plan

- [x] `./mvnw verify` passes (8 tests, 0 failures, 0 checkstyle violations)
- [x] `SeedUserTest` confirms the Argon2id hash in V2 matches the expected password
- [x] `grep -ri bcrypt` returns zero matches across the codebase

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)