### PR TITLE
Add cursor-based pagination to list endpoints

### DIFF
--- a/src/main/java/com/majordomo/adapter/in/web/concierge/ContactController.java
+++ b/src/main/java/com/majordomo/adapter/in/web/concierge/ContactController.java
@@ -1,5 +1,6 @@
 package com.majordomo.adapter.in.web.concierge;
 
+import com.majordomo.domain.model.Page;
 import com.majordomo.domain.model.concierge.Contact;
 import com.majordomo.domain.port.in.concierge.ManageContactUseCase;
 
@@ -13,7 +14,6 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.net.URI;
-import java.util.List;
 import java.util.UUID;
 
 /**
@@ -38,14 +38,19 @@ public class ContactController {
     }
 
     /**
-     * Returns all contacts belonging to the specified organization.
+     * Returns contacts belonging to the specified organization with cursor-based pagination.
      *
      * @param organizationId the UUID of the organization whose contacts are retrieved
-     * @return a list of matching contacts; empty if none exist
+     * @param cursor         optional cursor for the next page (exclusive start)
+     * @param limit          maximum number of results per page (default 20)
+     * @return a page of matching contacts
      */
     @GetMapping
-    public List<Contact> listByOrganization(@RequestParam UUID organizationId) {
-        return contactUseCase.findByOrganizationId(organizationId);
+    public Page<Contact> listByOrganization(
+            @RequestParam UUID organizationId,
+            @RequestParam(required = false) UUID cursor,
+            @RequestParam(defaultValue = "20") int limit) {
+        return contactUseCase.findByOrganizationId(organizationId, cursor, limit);
     }
 
     /**

--- a/src/main/java/com/majordomo/adapter/in/web/herald/ScheduleController.java
+++ b/src/main/java/com/majordomo/adapter/in/web/herald/ScheduleController.java
@@ -1,5 +1,6 @@
 package com.majordomo.adapter.in.web.herald;
 
+import com.majordomo.domain.model.Page;
 import com.majordomo.domain.model.herald.MaintenanceSchedule;
 import com.majordomo.domain.model.herald.ServiceRecord;
 import com.majordomo.domain.port.in.herald.ManageScheduleUseCase;
@@ -42,14 +43,19 @@ public class ScheduleController {
     }
 
     /**
-     * Returns all maintenance schedules associated with the specified property.
+     * Returns schedules associated with the specified property with cursor-based pagination.
      *
      * @param propertyId the UUID of the property whose schedules are retrieved
-     * @return a list of matching schedules; empty if none exist
+     * @param cursor     optional cursor for the next page (exclusive start)
+     * @param limit      maximum number of results per page (default 20)
+     * @return a page of matching schedules
      */
     @GetMapping
-    public List<MaintenanceSchedule> listByProperty(@RequestParam UUID propertyId) {
-        return scheduleUseCase.findByPropertyId(propertyId);
+    public Page<MaintenanceSchedule> listByProperty(
+            @RequestParam UUID propertyId,
+            @RequestParam(required = false) UUID cursor,
+            @RequestParam(defaultValue = "20") int limit) {
+        return scheduleUseCase.findByPropertyId(propertyId, cursor, limit);
     }
 
     /**

--- a/src/main/java/com/majordomo/adapter/in/web/steward/PropertyController.java
+++ b/src/main/java/com/majordomo/adapter/in/web/steward/PropertyController.java
@@ -1,5 +1,6 @@
 package com.majordomo.adapter.in.web.steward;
 
+import com.majordomo.domain.model.Page;
 import com.majordomo.domain.model.steward.Property;
 import com.majordomo.domain.port.in.steward.ManagePropertyUseCase;
 
@@ -40,14 +41,19 @@ public class PropertyController {
     }
 
     /**
-     * Returns all properties belonging to the specified organization.
+     * Returns properties belonging to the specified organization with cursor-based pagination.
      *
      * @param organizationId the UUID of the organization whose properties are retrieved
-     * @return a list of matching properties; empty if none exist
+     * @param cursor         optional cursor for the next page (exclusive start)
+     * @param limit          maximum number of results per page (default 20)
+     * @return a page of matching properties
      */
     @GetMapping
-    public List<Property> listByOrganization(@RequestParam UUID organizationId) {
-        return propertyUseCase.findByOrganizationId(organizationId);
+    public Page<Property> listByOrganization(
+            @RequestParam UUID organizationId,
+            @RequestParam(required = false) UUID cursor,
+            @RequestParam(defaultValue = "20") int limit) {
+        return propertyUseCase.findByOrganizationId(organizationId, cursor, limit);
     }
 
     /**

--- a/src/main/java/com/majordomo/adapter/out/persistence/concierge/ContactRepositoryAdapter.java
+++ b/src/main/java/com/majordomo/adapter/out/persistence/concierge/ContactRepositoryAdapter.java
@@ -3,6 +3,7 @@ package com.majordomo.adapter.out.persistence.concierge;
 import com.majordomo.domain.model.concierge.Contact;
 import com.majordomo.domain.port.out.concierge.ContactRepository;
 
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -36,5 +37,17 @@ public class ContactRepositoryAdapter implements ContactRepository {
     @Override
     public List<Contact> findByOrganizationId(UUID organizationId) {
         return jpa.findByOrganizationId(organizationId).stream().map(ContactMapper::toDomain).toList();
+    }
+
+    @Override
+    public List<Contact> findByOrganizationId(UUID organizationId, UUID cursor, int limit) {
+        List<ContactEntity> entities;
+        if (cursor == null) {
+            entities = jpa.findByOrganizationIdOrderById(organizationId, PageRequest.of(0, limit));
+        } else {
+            entities = jpa.findByOrganizationIdAndIdGreaterThanOrderById(
+                    organizationId, cursor, PageRequest.of(0, limit));
+        }
+        return entities.stream().map(ContactMapper::toDomain).toList();
     }
 }

--- a/src/main/java/com/majordomo/adapter/out/persistence/concierge/JpaContactRepository.java
+++ b/src/main/java/com/majordomo/adapter/out/persistence/concierge/JpaContactRepository.java
@@ -1,5 +1,6 @@
 package com.majordomo.adapter.out.persistence.concierge;
 
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
@@ -12,4 +13,24 @@ import java.util.UUID;
 public interface JpaContactRepository extends JpaRepository<ContactEntity, UUID> {
 
     List<ContactEntity> findByOrganizationId(UUID organizationId);
+
+    /**
+     * Returns contacts for an organization ordered by ID.
+     *
+     * @param organizationId the organization ID
+     * @param pageable       pagination information
+     * @return list of contact entities ordered by ID
+     */
+    List<ContactEntity> findByOrganizationIdOrderById(UUID organizationId, Pageable pageable);
+
+    /**
+     * Returns contacts for an organization with ID greater than the given cursor, ordered by ID.
+     *
+     * @param organizationId the organization ID
+     * @param id             the cursor ID (exclusive lower bound)
+     * @param pageable       pagination information
+     * @return list of contact entities after the cursor, ordered by ID
+     */
+    List<ContactEntity> findByOrganizationIdAndIdGreaterThanOrderById(
+            UUID organizationId, UUID id, Pageable pageable);
 }

--- a/src/main/java/com/majordomo/adapter/out/persistence/herald/JpaMaintenanceScheduleRepository.java
+++ b/src/main/java/com/majordomo/adapter/out/persistence/herald/JpaMaintenanceScheduleRepository.java
@@ -1,5 +1,6 @@
 package com.majordomo.adapter.out.persistence.herald;
 
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.time.LocalDate;
@@ -15,4 +16,24 @@ public interface JpaMaintenanceScheduleRepository extends JpaRepository<Maintena
     List<MaintenanceScheduleEntity> findByPropertyId(UUID propertyId);
 
     List<MaintenanceScheduleEntity> findByNextDueBefore(LocalDate date);
+
+    /**
+     * Returns schedules for a property ordered by ID.
+     *
+     * @param propertyId the property ID
+     * @param pageable   pagination information
+     * @return list of schedule entities ordered by ID
+     */
+    List<MaintenanceScheduleEntity> findByPropertyIdOrderById(UUID propertyId, Pageable pageable);
+
+    /**
+     * Returns schedules for a property with ID greater than the given cursor, ordered by ID.
+     *
+     * @param propertyId the property ID
+     * @param id         the cursor ID (exclusive lower bound)
+     * @param pageable   pagination information
+     * @return list of schedule entities after the cursor, ordered by ID
+     */
+    List<MaintenanceScheduleEntity> findByPropertyIdAndIdGreaterThanOrderById(
+            UUID propertyId, UUID id, Pageable pageable);
 }

--- a/src/main/java/com/majordomo/adapter/out/persistence/herald/MaintenanceScheduleRepositoryAdapter.java
+++ b/src/main/java/com/majordomo/adapter/out/persistence/herald/MaintenanceScheduleRepositoryAdapter.java
@@ -3,6 +3,7 @@ package com.majordomo.adapter.out.persistence.herald;
 import com.majordomo.domain.model.herald.MaintenanceSchedule;
 import com.majordomo.domain.port.out.herald.MaintenanceScheduleRepository;
 
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDate;
@@ -37,6 +38,18 @@ public class MaintenanceScheduleRepositoryAdapter implements MaintenanceSchedule
     @Override
     public List<MaintenanceSchedule> findByPropertyId(UUID propertyId) {
         return jpa.findByPropertyId(propertyId).stream().map(MaintenanceScheduleMapper::toDomain).toList();
+    }
+
+    @Override
+    public List<MaintenanceSchedule> findByPropertyId(UUID propertyId, UUID cursor, int limit) {
+        List<MaintenanceScheduleEntity> entities;
+        if (cursor == null) {
+            entities = jpa.findByPropertyIdOrderById(propertyId, PageRequest.of(0, limit));
+        } else {
+            entities = jpa.findByPropertyIdAndIdGreaterThanOrderById(
+                    propertyId, cursor, PageRequest.of(0, limit));
+        }
+        return entities.stream().map(MaintenanceScheduleMapper::toDomain).toList();
     }
 
     @Override

--- a/src/main/java/com/majordomo/adapter/out/persistence/steward/JpaPropertyRepository.java
+++ b/src/main/java/com/majordomo/adapter/out/persistence/steward/JpaPropertyRepository.java
@@ -1,5 +1,6 @@
 package com.majordomo.adapter.out.persistence.steward;
 
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
@@ -14,4 +15,24 @@ public interface JpaPropertyRepository extends JpaRepository<PropertyEntity, UUI
     List<PropertyEntity> findByOrganizationId(UUID organizationId);
 
     List<PropertyEntity> findByParentId(UUID parentId);
+
+    /**
+     * Returns properties for an organization ordered by ID.
+     *
+     * @param organizationId the organization ID
+     * @param pageable       pagination information
+     * @return list of property entities ordered by ID
+     */
+    List<PropertyEntity> findByOrganizationIdOrderById(UUID organizationId, Pageable pageable);
+
+    /**
+     * Returns properties for an organization with ID greater than the given cursor, ordered by ID.
+     *
+     * @param organizationId the organization ID
+     * @param id             the cursor ID (exclusive lower bound)
+     * @param pageable       pagination information
+     * @return list of property entities after the cursor, ordered by ID
+     */
+    List<PropertyEntity> findByOrganizationIdAndIdGreaterThanOrderById(
+            UUID organizationId, UUID id, Pageable pageable);
 }

--- a/src/main/java/com/majordomo/adapter/out/persistence/steward/PropertyRepositoryAdapter.java
+++ b/src/main/java/com/majordomo/adapter/out/persistence/steward/PropertyRepositoryAdapter.java
@@ -3,6 +3,7 @@ package com.majordomo.adapter.out.persistence.steward;
 import com.majordomo.domain.model.steward.Property;
 import com.majordomo.domain.port.out.steward.PropertyRepository;
 
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -36,6 +37,18 @@ public class PropertyRepositoryAdapter implements PropertyRepository {
     @Override
     public List<Property> findByOrganizationId(UUID organizationId) {
         return jpa.findByOrganizationId(organizationId).stream().map(PropertyMapper::toDomain).toList();
+    }
+
+    @Override
+    public List<Property> findByOrganizationId(UUID organizationId, UUID cursor, int limit) {
+        List<PropertyEntity> entities;
+        if (cursor == null) {
+            entities = jpa.findByOrganizationIdOrderById(organizationId, PageRequest.of(0, limit));
+        } else {
+            entities = jpa.findByOrganizationIdAndIdGreaterThanOrderById(
+                    organizationId, cursor, PageRequest.of(0, limit));
+        }
+        return entities.stream().map(PropertyMapper::toDomain).toList();
     }
 
     @Override

--- a/src/main/java/com/majordomo/application/concierge/ContactService.java
+++ b/src/main/java/com/majordomo/application/concierge/ContactService.java
@@ -1,5 +1,6 @@
 package com.majordomo.application.concierge;
 
+import com.majordomo.domain.model.Page;
 import com.majordomo.domain.model.concierge.Contact;
 import com.majordomo.domain.port.in.concierge.ManageContactUseCase;
 import com.majordomo.domain.port.out.concierge.ContactRepository;
@@ -45,5 +46,17 @@ public class ContactService implements ManageContactUseCase {
     @Override
     public List<Contact> findByOrganizationId(UUID organizationId) {
         return contactRepository.findByOrganizationId(organizationId);
+    }
+
+    @Override
+    public Page<Contact> findByOrganizationId(UUID organizationId, UUID cursor, int limit) {
+        int clampedLimit = Math.max(1, Math.min(limit, 100));
+        var items = contactRepository.findByOrganizationId(organizationId, cursor, clampedLimit + 1);
+        boolean hasMore = items.size() > clampedLimit;
+        if (hasMore) {
+            items = items.subList(0, clampedLimit);
+        }
+        UUID nextCursor = hasMore ? items.get(items.size() - 1).getId() : null;
+        return new Page<>(items, nextCursor, hasMore);
     }
 }

--- a/src/main/java/com/majordomo/application/herald/ScheduleService.java
+++ b/src/main/java/com/majordomo/application/herald/ScheduleService.java
@@ -1,5 +1,6 @@
 package com.majordomo.application.herald;
 
+import com.majordomo.domain.model.Page;
 import com.majordomo.domain.model.herald.MaintenanceSchedule;
 import com.majordomo.domain.model.herald.ServiceRecord;
 import com.majordomo.domain.port.in.herald.ManageScheduleUseCase;
@@ -54,6 +55,18 @@ public class ScheduleService implements ManageScheduleUseCase {
     @Override
     public List<MaintenanceSchedule> findByPropertyId(UUID propertyId) {
         return scheduleRepository.findByPropertyId(propertyId);
+    }
+
+    @Override
+    public Page<MaintenanceSchedule> findByPropertyId(UUID propertyId, UUID cursor, int limit) {
+        int clampedLimit = Math.max(1, Math.min(limit, 100));
+        var items = scheduleRepository.findByPropertyId(propertyId, cursor, clampedLimit + 1);
+        boolean hasMore = items.size() > clampedLimit;
+        if (hasMore) {
+            items = items.subList(0, clampedLimit);
+        }
+        UUID nextCursor = hasMore ? items.get(items.size() - 1).getId() : null;
+        return new Page<>(items, nextCursor, hasMore);
     }
 
     @Override

--- a/src/main/java/com/majordomo/application/steward/PropertyService.java
+++ b/src/main/java/com/majordomo/application/steward/PropertyService.java
@@ -1,5 +1,6 @@
 package com.majordomo.application.steward;
 
+import com.majordomo.domain.model.Page;
 import com.majordomo.domain.model.steward.Property;
 import com.majordomo.domain.model.steward.PropertyStatus;
 import com.majordomo.domain.port.in.steward.ManagePropertyUseCase;
@@ -49,6 +50,18 @@ public class PropertyService implements ManagePropertyUseCase {
     @Override
     public List<Property> findByOrganizationId(UUID organizationId) {
         return propertyRepository.findByOrganizationId(organizationId);
+    }
+
+    @Override
+    public Page<Property> findByOrganizationId(UUID organizationId, UUID cursor, int limit) {
+        int clampedLimit = Math.max(1, Math.min(limit, 100));
+        var items = propertyRepository.findByOrganizationId(organizationId, cursor, clampedLimit + 1);
+        boolean hasMore = items.size() > clampedLimit;
+        if (hasMore) {
+            items = items.subList(0, clampedLimit);
+        }
+        UUID nextCursor = hasMore ? items.get(items.size() - 1).getId() : null;
+        return new Page<>(items, nextCursor, hasMore);
     }
 
     @Override

--- a/src/main/java/com/majordomo/domain/model/Page.java
+++ b/src/main/java/com/majordomo/domain/model/Page.java
@@ -1,0 +1,20 @@
+package com.majordomo.domain.model;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * A page of results for cursor-based pagination.
+ * Uses UUIDv7 as the cursor since IDs are time-sortable.
+ *
+ * @param <T>        the type of items in the page
+ * @param items      the items in this page
+ * @param nextCursor the ID to use as cursor for the next page, or null if no more
+ * @param hasMore    true if there are more items after this page
+ */
+public record Page<T>(
+    List<T> items,
+    UUID nextCursor,
+    boolean hasMore
+) {
+}

--- a/src/main/java/com/majordomo/domain/port/in/concierge/ManageContactUseCase.java
+++ b/src/main/java/com/majordomo/domain/port/in/concierge/ManageContactUseCase.java
@@ -1,5 +1,6 @@
 package com.majordomo.domain.port.in.concierge;
 
+import com.majordomo.domain.model.Page;
 import com.majordomo.domain.model.concierge.Contact;
 
 import java.util.List;
@@ -34,4 +35,14 @@ public interface ManageContactUseCase {
      * @return list of contacts
      */
     List<Contact> findByOrganizationId(UUID organizationId);
+
+    /**
+     * Lists contacts for an organization with cursor-based pagination.
+     *
+     * @param organizationId the organization ID
+     * @param cursor         the cursor UUID (null for first page)
+     * @param limit          max results per page (1-100)
+     * @return a page of contacts
+     */
+    Page<Contact> findByOrganizationId(UUID organizationId, UUID cursor, int limit);
 }

--- a/src/main/java/com/majordomo/domain/port/in/herald/ManageScheduleUseCase.java
+++ b/src/main/java/com/majordomo/domain/port/in/herald/ManageScheduleUseCase.java
@@ -1,5 +1,6 @@
 package com.majordomo.domain.port.in.herald;
 
+import com.majordomo.domain.model.Page;
 import com.majordomo.domain.model.herald.MaintenanceSchedule;
 import com.majordomo.domain.model.herald.ServiceRecord;
 
@@ -36,6 +37,16 @@ public interface ManageScheduleUseCase {
      * @return list of schedules
      */
     List<MaintenanceSchedule> findByPropertyId(UUID propertyId);
+
+    /**
+     * Lists schedules for a property with cursor-based pagination.
+     *
+     * @param propertyId the property ID
+     * @param cursor     the cursor UUID (null for first page)
+     * @param limit      max results per page (1-100)
+     * @return a page of schedules
+     */
+    Page<MaintenanceSchedule> findByPropertyId(UUID propertyId, UUID cursor, int limit);
 
     /**
      * Lists all schedules due before the given date.

--- a/src/main/java/com/majordomo/domain/port/in/steward/ManagePropertyUseCase.java
+++ b/src/main/java/com/majordomo/domain/port/in/steward/ManagePropertyUseCase.java
@@ -1,5 +1,6 @@
 package com.majordomo.domain.port.in.steward;
 
+import com.majordomo.domain.model.Page;
 import com.majordomo.domain.model.steward.Property;
 
 import java.util.List;
@@ -34,6 +35,16 @@ public interface ManagePropertyUseCase {
      * @return list of properties
      */
     List<Property> findByOrganizationId(UUID organizationId);
+
+    /**
+     * Lists properties for an organization with cursor-based pagination.
+     *
+     * @param organizationId the organization ID
+     * @param cursor         the cursor UUID (null for first page)
+     * @param limit          max results per page (1-100)
+     * @return a page of properties
+     */
+    Page<Property> findByOrganizationId(UUID organizationId, UUID cursor, int limit);
 
     /**
      * Lists all direct child properties of the specified parent.

--- a/src/main/java/com/majordomo/domain/port/out/concierge/ContactRepository.java
+++ b/src/main/java/com/majordomo/domain/port/out/concierge/ContactRepository.java
@@ -36,4 +36,14 @@ public interface ContactRepository {
      * @return list of contacts for that organization, or an empty list if none exist
      */
     List<Contact> findByOrganizationId(UUID organizationId);
+
+    /**
+     * Returns contacts for an organization with cursor-based pagination.
+     *
+     * @param organizationId the organization ID
+     * @param cursor         exclusive start cursor (null for first page)
+     * @param limit          maximum number of results
+     * @return list of contacts after the cursor, ordered by ID
+     */
+    List<Contact> findByOrganizationId(UUID organizationId, UUID cursor, int limit);
 }

--- a/src/main/java/com/majordomo/domain/port/out/herald/MaintenanceScheduleRepository.java
+++ b/src/main/java/com/majordomo/domain/port/out/herald/MaintenanceScheduleRepository.java
@@ -39,6 +39,16 @@ public interface MaintenanceScheduleRepository {
     List<MaintenanceSchedule> findByPropertyId(UUID propertyId);
 
     /**
+     * Returns schedules for a property with cursor-based pagination.
+     *
+     * @param propertyId the property ID
+     * @param cursor     exclusive start cursor (null for first page)
+     * @param limit      maximum number of results
+     * @return list of schedules after the cursor, ordered by ID
+     */
+    List<MaintenanceSchedule> findByPropertyId(UUID propertyId, UUID cursor, int limit);
+
+    /**
      * Returns all maintenance schedules whose next due date falls before the given date.
      * Intended for surfacing overdue or imminently due tasks.
      *

--- a/src/main/java/com/majordomo/domain/port/out/steward/PropertyRepository.java
+++ b/src/main/java/com/majordomo/domain/port/out/steward/PropertyRepository.java
@@ -39,6 +39,16 @@ public interface PropertyRepository {
     List<Property> findByOrganizationId(UUID organizationId);
 
     /**
+     * Returns properties for an organization with cursor-based pagination.
+     *
+     * @param organizationId the organization ID
+     * @param cursor         exclusive start cursor (null for first page)
+     * @param limit          maximum number of results
+     * @return list of properties after the cursor, ordered by ID
+     */
+    List<Property> findByOrganizationId(UUID organizationId, UUID cursor, int limit);
+
+    /**
      * Returns all direct child properties of a given parent property.
      *
      * @param parentId the ID of the parent property

--- a/src/test/java/com/majordomo/application/concierge/ContactServicePaginationTest.java
+++ b/src/test/java/com/majordomo/application/concierge/ContactServicePaginationTest.java
@@ -1,0 +1,121 @@
+package com.majordomo.application.concierge;
+
+import com.majordomo.domain.model.Page;
+import com.majordomo.domain.model.concierge.Contact;
+import com.majordomo.domain.port.out.concierge.ContactRepository;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ContactServicePaginationTest {
+
+    @Mock
+    private ContactRepository contactRepository;
+
+    private ContactService contactService;
+
+    @BeforeEach
+    void setUp() {
+        contactService = new ContactService(contactRepository);
+    }
+
+    @Test
+    void findByOrganizationIdFirstPageReturnsItemsAndCursor() {
+        UUID orgId = UUID.randomUUID();
+        // Service requests limit+1 (3) items; repo returns 3 meaning hasMore=true
+        List<Contact> threeContacts = createContacts(3);
+        when(contactRepository.findByOrganizationId(orgId, null, 3)).thenReturn(threeContacts);
+
+        Page<Contact> page = contactService.findByOrganizationId(orgId, null, 2);
+
+        assertEquals(2, page.items().size());
+        assertTrue(page.hasMore());
+        assertNotNull(page.nextCursor());
+        assertEquals(threeContacts.get(1).getId(), page.nextCursor());
+        verify(contactRepository).findByOrganizationId(orgId, null, 3);
+    }
+
+    @Test
+    void findByOrganizationIdLastPageHasMoreFalse() {
+        UUID orgId = UUID.randomUUID();
+        UUID cursor = UUID.randomUUID();
+        // Service requests limit+1 (3) items; repo returns only 1 meaning hasMore=false
+        List<Contact> oneContact = createContacts(1);
+        when(contactRepository.findByOrganizationId(orgId, cursor, 3)).thenReturn(oneContact);
+
+        Page<Contact> page = contactService.findByOrganizationId(orgId, cursor, 2);
+
+        assertEquals(1, page.items().size());
+        assertFalse(page.hasMore());
+        assertNull(page.nextCursor());
+        verify(contactRepository).findByOrganizationId(orgId, cursor, 3);
+    }
+
+    @Test
+    void findByOrganizationIdLimitClampedMaxIs100() {
+        UUID orgId = UUID.randomUUID();
+        // Requesting 200 should be clamped to 100, so repo is called with 101
+        when(contactRepository.findByOrganizationId(orgId, null, 101))
+                .thenReturn(createContacts(101));
+
+        Page<Contact> page = contactService.findByOrganizationId(orgId, null, 200);
+
+        assertEquals(100, page.items().size());
+        assertTrue(page.hasMore());
+        verify(contactRepository).findByOrganizationId(orgId, null, 101);
+    }
+
+    @Test
+    void findByOrganizationIdLimitClampedMinIs1() {
+        UUID orgId = UUID.randomUUID();
+        // Requesting 0 should be clamped to 1, so repo is called with 2
+        when(contactRepository.findByOrganizationId(orgId, null, 2))
+                .thenReturn(createContacts(1));
+
+        Page<Contact> page = contactService.findByOrganizationId(orgId, null, 0);
+
+        assertEquals(1, page.items().size());
+        assertFalse(page.hasMore());
+        verify(contactRepository).findByOrganizationId(orgId, null, 2);
+    }
+
+    @Test
+    void findByOrganizationIdEmptyResultReturnsEmptyPage() {
+        UUID orgId = UUID.randomUUID();
+        when(contactRepository.findByOrganizationId(orgId, null, 21))
+                .thenReturn(List.of());
+
+        Page<Contact> page = contactService.findByOrganizationId(orgId, null, 20);
+
+        assertTrue(page.items().isEmpty());
+        assertFalse(page.hasMore());
+        assertNull(page.nextCursor());
+    }
+
+    private List<Contact> createContacts(int count) {
+        List<Contact> contacts = new ArrayList<>();
+        for (int i = 0; i < count; i++) {
+            var contact = new Contact();
+            contact.setId(UUID.randomUUID());
+            contact.setFormattedName("Contact " + i);
+            contacts.add(contact);
+        }
+        return contacts;
+    }
+}

--- a/src/test/java/com/majordomo/application/herald/ScheduleServicePaginationTest.java
+++ b/src/test/java/com/majordomo/application/herald/ScheduleServicePaginationTest.java
@@ -1,0 +1,95 @@
+package com.majordomo.application.herald;
+
+import com.majordomo.domain.model.Page;
+import com.majordomo.domain.model.herald.MaintenanceSchedule;
+import com.majordomo.domain.port.out.herald.MaintenanceScheduleRepository;
+import com.majordomo.domain.port.out.herald.ServiceRecordRepository;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ScheduleServicePaginationTest {
+
+    @Mock
+    private MaintenanceScheduleRepository scheduleRepository;
+
+    @Mock
+    private ServiceRecordRepository serviceRecordRepository;
+
+    private ScheduleService scheduleService;
+
+    @BeforeEach
+    void setUp() {
+        scheduleService = new ScheduleService(scheduleRepository, serviceRecordRepository);
+    }
+
+    @Test
+    void findByPropertyIdFirstPageReturnsItemsAndCursor() {
+        UUID propertyId = UUID.randomUUID();
+        List<MaintenanceSchedule> threeSchedules = createSchedules(3);
+        when(scheduleRepository.findByPropertyId(propertyId, null, 3)).thenReturn(threeSchedules);
+
+        Page<MaintenanceSchedule> page = scheduleService.findByPropertyId(propertyId, null, 2);
+
+        assertEquals(2, page.items().size());
+        assertTrue(page.hasMore());
+        assertNotNull(page.nextCursor());
+        assertEquals(threeSchedules.get(1).getId(), page.nextCursor());
+        verify(scheduleRepository).findByPropertyId(propertyId, null, 3);
+    }
+
+    @Test
+    void findByPropertyIdLastPageHasMoreFalse() {
+        UUID propertyId = UUID.randomUUID();
+        UUID cursor = UUID.randomUUID();
+        List<MaintenanceSchedule> oneSchedule = createSchedules(1);
+        when(scheduleRepository.findByPropertyId(propertyId, cursor, 3)).thenReturn(oneSchedule);
+
+        Page<MaintenanceSchedule> page = scheduleService.findByPropertyId(propertyId, cursor, 2);
+
+        assertEquals(1, page.items().size());
+        assertFalse(page.hasMore());
+        assertNull(page.nextCursor());
+        verify(scheduleRepository).findByPropertyId(propertyId, cursor, 3);
+    }
+
+    @Test
+    void findByPropertyIdLimitClampedMaxIs100() {
+        UUID propertyId = UUID.randomUUID();
+        when(scheduleRepository.findByPropertyId(propertyId, null, 101))
+                .thenReturn(createSchedules(101));
+
+        Page<MaintenanceSchedule> page = scheduleService.findByPropertyId(propertyId, null, 200);
+
+        assertEquals(100, page.items().size());
+        assertTrue(page.hasMore());
+        verify(scheduleRepository).findByPropertyId(propertyId, null, 101);
+    }
+
+    private List<MaintenanceSchedule> createSchedules(int count) {
+        List<MaintenanceSchedule> schedules = new ArrayList<>();
+        for (int i = 0; i < count; i++) {
+            var schedule = new MaintenanceSchedule();
+            schedule.setId(UUID.randomUUID());
+            schedule.setDescription("Schedule " + i);
+            schedules.add(schedule);
+        }
+        return schedules;
+    }
+}

--- a/src/test/java/com/majordomo/application/steward/PropertyServicePaginationTest.java
+++ b/src/test/java/com/majordomo/application/steward/PropertyServicePaginationTest.java
@@ -1,0 +1,91 @@
+package com.majordomo.application.steward;
+
+import com.majordomo.domain.model.Page;
+import com.majordomo.domain.model.steward.Property;
+import com.majordomo.domain.port.out.steward.PropertyRepository;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class PropertyServicePaginationTest {
+
+    @Mock
+    private PropertyRepository propertyRepository;
+
+    private PropertyService propertyService;
+
+    @BeforeEach
+    void setUp() {
+        propertyService = new PropertyService(propertyRepository);
+    }
+
+    @Test
+    void findByOrganizationIdFirstPageReturnsItemsAndCursor() {
+        UUID orgId = UUID.randomUUID();
+        List<Property> threeProperties = createProperties(3);
+        when(propertyRepository.findByOrganizationId(orgId, null, 3)).thenReturn(threeProperties);
+
+        Page<Property> page = propertyService.findByOrganizationId(orgId, null, 2);
+
+        assertEquals(2, page.items().size());
+        assertTrue(page.hasMore());
+        assertNotNull(page.nextCursor());
+        assertEquals(threeProperties.get(1).getId(), page.nextCursor());
+        verify(propertyRepository).findByOrganizationId(orgId, null, 3);
+    }
+
+    @Test
+    void findByOrganizationIdLastPageHasMoreFalse() {
+        UUID orgId = UUID.randomUUID();
+        UUID cursor = UUID.randomUUID();
+        List<Property> oneProperty = createProperties(1);
+        when(propertyRepository.findByOrganizationId(orgId, cursor, 3)).thenReturn(oneProperty);
+
+        Page<Property> page = propertyService.findByOrganizationId(orgId, cursor, 2);
+
+        assertEquals(1, page.items().size());
+        assertFalse(page.hasMore());
+        assertNull(page.nextCursor());
+        verify(propertyRepository).findByOrganizationId(orgId, cursor, 3);
+    }
+
+    @Test
+    void findByOrganizationIdLimitClampedMaxIs100() {
+        UUID orgId = UUID.randomUUID();
+        when(propertyRepository.findByOrganizationId(orgId, null, 101))
+                .thenReturn(createProperties(101));
+
+        Page<Property> page = propertyService.findByOrganizationId(orgId, null, 200);
+
+        assertEquals(100, page.items().size());
+        assertTrue(page.hasMore());
+        verify(propertyRepository).findByOrganizationId(orgId, null, 101);
+    }
+
+    private List<Property> createProperties(int count) {
+        List<Property> properties = new ArrayList<>();
+        for (int i = 0; i < count; i++) {
+            var property = new Property();
+            property.setId(UUID.randomUUID());
+            property.setName("Property " + i);
+            properties.add(property);
+        }
+        return properties;
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `Page<T>` record in the domain model for cursor-based pagination using UUIDv7 time-sortable IDs
- Adds paginated overloads to outbound repository ports (`ContactRepository`, `PropertyRepository`, `MaintenanceScheduleRepository`) with cursor and limit parameters
- Adds Spring Data query methods to JPA repositories (`findBy...OrderById`, `findBy...AndIdGreaterThanOrderById`) with `Pageable` support
- Implements cursor logic in repository adapters (null cursor = first page, otherwise ID > cursor)
- Adds paginated overloads to inbound ports (`ManageContactUseCase`, `ManagePropertyUseCase`, `ManageScheduleUseCase`)
- Implements pagination in application services with limit clamping (1-100) and N+1 fetch strategy for `hasMore` detection
- Updates REST controllers (`ContactController`, `PropertyController`, `ScheduleController`) to accept optional `cursor` and `limit` query parameters, returning `Page<T>` responses
- Existing non-paginated methods retained for internal use

## Test plan

- [x] `ContactServicePaginationTest` — first page returns items and cursor, last page has hasMore=false, limit clamped to max 100, limit clamped to min 1, empty result returns empty page
- [x] `PropertyServicePaginationTest` — first page, last page, limit clamping
- [x] `ScheduleServicePaginationTest` — first page, last page, limit clamping
- [x] All 39 unit tests pass, 0 Checkstyle violations

Closes #31

Generated with [Claude Code](https://claude.com/claude-code)