### PR TITLE
Design review: extract pagination helper, document trade-offs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,6 +55,10 @@ adapter/out/persistence/ — JPA entities, mappers, repository adapters
 ./mvnw spring-boot:run   # Start app (requires PostgreSQL on localhost:5432)
 ```
 
+## Known Trade-offs
+
+- **Jakarta Validation in domain models**: Domain models (`Contact`, `Property`, `MaintenanceSchedule`, `ServiceRecord`) use `@NotBlank` and `@NotNull` from Jakarta Validation. Strictly, hexagonal architecture says domain should have zero framework dependencies. We accept this pragmatic trade-off because: (1) Jakarta Validation is a spec, not a framework implementation; (2) moving annotations to adapter-layer DTOs would duplicate every field definition; (3) the coupling is shallow — annotations are metadata only, with no behavioral dependency on a framework runtime. If this becomes problematic, extract validation to request DTOs in the adapter layer.
+
 ## Conventions
 
 - **Javadoc** (ADR-0015): Required on all public classes and methods. Getters/setters/entities exempt.

--- a/src/main/java/com/majordomo/application/concierge/ContactService.java
+++ b/src/main/java/com/majordomo/application/concierge/ContactService.java
@@ -53,12 +53,7 @@ public class ContactService implements ManageContactUseCase {
     public Page<Contact> findByOrganizationId(UUID organizationId, UUID cursor, int limit) {
         int clampedLimit = Math.max(1, Math.min(limit, 100));
         var items = contactRepository.findByOrganizationId(organizationId, cursor, clampedLimit + 1);
-        boolean hasMore = items.size() > clampedLimit;
-        if (hasMore) {
-            items = items.subList(0, clampedLimit);
-        }
-        UUID nextCursor = hasMore ? items.get(items.size() - 1).getId() : null;
-        return new Page<>(items, nextCursor, hasMore);
+        return Page.fromOverfetch(items, limit, Contact::getId);
     }
 
     @Override

--- a/src/main/java/com/majordomo/application/herald/ScheduleService.java
+++ b/src/main/java/com/majordomo/application/herald/ScheduleService.java
@@ -62,12 +62,7 @@ public class ScheduleService implements ManageScheduleUseCase {
     public Page<MaintenanceSchedule> findByPropertyId(UUID propertyId, UUID cursor, int limit) {
         int clampedLimit = Math.max(1, Math.min(limit, 100));
         var items = scheduleRepository.findByPropertyId(propertyId, cursor, clampedLimit + 1);
-        boolean hasMore = items.size() > clampedLimit;
-        if (hasMore) {
-            items = items.subList(0, clampedLimit);
-        }
-        UUID nextCursor = hasMore ? items.get(items.size() - 1).getId() : null;
-        return new Page<>(items, nextCursor, hasMore);
+        return Page.fromOverfetch(items, limit, MaintenanceSchedule::getId);
     }
 
     @Override

--- a/src/main/java/com/majordomo/application/steward/PropertyService.java
+++ b/src/main/java/com/majordomo/application/steward/PropertyService.java
@@ -57,12 +57,7 @@ public class PropertyService implements ManagePropertyUseCase {
     public Page<Property> findByOrganizationId(UUID organizationId, UUID cursor, int limit) {
         int clampedLimit = Math.max(1, Math.min(limit, 100));
         var items = propertyRepository.findByOrganizationId(organizationId, cursor, clampedLimit + 1);
-        boolean hasMore = items.size() > clampedLimit;
-        if (hasMore) {
-            items = items.subList(0, clampedLimit);
-        }
-        UUID nextCursor = hasMore ? items.get(items.size() - 1).getId() : null;
-        return new Page<>(items, nextCursor, hasMore);
+        return Page.fromOverfetch(items, limit, Property::getId);
     }
 
     @Override

--- a/src/main/java/com/majordomo/domain/model/Page.java
+++ b/src/main/java/com/majordomo/domain/model/Page.java
@@ -2,6 +2,7 @@ package com.majordomo.domain.model;
 
 import java.util.List;
 import java.util.UUID;
+import java.util.function.Function;
 
 /**
  * A page of results for cursor-based pagination.
@@ -17,4 +18,26 @@ public record Page<T>(
     UUID nextCursor,
     boolean hasMore
 ) {
+
+    /**
+     * Creates a page from a list that was fetched with limit+1 to detect hasMore.
+     * Clamps the limit to [1, 100], trims the extra item if present, and extracts
+     * the cursor from the last item in the page.
+     *
+     * @param items       the fetched items (may contain one extra for hasMore detection)
+     * @param limit       the requested page size (will be clamped to [1, 100])
+     * @param idExtractor function to extract the UUID from an item for cursor use
+     * @param <T>         the item type
+     * @return a page with correct items, cursor, and hasMore flag
+     */
+    public static <T> Page<T> fromOverfetch(List<T> items, int limit,
+            Function<T, UUID> idExtractor) {
+        int clampedLimit = Math.max(1, Math.min(limit, 100));
+        boolean hasMore = items.size() > clampedLimit;
+        List<T> pageItems = hasMore ? items.subList(0, clampedLimit) : items;
+        UUID nextCursor = hasMore
+                ? idExtractor.apply(pageItems.get(pageItems.size() - 1))
+                : null;
+        return new Page<>(pageItems, nextCursor, hasMore);
+    }
 }


### PR DESCRIPTION
## Summary

- **DRY: Extract `Page.fromOverfetch()` static factory** — The same pagination pattern (clamp limit, fetch N+1, check hasMore, build Page) was duplicated across `ContactService`, `PropertyService`, and `ScheduleService`. Extracted into a single `Page.fromOverfetch(items, limit, idExtractor)` method that all three services now call.
- **Hexagonal: Document Jakarta Validation trade-off** — Domain models use `@NotBlank`/`@NotNull` from Jakarta Validation, which is technically a framework dependency in the domain layer. Documented this as an accepted pragmatic trade-off in CLAUDE.md with rationale and migration path.
- **Audit findings** — No Spring, JPA, or Hibernate imports were found in the domain layer (only Jakarta Validation annotations). Use case interfaces are reasonably sized. Update/archive patterns are similar across services but differ enough per entity that abstracting would over-engineer.

## Test plan

- [x] Checkstyle passes (0 violations)
- [ ] Verify existing pagination tests still pass (requires Java 25 environment)
- [ ] Manually confirm cursor-based pagination behavior is unchanged

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)