### PR TITLE
Add Resilience4j circuit breakers, timeouts, and retries

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -122,6 +122,20 @@
             <artifactId>bcprov-jdk18on</artifactId>
             <version>1.80</version>
         </dependency>
+        <dependency>
+            <groupId>io.github.resilience4j</groupId>
+            <artifactId>resilience4j-spring-boot3</artifactId>
+            <version>2.2.0</version>
+        </dependency>
+        <dependency>
+            <groupId>io.github.resilience4j</groupId>
+            <artifactId>resilience4j-micrometer</artifactId>
+            <version>2.2.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-aop</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/com/majordomo/adapter/out/notification/NotificationAdapter.java
+++ b/src/main/java/com/majordomo/adapter/out/notification/NotificationAdapter.java
@@ -1,0 +1,44 @@
+package com.majordomo.adapter.out.notification;
+
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
+import io.github.resilience4j.retry.annotation.Retry;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+/**
+ * Notification adapter with circuit breaker and retry protection.
+ * Currently logs notifications; will send real emails when SMTP is configured.
+ */
+@Component
+public class NotificationAdapter {
+
+    private static final Logger LOG = LoggerFactory.getLogger(NotificationAdapter.class);
+
+    /**
+     * Sends a notification with circuit breaker and retry protection.
+     *
+     * @param to      the recipient
+     * @param subject the notification subject
+     * @param body    the notification body
+     */
+    @CircuitBreaker(name = "notification", fallbackMethod = "sendFallback")
+    @Retry(name = "notification")
+    public void send(String to, String subject, String body) {
+        LOG.info("Notification to={} subject={}", to, subject);
+        // Future: delegate to email sender
+    }
+
+    /**
+     * Fallback when notification sending fails.
+     *
+     * @param to      the recipient
+     * @param subject the notification subject
+     * @param body    the notification body
+     * @param ex      the cause of failure
+     */
+    public void sendFallback(String to, String subject, String body, Exception ex) {
+        LOG.warn("Notification failed (circuit breaker), will retry later: to={} subject={} error={}",
+                to, subject, ex.getMessage());
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -20,10 +20,49 @@ management:
   endpoints:
     web:
       exposure:
-        include: health,info,prometheus
+        include: health,info,prometheus,circuitbreakers,retries
   endpoint:
     health:
       show-details: when-authorized
+
+resilience4j:
+  circuitbreaker:
+    configs:
+      default:
+        sliding-window-size: 5
+        failure-rate-threshold: 50
+        wait-duration-in-open-state:
+          seconds: 10
+        permitted-number-of-calls-in-half-open-state: 3
+    instances:
+      notification:
+        base-config: default
+      fileStorage:
+        base-config: default
+  retry:
+    configs:
+      default:
+        max-attempts: 3
+        wait-duration:
+          millis: 500
+        exponential-backoff-multiplier: 2
+    instances:
+      notification:
+        base-config: default
+      fileStorage:
+        base-config: default
+        max-attempts: 2
+  timelimiter:
+    configs:
+      default:
+        timeout-duration:
+          seconds: 5
+    instances:
+      notification:
+        base-config: default
+      fileStorage:
+        timeout-duration:
+          seconds: 10
 
 springdoc:
   api-docs:

--- a/src/test/java/com/majordomo/adapter/out/notification/NotificationAdapterTest.java
+++ b/src/test/java/com/majordomo/adapter/out/notification/NotificationAdapterTest.java
@@ -1,0 +1,35 @@
+package com.majordomo.adapter.out.notification;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+/**
+ * Unit tests for {@link NotificationAdapter}.
+ *
+ * <p>Note: Circuit breaker and retry behavior require a Spring integration test
+ * context because Resilience4j uses AOP proxies. These unit tests verify the
+ * adapter's direct method behavior without the proxy layer.</p>
+ */
+class NotificationAdapterTest {
+
+    private final NotificationAdapter adapter = new NotificationAdapter();
+
+    /**
+     * Verifies that send completes without throwing.
+     */
+    @Test
+    void sendLogsSuccessfully() {
+        assertDoesNotThrow(() -> adapter.send("user@example.com", "Test Subject", "Test Body"));
+    }
+
+    /**
+     * Verifies that the fallback method completes without throwing.
+     */
+    @Test
+    void sendFallbackLogsWarning() {
+        assertDoesNotThrow(() ->
+                adapter.sendFallback("user@example.com", "Test Subject", "Test Body",
+                        new RuntimeException("connection refused")));
+    }
+}


### PR DESCRIPTION
## Summary
- Add Resilience4j Spring Boot 3, Micrometer, and AOP dependencies for circuit breaker, retry, and timeout support
- Configure default resilience policies (50% failure threshold, 3 retries with exponential backoff, 5s timeout) and named instances for `notification` and `fileStorage`
- Create `NotificationAdapter` with `@CircuitBreaker` + `@Retry` annotations and fallback method as the reference pattern for future outbound adapters
- Expose circuit breaker and retry actuator endpoints for monitoring

## Test plan
- [x] `NotificationAdapter.send()` completes without error
- [x] `NotificationAdapter.sendFallback()` completes without error
- [x] Checkstyle passes (`./mvnw validate`)
- [ ] Verify actuator endpoints `/actuator/circuitbreakers` and `/actuator/retries` return data when app is running
- [ ] Integration test with Spring context to verify AOP proxy wiring (future)

Closes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)