### PR TITLE
Add email notifications for upcoming maintenance

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -153,6 +153,10 @@
             <artifactId>ez-vcard</artifactId>
             <version>0.12.1</version>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-mail</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/com/majordomo/MajordomoApplication.java
+++ b/src/main/java/com/majordomo/MajordomoApplication.java
@@ -3,6 +3,7 @@ package com.majordomo;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 /**
  * Entry point for the Majordomo Spring Boot application.
@@ -14,6 +15,7 @@ import org.springframework.cache.annotation.EnableCaching;
  */
 @SpringBootApplication
 @EnableCaching
+@EnableScheduling
 public class MajordomoApplication {
 
     /**

--- a/src/main/java/com/majordomo/adapter/out/notification/NotificationAdapter.java
+++ b/src/main/java/com/majordomo/adapter/out/notification/NotificationAdapter.java
@@ -1,5 +1,7 @@
 package com.majordomo.adapter.out.notification;
 
+import com.majordomo.domain.port.out.herald.NotificationPort;
+
 import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
 import io.github.resilience4j.retry.annotation.Retry;
 import org.slf4j.Logger;
@@ -11,7 +13,7 @@ import org.springframework.stereotype.Component;
  * Currently logs notifications; will send real emails when SMTP is configured.
  */
 @Component
-public class NotificationAdapter {
+public class NotificationAdapter implements NotificationPort {
 
     private static final Logger LOG = LoggerFactory.getLogger(NotificationAdapter.class);
 
@@ -22,11 +24,12 @@ public class NotificationAdapter {
      * @param subject the notification subject
      * @param body    the notification body
      */
+    @Override
     @CircuitBreaker(name = "notification", fallbackMethod = "sendFallback")
     @Retry(name = "notification")
     public void send(String to, String subject, String body) {
         LOG.info("Notification to={} subject={}", to, subject);
-        // Future: delegate to email sender
+        // Future: delegate to JavaMailSender in prod profile
     }
 
     /**

--- a/src/main/java/com/majordomo/adapter/out/persistence/herald/MaintenanceScheduleEntity.java
+++ b/src/main/java/com/majordomo/adapter/out/persistence/herald/MaintenanceScheduleEntity.java
@@ -48,6 +48,9 @@ public class MaintenanceScheduleEntity {
     @Column(name = "archived_at")
     private Instant archivedAt;
 
+    @Column(name = "notification_sent_at")
+    private Instant notificationSentAt;
+
     public UUID getId() { return id; }
     public void setId(UUID id) { this.id = id; }
 
@@ -77,4 +80,7 @@ public class MaintenanceScheduleEntity {
 
     public Instant getArchivedAt() { return archivedAt; }
     public void setArchivedAt(Instant archivedAt) { this.archivedAt = archivedAt; }
+
+    public Instant getNotificationSentAt() { return notificationSentAt; }
+    public void setNotificationSentAt(Instant notificationSentAt) { this.notificationSentAt = notificationSentAt; }
 }

--- a/src/main/java/com/majordomo/adapter/out/persistence/herald/MaintenanceScheduleMapper.java
+++ b/src/main/java/com/majordomo/adapter/out/persistence/herald/MaintenanceScheduleMapper.java
@@ -18,6 +18,7 @@ final class MaintenanceScheduleMapper {
         entity.setCreatedAt(schedule.getCreatedAt());
         entity.setUpdatedAt(schedule.getUpdatedAt());
         entity.setArchivedAt(schedule.getArchivedAt());
+        entity.setNotificationSentAt(schedule.getNotificationSentAt());
         return entity;
     }
 
@@ -33,6 +34,7 @@ final class MaintenanceScheduleMapper {
         schedule.setCreatedAt(entity.getCreatedAt());
         schedule.setUpdatedAt(entity.getUpdatedAt());
         schedule.setArchivedAt(entity.getArchivedAt());
+        schedule.setNotificationSentAt(entity.getNotificationSentAt());
         return schedule;
     }
 }

--- a/src/main/java/com/majordomo/application/herald/MaintenanceNotificationService.java
+++ b/src/main/java/com/majordomo/application/herald/MaintenanceNotificationService.java
@@ -1,0 +1,90 @@
+package com.majordomo.application.herald;
+
+import com.majordomo.domain.model.identity.MemberRole;
+import com.majordomo.domain.port.out.herald.MaintenanceScheduleRepository;
+import com.majordomo.domain.port.out.herald.NotificationPort;
+import com.majordomo.domain.port.out.identity.MembershipRepository;
+import com.majordomo.domain.port.out.identity.UserRepository;
+import com.majordomo.domain.port.out.steward.PropertyRepository;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import java.time.Instant;
+import java.time.LocalDate;
+
+/**
+ * Scheduled service that checks for upcoming maintenance and sends
+ * email notifications to organization admins.
+ */
+@Service
+public class MaintenanceNotificationService {
+
+    private static final Logger LOG = LoggerFactory.getLogger(MaintenanceNotificationService.class);
+
+    private final MaintenanceScheduleRepository scheduleRepository;
+    private final PropertyRepository propertyRepository;
+    private final MembershipRepository membershipRepository;
+    private final UserRepository userRepository;
+    private final NotificationPort notificationPort;
+
+    /**
+     * Constructs the notification service with required dependencies.
+     *
+     * @param scheduleRepository   repository for maintenance schedules
+     * @param propertyRepository   repository for properties
+     * @param membershipRepository repository for organization memberships
+     * @param userRepository       repository for users
+     * @param notificationPort     outbound port for sending notifications
+     */
+    public MaintenanceNotificationService(MaintenanceScheduleRepository scheduleRepository,
+                                          PropertyRepository propertyRepository,
+                                          MembershipRepository membershipRepository,
+                                          UserRepository userRepository,
+                                          NotificationPort notificationPort) {
+        this.scheduleRepository = scheduleRepository;
+        this.propertyRepository = propertyRepository;
+        this.membershipRepository = membershipRepository;
+        this.userRepository = userRepository;
+        this.notificationPort = notificationPort;
+    }
+
+    /**
+     * Runs on a configurable schedule to check for maintenance due within 7 days.
+     * Sends email notifications and marks schedules as notified.
+     */
+    @Scheduled(cron = "${majordomo.notifications.cron:0 0 8 * * *}")
+    public void checkAndNotify() {
+        var dueSchedules = scheduleRepository.findDueBefore(LocalDate.now().plusDays(7));
+        for (var schedule : dueSchedules) {
+            if (schedule.getNotificationSentAt() != null) {
+                continue;
+            }
+
+            var property = propertyRepository.findById(schedule.getPropertyId());
+            if (property.isEmpty()) {
+                continue;
+            }
+
+            var memberships = membershipRepository.findByOrganizationId(
+                    property.get().getOrganizationId());
+            for (var membership : memberships) {
+                if (membership.getRole() == MemberRole.MEMBER) {
+                    continue;
+                }
+                var user = userRepository.findById(membership.getUserId());
+                user.ifPresent(u -> notificationPort.send(
+                        u.getEmail(),
+                        "Upcoming maintenance: " + schedule.getDescription(),
+                        "Maintenance for " + property.get().getName()
+                                + " is due on " + schedule.getNextDue()));
+            }
+
+            schedule.setNotificationSentAt(Instant.now());
+            scheduleRepository.save(schedule);
+        }
+        LOG.info("Maintenance notification check complete");
+    }
+}

--- a/src/main/java/com/majordomo/domain/model/herald/MaintenanceSchedule.java
+++ b/src/main/java/com/majordomo/domain/model/herald/MaintenanceSchedule.java
@@ -26,6 +26,7 @@ public class MaintenanceSchedule {
     private Instant createdAt;
     private Instant updatedAt;
     private Instant archivedAt;
+    private Instant notificationSentAt;
 
     public MaintenanceSchedule() {}
 
@@ -58,4 +59,7 @@ public class MaintenanceSchedule {
 
     public Instant getArchivedAt() { return archivedAt; }
     public void setArchivedAt(Instant archivedAt) { this.archivedAt = archivedAt; }
+
+    public Instant getNotificationSentAt() { return notificationSentAt; }
+    public void setNotificationSentAt(Instant notificationSentAt) { this.notificationSentAt = notificationSentAt; }
 }

--- a/src/main/java/com/majordomo/domain/port/out/herald/NotificationPort.java
+++ b/src/main/java/com/majordomo/domain/port/out/herald/NotificationPort.java
@@ -1,0 +1,16 @@
+package com.majordomo.domain.port.out.herald;
+
+/**
+ * Outbound port for sending notifications.
+ */
+public interface NotificationPort {
+
+    /**
+     * Sends a notification.
+     *
+     * @param to      the recipient
+     * @param subject the subject line
+     * @param body    the message body
+     */
+    void send(String to, String subject, String body);
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -89,6 +89,8 @@ majordomo:
     base-dir: ./data/attachments
     max-file-size: 10485760
     allowed-types: image/jpeg,image/png,application/pdf,text/plain
+  notifications:
+    cron: "0 0 8 * * *"
 
 springdoc:
   api-docs:

--- a/src/main/resources/db/migration/V7__add_notification_sent_at.sql
+++ b/src/main/resources/db/migration/V7__add_notification_sent_at.sql
@@ -1,0 +1,1 @@
+ALTER TABLE maintenance_schedules ADD COLUMN notification_sent_at TIMESTAMPTZ;

--- a/src/test/java/com/majordomo/application/herald/MaintenanceNotificationServiceTest.java
+++ b/src/test/java/com/majordomo/application/herald/MaintenanceNotificationServiceTest.java
@@ -1,0 +1,132 @@
+package com.majordomo.application.herald;
+
+import com.majordomo.domain.model.herald.Frequency;
+import com.majordomo.domain.model.herald.MaintenanceSchedule;
+import com.majordomo.domain.model.identity.MemberRole;
+import com.majordomo.domain.model.identity.Membership;
+import com.majordomo.domain.model.identity.User;
+import com.majordomo.domain.model.steward.Property;
+import com.majordomo.domain.port.out.herald.MaintenanceScheduleRepository;
+import com.majordomo.domain.port.out.herald.NotificationPort;
+import com.majordomo.domain.port.out.identity.MembershipRepository;
+import com.majordomo.domain.port.out.identity.UserRepository;
+import com.majordomo.domain.port.out.steward.PropertyRepository;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class MaintenanceNotificationServiceTest {
+
+    @Mock
+    private MaintenanceScheduleRepository scheduleRepository;
+
+    @Mock
+    private PropertyRepository propertyRepository;
+
+    @Mock
+    private MembershipRepository membershipRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private NotificationPort notificationPort;
+
+    private MaintenanceNotificationService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new MaintenanceNotificationService(
+                scheduleRepository, propertyRepository, membershipRepository,
+                userRepository, notificationPort);
+    }
+
+    @Test
+    void checkAndNotifyDueScheduleSendsNotification() {
+        var propertyId = UUID.randomUUID();
+        var orgId = UUID.randomUUID();
+        var userId = UUID.randomUUID();
+
+        var schedule = new MaintenanceSchedule();
+        schedule.setId(UUID.randomUUID());
+        schedule.setPropertyId(propertyId);
+        schedule.setDescription("HVAC filter replacement");
+        schedule.setFrequency(Frequency.MONTHLY);
+        schedule.setNextDue(LocalDate.now().plusDays(3));
+
+        var property = new Property();
+        property.setId(propertyId);
+        property.setOrganizationId(orgId);
+        property.setName("Main Building");
+
+        var membership = new Membership(UUID.randomUUID(), userId, orgId, MemberRole.OWNER);
+
+        var user = new User(userId, "admin", "admin@example.com");
+
+        when(scheduleRepository.findDueBefore(any(LocalDate.class)))
+                .thenReturn(List.of(schedule));
+        when(propertyRepository.findById(propertyId))
+                .thenReturn(Optional.of(property));
+        when(membershipRepository.findByOrganizationId(orgId))
+                .thenReturn(List.of(membership));
+        when(userRepository.findById(userId))
+                .thenReturn(Optional.of(user));
+        when(scheduleRepository.save(any(MaintenanceSchedule.class)))
+                .thenReturn(schedule);
+
+        service.checkAndNotify();
+
+        verify(notificationPort).send(
+                eq("admin@example.com"),
+                eq("Upcoming maintenance: HVAC filter replacement"),
+                anyString());
+        verify(scheduleRepository).save(schedule);
+    }
+
+    @Test
+    void checkAndNotifyAlreadyNotifiedSkips() {
+        var schedule = new MaintenanceSchedule();
+        schedule.setId(UUID.randomUUID());
+        schedule.setPropertyId(UUID.randomUUID());
+        schedule.setDescription("Already notified");
+        schedule.setFrequency(Frequency.MONTHLY);
+        schedule.setNextDue(LocalDate.now().plusDays(3));
+        schedule.setNotificationSentAt(Instant.now());
+
+        when(scheduleRepository.findDueBefore(any(LocalDate.class)))
+                .thenReturn(List.of(schedule));
+
+        service.checkAndNotify();
+
+        verify(notificationPort, never()).send(anyString(), anyString(), anyString());
+        verify(scheduleRepository, never()).save(any());
+    }
+
+    @Test
+    void checkAndNotifyNoSchedulesDueDoesNothing() {
+        when(scheduleRepository.findDueBefore(any(LocalDate.class)))
+                .thenReturn(List.of());
+
+        service.checkAndNotify();
+
+        verify(notificationPort, never()).send(anyString(), anyString(), anyString());
+        verify(scheduleRepository, never()).save(any());
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `spring-boot-starter-mail` dependency and `NotificationPort` outbound port with logging stub adapter (circuit breaker + retry)
- Introduces `MaintenanceNotificationService` scheduled task that checks for maintenance due within 7 days, notifies org owners/admins via email, and marks schedules as notified to prevent duplicates
- Includes V7 Flyway migration (`notification_sent_at` column), domain/entity/mapper updates, `@EnableScheduling`, configurable cron, and unit tests

## Test plan
- [x] `checkAndNotifyDueScheduleSendsNotification` — verifies notification sent for due schedule
- [x] `checkAndNotifyAlreadyNotifiedSkips` — verifies no duplicate notifications
- [x] `checkAndNotifyNoSchedulesDueDoesNothing` — verifies no-op when nothing is due
- [ ] Manual: verify Checkstyle passes (`./mvnw validate`)
- [ ] Manual: verify full build (`./mvnw verify`) once DB is available

Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)