### PR TITLE
Replace UUID.randomUUID() with UUIDv7 factory and ADR

### DIFF
--- a/doc/adr/0018-use-uuidv7-for-entity-identifiers.md
+++ b/doc/adr/0018-use-uuidv7-for-entity-identifiers.md
@@ -1,0 +1,25 @@
+# 18. Use UUIDv7 for all entity identifiers
+
+Date: 2026-03-25
+
+## Status
+Accepted
+
+## Context
+Entity IDs need to be unique, globally uncoordinated, and time-sortable for efficient cursor-based pagination and database indexing. UUID v4 (random) provides uniqueness but is not time-ordered, leading to index fragmentation and making cursor pagination unreliable.
+
+## Decision
+We will use UUIDv7 (RFC 9562) for all entity primary keys, generated via `UuidFactory.newId()`.
+
+UUIDv7 encodes a Unix timestamp in the most significant bits, making IDs monotonically increasing within a millisecond. This provides:
+- Efficient B-tree indexing (sequential inserts)
+- Reliable cursor-based pagination (WHERE id > cursor ORDER BY id)
+- Embedded creation timestamp (extractable if needed)
+
+Implementation uses the `uuid-creator` library via a domain-layer factory class.
+
+## Consequences
+- All new entities get time-ordered IDs automatically
+- Cursor-based pagination is stable and efficient
+- Existing v4 UUIDs from seed migrations are acceptable (they predate this decision)
+- Single factory class makes the ID strategy swappable if needed

--- a/pom.xml
+++ b/pom.xml
@@ -157,6 +157,11 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-mail</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.github.f4b6a3</groupId>
+            <artifactId>uuid-creator</artifactId>
+            <version>6.0.0</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/com/majordomo/adapter/in/web/config/OAuth2UserService.java
+++ b/src/main/java/com/majordomo/adapter/in/web/config/OAuth2UserService.java
@@ -10,6 +10,8 @@ import com.majordomo.domain.port.out.identity.OAuthLinkRepository;
 import com.majordomo.domain.port.out.identity.OrganizationRepository;
 import com.majordomo.domain.port.out.identity.UserRepository;
 
+import com.majordomo.domain.model.UuidFactory;
+
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
@@ -86,18 +88,18 @@ public class OAuth2UserService extends DefaultOAuth2UserService {
     User createNewUser(String name, String email) {
         Instant now = Instant.now();
 
-        String username = email.split("@")[0] + "-" + UUID.randomUUID().toString().substring(0, 8);
-        var user = new User(UUID.randomUUID(), username, email);
+        String username = email.split("@")[0] + "-" + UuidFactory.newId().toString().substring(0, 8);
+        var user = new User(UuidFactory.newId(), username, email);
         user.setCreatedAt(now);
         user.setUpdatedAt(now);
         var savedUser = userRepository.save(user);
 
-        var org = new Organization(UUID.randomUUID(), name + "'s Organization");
+        var org = new Organization(UuidFactory.newId(), name + "'s Organization");
         org.setCreatedAt(now);
         org.setUpdatedAt(now);
         var savedOrg = organizationRepository.save(org);
 
-        var membership = new Membership(UUID.randomUUID(), savedUser.getId(),
+        var membership = new Membership(UuidFactory.newId(), savedUser.getId(),
                 savedOrg.getId(), MemberRole.OWNER);
         membership.setCreatedAt(now);
         membership.setUpdatedAt(now);
@@ -116,7 +118,7 @@ public class OAuth2UserService extends DefaultOAuth2UserService {
      */
     void createOAuthLink(UUID userId, String provider, String externalId, String email) {
         Instant now = Instant.now();
-        var link = new OAuthLink(UUID.randomUUID(), userId, provider, externalId, email);
+        var link = new OAuthLink(UuidFactory.newId(), userId, provider, externalId, email);
         link.setCreatedAt(now);
         link.setUpdatedAt(now);
         oauthLinkRepository.save(link);

--- a/src/main/java/com/majordomo/adapter/in/web/identity/ApiKeyController.java
+++ b/src/main/java/com/majordomo/adapter/in/web/identity/ApiKeyController.java
@@ -4,6 +4,8 @@ import com.majordomo.adapter.in.web.config.ApiKeyAuthenticationFilter;
 import com.majordomo.domain.model.identity.ApiKey;
 import com.majordomo.domain.port.out.identity.ApiKeyRepository;
 
+import com.majordomo.domain.model.UuidFactory;
+
 import io.swagger.v3.oas.annotations.tags.Tag;
 
 import org.springframework.http.ResponseEntity;
@@ -64,7 +66,7 @@ public class ApiKeyController {
         String hashedKey = ApiKeyAuthenticationFilter.sha256(rawKey);
 
         var now = Instant.now();
-        var apiKey = new ApiKey(UUID.randomUUID(), orgId, request.name(), hashedKey);
+        var apiKey = new ApiKey(UuidFactory.newId(), orgId, request.name(), hashedKey);
         apiKey.setCreatedAt(now);
         apiKey.setUpdatedAt(now);
         apiKey.setExpiresAt(request.expiresAt());

--- a/src/main/java/com/majordomo/application/AttachmentService.java
+++ b/src/main/java/com/majordomo/application/AttachmentService.java
@@ -6,6 +6,8 @@ import com.majordomo.domain.port.in.ManageAttachmentUseCase;
 import com.majordomo.domain.port.out.AttachmentRepository;
 import com.majordomo.domain.port.out.FileStoragePort;
 
+import com.majordomo.domain.model.UuidFactory;
+
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
@@ -59,7 +61,7 @@ public class AttachmentService implements ManageAttachmentUseCase {
                     "Content type " + contentType + " is not allowed");
         }
 
-        UUID id = UUID.randomUUID();
+        UUID id = UuidFactory.newId();
         String path = entityType + "/" + entityId + "/" + id + "/" + filename;
         fileStorage.store(path, content);
 

--- a/src/main/java/com/majordomo/application/concierge/ContactService.java
+++ b/src/main/java/com/majordomo/application/concierge/ContactService.java
@@ -10,6 +10,8 @@ import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 
+import com.majordomo.domain.model.UuidFactory;
+
 import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
@@ -36,7 +38,7 @@ public class ContactService implements ManageContactUseCase {
     @Override
     @CacheEvict(value = "contacts", allEntries = true)
     public Contact create(Contact contact) {
-        contact.setId(UUID.randomUUID());
+        contact.setId(UuidFactory.newId());
         contact.setCreatedAt(Instant.now());
         contact.setUpdatedAt(Instant.now());
         return contactRepository.save(contact);

--- a/src/main/java/com/majordomo/application/herald/ScheduleService.java
+++ b/src/main/java/com/majordomo/application/herald/ScheduleService.java
@@ -12,6 +12,8 @@ import com.majordomo.domain.port.out.herald.ServiceRecordRepository;
 
 import org.springframework.stereotype.Service;
 
+import com.majordomo.domain.model.UuidFactory;
+
 import java.time.Instant;
 import java.time.LocalDate;
 import java.util.List;
@@ -48,7 +50,7 @@ public class ScheduleService implements ManageScheduleUseCase {
 
     @Override
     public MaintenanceSchedule create(MaintenanceSchedule schedule) {
-        schedule.setId(UUID.randomUUID());
+        schedule.setId(UuidFactory.newId());
         schedule.setCreatedAt(Instant.now());
         schedule.setUpdatedAt(Instant.now());
         return scheduleRepository.save(schedule);
@@ -86,7 +88,7 @@ public class ScheduleService implements ManageScheduleUseCase {
 
     @Override
     public ServiceRecord recordService(UUID scheduleId, ServiceRecord record) {
-        record.setId(UUID.randomUUID());
+        record.setId(UuidFactory.newId());
         record.setScheduleId(scheduleId);
         record.setCreatedAt(Instant.now());
         record.setUpdatedAt(Instant.now());

--- a/src/main/java/com/majordomo/application/identity/UserManagementService.java
+++ b/src/main/java/com/majordomo/application/identity/UserManagementService.java
@@ -11,6 +11,8 @@ import com.majordomo.domain.port.out.identity.CredentialRepository;
 import com.majordomo.domain.port.out.identity.MembershipRepository;
 import com.majordomo.domain.port.out.identity.UserRepository;
 
+import com.majordomo.domain.model.UuidFactory;
+
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -81,20 +83,20 @@ public class UserManagementService implements ManageUserUseCase {
 
         // Create user
         Instant now = Instant.now();
-        var user = new User(UUID.randomUUID(), username, email);
+        var user = new User(UuidFactory.newId(), username, email);
         user.setCreatedAt(now);
         user.setUpdatedAt(now);
         var savedUser = userRepository.save(user);
 
         // Create credential
-        var credential = new Credential(UUID.randomUUID(), savedUser.getId(),
+        var credential = new Credential(UuidFactory.newId(), savedUser.getId(),
                 passwordEncoder.encode(plainPassword));
         credential.setCreatedAt(now);
         credential.setUpdatedAt(now);
         credentialRepository.save(credential);
 
         // Create membership as MEMBER
-        var membership = new Membership(UUID.randomUUID(), savedUser.getId(),
+        var membership = new Membership(UuidFactory.newId(), savedUser.getId(),
                 organizationId, MemberRole.MEMBER);
         membership.setCreatedAt(now);
         membership.setUpdatedAt(now);

--- a/src/main/java/com/majordomo/application/steward/PropertyService.java
+++ b/src/main/java/com/majordomo/application/steward/PropertyService.java
@@ -13,6 +13,8 @@ import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 
+import com.majordomo.domain.model.UuidFactory;
+
 import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
@@ -43,7 +45,7 @@ public class PropertyService implements ManagePropertyUseCase {
     @Override
     @CacheEvict(value = "properties", allEntries = true)
     public Property create(Property property) {
-        property.setId(UUID.randomUUID());
+        property.setId(UuidFactory.newId());
         if (property.getStatus() == null) {
             property.setStatus(PropertyStatus.ACTIVE);
         }

--- a/src/main/java/com/majordomo/domain/model/UuidFactory.java
+++ b/src/main/java/com/majordomo/domain/model/UuidFactory.java
@@ -1,0 +1,25 @@
+package com.majordomo.domain.model;
+
+import com.github.f4b6a3.uuid.UuidCreator;
+
+import java.util.UUID;
+
+/**
+ * Factory for generating UUIDv7 identifiers.
+ * All entity IDs should be created through this factory
+ * to ensure time-ordered, globally unique identifiers.
+ */
+public final class UuidFactory {
+
+    private UuidFactory() {
+    }
+
+    /**
+     * Generates a new UUIDv7 identifier.
+     *
+     * @return a time-ordered UUID
+     */
+    public static UUID newId() {
+        return UuidCreator.getTimeOrderedEpoch();
+    }
+}

--- a/src/test/java/com/majordomo/domain/model/UuidFactoryTest.java
+++ b/src/test/java/com/majordomo/domain/model/UuidFactoryTest.java
@@ -1,0 +1,46 @@
+package com.majordomo.domain.model;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for {@link UuidFactory}.
+ */
+class UuidFactoryTest {
+
+    /** Generated IDs should not be null. */
+    @Test
+    void newIdReturnsNonNull() {
+        UUID id = UuidFactory.newId();
+        assertNotNull(id);
+    }
+
+    /** Generated IDs should be unique. */
+    @Test
+    void newIdReturnsUniqueValues() {
+        UUID id1 = UuidFactory.newId();
+        UUID id2 = UuidFactory.newId();
+        assertNotEquals(id1, id2);
+    }
+
+    /** Generated IDs should be version 7 (time-ordered). */
+    @Test
+    void newIdReturnsVersion7() {
+        UUID id = UuidFactory.newId();
+        assertEquals(7, id.version());
+    }
+
+    /** Sequential IDs should be monotonically increasing. */
+    @Test
+    void newIdIsMonotonicallyIncreasing() {
+        UUID id1 = UuidFactory.newId();
+        UUID id2 = UuidFactory.newId();
+        assertTrue(id1.compareTo(id2) < 0, "Sequential UUIDv7 should be ordered");
+    }
+}


### PR DESCRIPTION
## Summary
- Added `uuid-creator` 6.0.0 dependency for RFC 9562 UUIDv7 generation
- Created `UuidFactory.newId()` domain-layer factory producing time-ordered UUIDv7 identifiers
- Replaced all 14 `UUID.randomUUID()` calls across 7 production files with `UuidFactory.newId()`
- Added ADR 0018 documenting the decision for UUIDv7 entity identifiers
- Unit tests verify non-null, uniqueness, version 7, and monotonic ordering

## Test plan
- [ ] `./mvnw validate` passes Checkstyle (verified: 0 violations)
- [ ] `UuidFactoryTest` passes all 4 assertions (non-null, unique, version 7, monotonic)
- [ ] `./mvnw test` passes all existing tests (no behavioral change — IDs are still UUIDs)
- [ ] Grep confirms zero `UUID.randomUUID()` in `src/main/java/`

Closes #84, closes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)