### PR TITLE
Add property warranty expiration alerts

### DIFF
--- a/src/main/java/com/majordomo/adapter/out/persistence/steward/JpaPropertyRepository.java
+++ b/src/main/java/com/majordomo/adapter/out/persistence/steward/JpaPropertyRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.UUID;
 
@@ -87,4 +88,16 @@ public interface JpaPropertyRepository extends JpaRepository<PropertyEntity, UUI
             @Param("orgId") UUID orgId, @Param("q") String query,
             @Param("category") String category, @Param("status") PropertyStatus status,
             @Param("cursor") UUID cursor, Pageable pageable);
+
+    /**
+     * Returns all properties whose warranty expires before the given date
+     * and whose warranty notification has not yet been sent.
+     *
+     * @param date the upper bound date for warranty expiration
+     * @return list of matching property entities
+     */
+    @Query("SELECT p FROM PropertyEntity p WHERE p.warrantyExpiresOn IS NOT NULL "
+            + "AND p.warrantyExpiresOn < :date "
+            + "AND p.warrantyNotificationSentAt IS NULL")
+    List<PropertyEntity> findWithWarrantyExpiringBefore(@Param("date") LocalDate date);
 }

--- a/src/main/java/com/majordomo/adapter/out/persistence/steward/PropertyEntity.java
+++ b/src/main/java/com/majordomo/adapter/out/persistence/steward/PropertyEntity.java
@@ -64,6 +64,9 @@ public class PropertyEntity {
     @Column(name = "purchase_price")
     private BigDecimal purchasePrice;
 
+    @Column(name = "warranty_notification_sent_at")
+    private Instant warrantyNotificationSentAt;
+
     public UUID getId() { return id; }
     public void setId(UUID id) { this.id = id; }
 
@@ -117,4 +120,12 @@ public class PropertyEntity {
 
     /** Sets the purchase price. */
     public void setPurchasePrice(BigDecimal purchasePrice) { this.purchasePrice = purchasePrice; }
+
+    /** Returns the warranty notification sent timestamp. */
+    public Instant getWarrantyNotificationSentAt() { return warrantyNotificationSentAt; }
+
+    /** Sets the warranty notification sent timestamp. */
+    public void setWarrantyNotificationSentAt(Instant warrantyNotificationSentAt) {
+        this.warrantyNotificationSentAt = warrantyNotificationSentAt;
+    }
 }

--- a/src/main/java/com/majordomo/adapter/out/persistence/steward/PropertyMapper.java
+++ b/src/main/java/com/majordomo/adapter/out/persistence/steward/PropertyMapper.java
@@ -25,6 +25,7 @@ final class PropertyMapper {
         entity.setUpdatedAt(property.getUpdatedAt());
         entity.setArchivedAt(property.getArchivedAt());
         entity.setPurchasePrice(property.getPurchasePrice());
+        entity.setWarrantyNotificationSentAt(property.getWarrantyNotificationSentAt());
         return entity;
     }
 
@@ -47,6 +48,7 @@ final class PropertyMapper {
         property.setUpdatedAt(entity.getUpdatedAt());
         property.setArchivedAt(entity.getArchivedAt());
         property.setPurchasePrice(entity.getPurchasePrice());
+        property.setWarrantyNotificationSentAt(entity.getWarrantyNotificationSentAt());
         return property;
     }
 }

--- a/src/main/java/com/majordomo/adapter/out/persistence/steward/PropertyRepositoryAdapter.java
+++ b/src/main/java/com/majordomo/adapter/out/persistence/steward/PropertyRepositoryAdapter.java
@@ -7,6 +7,7 @@ import com.majordomo.domain.port.out.steward.PropertyRepository;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -55,6 +56,11 @@ public class PropertyRepositoryAdapter implements PropertyRepository {
     @Override
     public List<Property> findByParentId(UUID parentId) {
         return jpa.findByParentId(parentId).stream().map(PropertyMapper::toDomain).toList();
+    }
+
+    @Override
+    public List<Property> findWithWarrantyExpiringBefore(LocalDate date) {
+        return jpa.findWithWarrantyExpiringBefore(date).stream().map(PropertyMapper::toDomain).toList();
     }
 
     @Override

--- a/src/main/java/com/majordomo/application/steward/WarrantyAlertService.java
+++ b/src/main/java/com/majordomo/application/steward/WarrantyAlertService.java
@@ -1,0 +1,83 @@
+package com.majordomo.application.steward;
+
+import com.majordomo.domain.model.identity.MemberRole;
+import com.majordomo.domain.port.out.herald.NotificationPort;
+import com.majordomo.domain.port.out.identity.MembershipRepository;
+import com.majordomo.domain.port.out.identity.UserRepository;
+import com.majordomo.domain.port.out.steward.PropertyRepository;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import java.time.Instant;
+import java.time.LocalDate;
+
+/**
+ * Scheduled service that checks for properties with warranties expiring within
+ * 30 days and sends email notifications to organization admins and owners.
+ */
+@Service
+public class WarrantyAlertService {
+
+    private static final Logger LOG = LoggerFactory.getLogger(WarrantyAlertService.class);
+
+    private final PropertyRepository propertyRepository;
+    private final MembershipRepository membershipRepository;
+    private final UserRepository userRepository;
+    private final NotificationPort notificationPort;
+
+    /**
+     * Constructs the warranty alert service with required dependencies.
+     *
+     * @param propertyRepository   repository for properties
+     * @param membershipRepository repository for organization memberships
+     * @param userRepository       repository for users
+     * @param notificationPort     outbound port for sending notifications
+     */
+    public WarrantyAlertService(PropertyRepository propertyRepository,
+                                MembershipRepository membershipRepository,
+                                UserRepository userRepository,
+                                NotificationPort notificationPort) {
+        this.propertyRepository = propertyRepository;
+        this.membershipRepository = membershipRepository;
+        this.userRepository = userRepository;
+        this.notificationPort = notificationPort;
+    }
+
+    /**
+     * Runs on a configurable schedule to check for warranties expiring within 30 days.
+     * Sends email notifications to organization admins and owners, then marks
+     * each property so it is not notified again.
+     */
+    @Scheduled(cron = "${majordomo.notifications.warranty-cron:0 0 9 * * *}")
+    public void checkAndNotify() {
+        var expiringProperties = propertyRepository.findWithWarrantyExpiringBefore(
+                LocalDate.now().plusDays(30));
+        for (var property : expiringProperties) {
+            if (property.getWarrantyNotificationSentAt() != null) {
+                continue;
+            }
+
+            var memberships = membershipRepository.findByOrganizationId(
+                    property.getOrganizationId());
+            for (var membership : memberships) {
+                if (membership.getRole() == MemberRole.MEMBER) {
+                    continue;
+                }
+                var user = userRepository.findById(membership.getUserId());
+                user.ifPresent(u -> notificationPort.send(
+                        u.getEmail(),
+                        "Warranty expiring soon: " + property.getName(),
+                        "The warranty for " + property.getName()
+                                + " expires on " + property.getWarrantyExpiresOn()
+                                + ". Please take action if renewal or replacement is needed."));
+            }
+
+            property.setWarrantyNotificationSentAt(Instant.now());
+            propertyRepository.save(property);
+        }
+        LOG.info("Warranty alert check complete");
+    }
+}

--- a/src/main/java/com/majordomo/domain/model/steward/Property.java
+++ b/src/main/java/com/majordomo/domain/model/steward/Property.java
@@ -32,6 +32,7 @@ public class Property {
     private Instant updatedAt;
     private Instant archivedAt;
     private BigDecimal purchasePrice;
+    private Instant warrantyNotificationSentAt;
 
     public Property() {}
 
@@ -88,4 +89,12 @@ public class Property {
 
     /** Sets the purchase price of the property. */
     public void setPurchasePrice(BigDecimal purchasePrice) { this.purchasePrice = purchasePrice; }
+
+    /** Returns the timestamp when the warranty expiration notification was sent, or null if not yet sent. */
+    public Instant getWarrantyNotificationSentAt() { return warrantyNotificationSentAt; }
+
+    /** Sets the timestamp when the warranty expiration notification was sent. */
+    public void setWarrantyNotificationSentAt(Instant warrantyNotificationSentAt) {
+        this.warrantyNotificationSentAt = warrantyNotificationSentAt;
+    }
 }

--- a/src/main/java/com/majordomo/domain/port/out/steward/PropertyRepository.java
+++ b/src/main/java/com/majordomo/domain/port/out/steward/PropertyRepository.java
@@ -2,6 +2,7 @@ package com.majordomo.domain.port.out.steward;
 
 import com.majordomo.domain.model.steward.Property;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -71,4 +72,13 @@ public interface PropertyRepository {
      */
     List<Property> search(UUID organizationId, String query, String category,
                           String status, UUID cursor, int limit);
+
+    /**
+     * Returns all properties whose warranty expires before the given date
+     * and whose warranty notification has not yet been sent.
+     *
+     * @param date properties with {@code warrantyExpiresOn} before this date are returned
+     * @return list of matching properties, or an empty list if none exist
+     */
+    List<Property> findWithWarrantyExpiringBefore(LocalDate date);
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -91,6 +91,7 @@ majordomo:
     allowed-types: image/jpeg,image/png,application/pdf,text/plain
   notifications:
     cron: "0 0 8 * * *"
+    warranty-cron: "0 0 9 * * *"
 
 springdoc:
   api-docs:

--- a/src/main/resources/db/migration/V9__add_warranty_notification.sql
+++ b/src/main/resources/db/migration/V9__add_warranty_notification.sql
@@ -1,0 +1,1 @@
+ALTER TABLE properties ADD COLUMN warranty_notification_sent_at TIMESTAMPTZ;

--- a/src/test/java/com/majordomo/application/steward/WarrantyAlertServiceTest.java
+++ b/src/test/java/com/majordomo/application/steward/WarrantyAlertServiceTest.java
@@ -1,0 +1,115 @@
+package com.majordomo.application.steward;
+
+import com.majordomo.domain.model.identity.MemberRole;
+import com.majordomo.domain.model.identity.Membership;
+import com.majordomo.domain.model.identity.User;
+import com.majordomo.domain.model.steward.Property;
+import com.majordomo.domain.port.out.herald.NotificationPort;
+import com.majordomo.domain.port.out.identity.MembershipRepository;
+import com.majordomo.domain.port.out.identity.UserRepository;
+import com.majordomo.domain.port.out.steward.PropertyRepository;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class WarrantyAlertServiceTest {
+
+    @Mock
+    private PropertyRepository propertyRepository;
+
+    @Mock
+    private MembershipRepository membershipRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private NotificationPort notificationPort;
+
+    private WarrantyAlertService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new WarrantyAlertService(
+                propertyRepository, membershipRepository, userRepository, notificationPort);
+    }
+
+    @Test
+    void checkAndNotifyDueWarrantySendsAlert() {
+        var propertyId = UUID.randomUUID();
+        var orgId = UUID.randomUUID();
+        var userId = UUID.randomUUID();
+
+        var property = new Property();
+        property.setId(propertyId);
+        property.setOrganizationId(orgId);
+        property.setName("HVAC Unit");
+        property.setWarrantyExpiresOn(LocalDate.now().plusDays(15));
+
+        var membership = new Membership(UUID.randomUUID(), userId, orgId, MemberRole.ADMIN);
+        var user = new User(userId, "admin", "admin@example.com");
+
+        when(propertyRepository.findWithWarrantyExpiringBefore(any(LocalDate.class)))
+                .thenReturn(List.of(property));
+        when(membershipRepository.findByOrganizationId(orgId))
+                .thenReturn(List.of(membership));
+        when(userRepository.findById(userId))
+                .thenReturn(Optional.of(user));
+        when(propertyRepository.save(any(Property.class)))
+                .thenReturn(property);
+
+        service.checkAndNotify();
+
+        verify(notificationPort).send(
+                eq("admin@example.com"),
+                eq("Warranty expiring soon: HVAC Unit"),
+                anyString());
+        verify(propertyRepository).save(property);
+    }
+
+    @Test
+    void checkAndNotifyAlreadyNotifiedSkips() {
+        var property = new Property();
+        property.setId(UUID.randomUUID());
+        property.setOrganizationId(UUID.randomUUID());
+        property.setName("Old Boiler");
+        property.setWarrantyExpiresOn(LocalDate.now().plusDays(5));
+        property.setWarrantyNotificationSentAt(Instant.now());
+
+        when(propertyRepository.findWithWarrantyExpiringBefore(any(LocalDate.class)))
+                .thenReturn(List.of(property));
+
+        service.checkAndNotify();
+
+        verify(notificationPort, never()).send(anyString(), anyString(), anyString());
+        verify(propertyRepository, never()).save(any());
+    }
+
+    @Test
+    void checkAndNotifyNoExpiringWarrantiesDoesNothing() {
+        when(propertyRepository.findWithWarrantyExpiringBefore(any(LocalDate.class)))
+                .thenReturn(List.of());
+
+        service.checkAndNotify();
+
+        verify(notificationPort, never()).send(anyString(), anyString(), anyString());
+        verify(propertyRepository, never()).save(any());
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `warrantyNotificationSentAt` field to `Property` domain model, `PropertyEntity`, and `PropertyMapper`
- Flyway migration `V9__add_warranty_notification.sql` adds `warranty_notification_sent_at TIMESTAMPTZ` column to `properties`
- New `findWithWarrantyExpiringBefore(LocalDate)` method on `PropertyRepository` port, `JpaPropertyRepository` (JPQL query), and `PropertyRepositoryAdapter`
- `WarrantyAlertService` (@Service) runs daily at 09:00 via `@Scheduled(cron = "${majordomo.notifications.warranty-cron:0 0 9 * * *}")`, finds properties with warranty expiring within 30 days, notifies org admins/owners via `NotificationPort`, and stamps `warrantyNotificationSentAt` to prevent duplicate alerts
- `application.yml` updated with `majordomo.notifications.warranty-cron: "0 0 9 * * *"`

## Test plan

- [ ] `WarrantyAlertServiceTest#checkAndNotifyDueWarrantySendsAlert` — property with expiring warranty triggers notification and stamps sent-at
- [ ] `WarrantyAlertServiceTest#checkAndNotifyAlreadyNotifiedSkips` — property with `warrantyNotificationSentAt` already set is skipped
- [ ] `WarrantyAlertServiceTest#checkAndNotifyNoExpiringWarrantiesDoesNothing` — empty result list produces no notifications or saves

Closes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)