### PR TITLE
Add recurring cost tracking on maintenance schedules

### DIFF
--- a/src/main/java/com/majordomo/adapter/in/web/ledger/LedgerController.java
+++ b/src/main/java/com/majordomo/adapter/in/web/ledger/LedgerController.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.math.BigDecimal;
 import java.util.UUID;
 
 /**
@@ -68,5 +69,17 @@ public class LedgerController {
             @PathVariable UUID organizationId) {
         organizationAccessService.verifyAccess(organizationId);
         return querySpendUseCase.spendForOrganization(organizationId);
+    }
+
+    /**
+     * Returns the projected annual maintenance spend for an organization.
+     *
+     * @param organizationId the organization UUID
+     * @return projected annual cost based on schedule frequencies and estimated costs
+     */
+    @GetMapping("/organizations/{organizationId}/projected-annual")
+    public BigDecimal projectedAnnualSpend(@PathVariable UUID organizationId) {
+        organizationAccessService.verifyAccess(organizationId);
+        return querySpendUseCase.projectedAnnualSpend(organizationId);
     }
 }

--- a/src/main/java/com/majordomo/adapter/out/persistence/herald/MaintenanceScheduleEntity.java
+++ b/src/main/java/com/majordomo/adapter/out/persistence/herald/MaintenanceScheduleEntity.java
@@ -9,6 +9,7 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 
+import java.math.BigDecimal;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.util.UUID;
@@ -51,6 +52,9 @@ public class MaintenanceScheduleEntity {
     @Column(name = "notification_sent_at")
     private Instant notificationSentAt;
 
+    @Column(name = "estimated_cost", precision = 12, scale = 2)
+    private BigDecimal estimatedCost;
+
     public UUID getId() { return id; }
     public void setId(UUID id) { this.id = id; }
 
@@ -83,4 +87,7 @@ public class MaintenanceScheduleEntity {
 
     public Instant getNotificationSentAt() { return notificationSentAt; }
     public void setNotificationSentAt(Instant notificationSentAt) { this.notificationSentAt = notificationSentAt; }
+
+    public BigDecimal getEstimatedCost() { return estimatedCost; }
+    public void setEstimatedCost(BigDecimal estimatedCost) { this.estimatedCost = estimatedCost; }
 }

--- a/src/main/java/com/majordomo/adapter/out/persistence/herald/MaintenanceScheduleMapper.java
+++ b/src/main/java/com/majordomo/adapter/out/persistence/herald/MaintenanceScheduleMapper.java
@@ -19,6 +19,7 @@ final class MaintenanceScheduleMapper {
         entity.setUpdatedAt(schedule.getUpdatedAt());
         entity.setArchivedAt(schedule.getArchivedAt());
         entity.setNotificationSentAt(schedule.getNotificationSentAt());
+        entity.setEstimatedCost(schedule.getEstimatedCost());
         return entity;
     }
 
@@ -35,6 +36,7 @@ final class MaintenanceScheduleMapper {
         schedule.setUpdatedAt(entity.getUpdatedAt());
         schedule.setArchivedAt(entity.getArchivedAt());
         schedule.setNotificationSentAt(entity.getNotificationSentAt());
+        schedule.setEstimatedCost(entity.getEstimatedCost());
         return schedule;
     }
 }

--- a/src/main/java/com/majordomo/application/ledger/LedgerService.java
+++ b/src/main/java/com/majordomo/application/ledger/LedgerService.java
@@ -1,7 +1,10 @@
 package com.majordomo.application.ledger;
 
+import com.majordomo.domain.model.herald.Frequency;
+import com.majordomo.domain.model.herald.MaintenanceSchedule;
 import com.majordomo.domain.model.ledger.SpendSummary;
 import com.majordomo.domain.port.in.ledger.QuerySpendUseCase;
+import com.majordomo.domain.port.out.herald.MaintenanceScheduleRepository;
 import com.majordomo.domain.port.out.ledger.LedgerQueryRepository;
 import com.majordomo.domain.port.out.steward.PropertyRepository;
 
@@ -18,19 +21,25 @@ import java.util.UUID;
 @Service
 public class LedgerService implements QuerySpendUseCase {
 
+    private static final int DAYS_IN_YEAR = 365;
+
     private final PropertyRepository propertyRepository;
     private final LedgerQueryRepository ledgerQueryRepository;
+    private final MaintenanceScheduleRepository maintenanceScheduleRepository;
 
     /**
      * Constructs the service with required repositories.
      *
-     * @param propertyRepository    port for loading property details
-     * @param ledgerQueryRepository port for aggregating maintenance costs
+     * @param propertyRepository            port for loading property details
+     * @param ledgerQueryRepository         port for aggregating maintenance costs
+     * @param maintenanceScheduleRepository port for loading maintenance schedules
      */
     public LedgerService(PropertyRepository propertyRepository,
-                          LedgerQueryRepository ledgerQueryRepository) {
+                          LedgerQueryRepository ledgerQueryRepository,
+                          MaintenanceScheduleRepository maintenanceScheduleRepository) {
         this.propertyRepository = propertyRepository;
         this.ledgerQueryRepository = ledgerQueryRepository;
+        this.maintenanceScheduleRepository = maintenanceScheduleRepository;
     }
 
     @Override
@@ -61,5 +70,49 @@ public class LedgerService implements QuerySpendUseCase {
                         organizationId);
         return new SpendSummary(purchasePrice, maintenanceCost,
                 purchasePrice.add(maintenanceCost));
+    }
+
+    @Override
+    public BigDecimal projectedAnnualSpend(UUID organizationId) {
+        return propertyRepository.findByOrganizationId(organizationId).stream()
+                .flatMap(p -> maintenanceScheduleRepository
+                        .findByPropertyId(p.getId()).stream())
+                .filter(s -> s.getEstimatedCost() != null)
+                .map(this::annualCostForSchedule)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+    }
+
+    /**
+     * Computes the annual projected cost for a single maintenance schedule.
+     *
+     * @param schedule the maintenance schedule with a non-null estimated cost
+     * @return the estimated cost multiplied by the number of occurrences per year
+     */
+    private BigDecimal annualCostForSchedule(MaintenanceSchedule schedule) {
+        int occurrences = occurrencesPerYear(schedule);
+        return schedule.getEstimatedCost()
+                .multiply(BigDecimal.valueOf(occurrences));
+    }
+
+    /**
+     * Returns the number of occurrences per year for the given schedule's frequency.
+     *
+     * @param schedule the maintenance schedule
+     * @return occurrences per year (rounded up for CUSTOM frequency)
+     */
+    private int occurrencesPerYear(MaintenanceSchedule schedule) {
+        if (schedule.getFrequency() == Frequency.CUSTOM) {
+            int intervalDays = schedule.getCustomIntervalDays() != null
+                    ? schedule.getCustomIntervalDays() : 1;
+            return (int) Math.ceil((double) DAYS_IN_YEAR / intervalDays);
+        }
+        return switch (schedule.getFrequency()) {
+            case WEEKLY -> 52;
+            case MONTHLY -> 12;
+            case QUARTERLY -> 4;
+            case SEMI_ANNUAL -> 2;
+            case ANNUAL -> 1;
+            default -> 1;
+        };
     }
 }

--- a/src/main/java/com/majordomo/domain/model/herald/MaintenanceSchedule.java
+++ b/src/main/java/com/majordomo/domain/model/herald/MaintenanceSchedule.java
@@ -3,6 +3,7 @@ package com.majordomo.domain.model.herald;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
+import java.math.BigDecimal;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.util.UUID;
@@ -27,6 +28,7 @@ public class MaintenanceSchedule {
     private Instant updatedAt;
     private Instant archivedAt;
     private Instant notificationSentAt;
+    private BigDecimal estimatedCost;
 
     public MaintenanceSchedule() {}
 
@@ -62,4 +64,7 @@ public class MaintenanceSchedule {
 
     public Instant getNotificationSentAt() { return notificationSentAt; }
     public void setNotificationSentAt(Instant notificationSentAt) { this.notificationSentAt = notificationSentAt; }
+
+    public BigDecimal getEstimatedCost() { return estimatedCost; }
+    public void setEstimatedCost(BigDecimal estimatedCost) { this.estimatedCost = estimatedCost; }
 }

--- a/src/main/java/com/majordomo/domain/port/in/ledger/QuerySpendUseCase.java
+++ b/src/main/java/com/majordomo/domain/port/in/ledger/QuerySpendUseCase.java
@@ -2,6 +2,7 @@ package com.majordomo.domain.port.in.ledger;
 
 import com.majordomo.domain.model.ledger.SpendSummary;
 
+import java.math.BigDecimal;
 import java.util.UUID;
 
 /**
@@ -24,4 +25,12 @@ public interface QuerySpendUseCase {
      * @return the aggregated spend summary
      */
     SpendSummary spendForOrganization(UUID organizationId);
+
+    /**
+     * Returns projected annual maintenance spend for an organization.
+     *
+     * @param organizationId the organization ID
+     * @return projected annual cost based on schedule frequencies and estimated costs
+     */
+    BigDecimal projectedAnnualSpend(UUID organizationId);
 }

--- a/src/main/resources/db/migration/V11__add_estimated_cost.sql
+++ b/src/main/resources/db/migration/V11__add_estimated_cost.sql
@@ -1,0 +1,1 @@
+ALTER TABLE maintenance_schedules ADD COLUMN estimated_cost NUMERIC(12, 2);

--- a/src/test/java/com/majordomo/application/ledger/LedgerServiceTest.java
+++ b/src/test/java/com/majordomo/application/ledger/LedgerServiceTest.java
@@ -2,6 +2,7 @@ package com.majordomo.application.ledger;
 
 import com.majordomo.domain.model.ledger.SpendSummary;
 import com.majordomo.domain.model.steward.Property;
+import com.majordomo.domain.port.out.herald.MaintenanceScheduleRepository;
 import com.majordomo.domain.port.out.ledger.LedgerQueryRepository;
 import com.majordomo.domain.port.out.steward.PropertyRepository;
 
@@ -32,13 +33,16 @@ class LedgerServiceTest {
     @Mock
     private LedgerQueryRepository ledgerQueryRepository;
 
+    @Mock
+    private MaintenanceScheduleRepository maintenanceScheduleRepository;
+
     private LedgerService ledgerService;
 
     /** Sets up the service under test with mocked dependencies. */
     @BeforeEach
     void setUp() {
         ledgerService = new LedgerService(propertyRepository,
-                ledgerQueryRepository);
+                ledgerQueryRepository, maintenanceScheduleRepository);
     }
 
     /** Verifies that spendForProperty returns the correct summary. */

--- a/src/test/java/com/majordomo/application/ledger/ProjectedAnnualSpendTest.java
+++ b/src/test/java/com/majordomo/application/ledger/ProjectedAnnualSpendTest.java
@@ -1,0 +1,214 @@
+package com.majordomo.application.ledger;
+
+import com.majordomo.domain.model.herald.Frequency;
+import com.majordomo.domain.model.herald.MaintenanceSchedule;
+import com.majordomo.domain.model.steward.Property;
+import com.majordomo.domain.port.out.herald.MaintenanceScheduleRepository;
+import com.majordomo.domain.port.out.ledger.LedgerQueryRepository;
+import com.majordomo.domain.port.out.steward.PropertyRepository;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link LedgerService#projectedAnnualSpend(UUID)}, covering all
+ * standard frequencies and the CUSTOM interval calculation.
+ */
+@ExtendWith(MockitoExtension.class)
+class ProjectedAnnualSpendTest {
+
+    @Mock
+    private PropertyRepository propertyRepository;
+
+    @Mock
+    private LedgerQueryRepository ledgerQueryRepository;
+
+    @Mock
+    private MaintenanceScheduleRepository maintenanceScheduleRepository;
+
+    private LedgerService ledgerService;
+
+    private UUID orgId;
+    private UUID propertyId;
+    private Property property;
+
+    /** Sets up the service and shared fixtures before each test. */
+    @BeforeEach
+    void setUp() {
+        ledgerService = new LedgerService(propertyRepository,
+                ledgerQueryRepository, maintenanceScheduleRepository);
+        orgId = UUID.randomUUID();
+        propertyId = UUID.randomUUID();
+        property = new Property();
+        property.setId(propertyId);
+    }
+
+    /** Weekly schedule: cost * 52. */
+    @Test
+    void weeklyFrequencyMultipliesBy52() {
+        MaintenanceSchedule schedule = schedule(Frequency.WEEKLY, null,
+                new BigDecimal("10.00"));
+        stubOrgWithSchedules(List.of(schedule));
+
+        BigDecimal result = ledgerService.projectedAnnualSpend(orgId);
+
+        assertEquals(new BigDecimal("520.00"), result);
+    }
+
+    /** Monthly schedule: cost * 12. */
+    @Test
+    void monthlyFrequencyMultipliesBy12() {
+        MaintenanceSchedule schedule = schedule(Frequency.MONTHLY, null,
+                new BigDecimal("50.00"));
+        stubOrgWithSchedules(List.of(schedule));
+
+        BigDecimal result = ledgerService.projectedAnnualSpend(orgId);
+
+        assertEquals(new BigDecimal("600.00"), result);
+    }
+
+    /** Quarterly schedule: cost * 4. */
+    @Test
+    void quarterlyFrequencyMultipliesBy4() {
+        MaintenanceSchedule schedule = schedule(Frequency.QUARTERLY, null,
+                new BigDecimal("100.00"));
+        stubOrgWithSchedules(List.of(schedule));
+
+        BigDecimal result = ledgerService.projectedAnnualSpend(orgId);
+
+        assertEquals(new BigDecimal("400.00"), result);
+    }
+
+    /** Semi-annual schedule: cost * 2. */
+    @Test
+    void semiAnnualFrequencyMultipliesBy2() {
+        MaintenanceSchedule schedule = schedule(Frequency.SEMI_ANNUAL, null,
+                new BigDecimal("200.00"));
+        stubOrgWithSchedules(List.of(schedule));
+
+        BigDecimal result = ledgerService.projectedAnnualSpend(orgId);
+
+        assertEquals(new BigDecimal("400.00"), result);
+    }
+
+    /** Annual schedule: cost * 1. */
+    @Test
+    void annualFrequencyMultipliesBy1() {
+        MaintenanceSchedule schedule = schedule(Frequency.ANNUAL, null,
+                new BigDecimal("1000.00"));
+        stubOrgWithSchedules(List.of(schedule));
+
+        BigDecimal result = ledgerService.projectedAnnualSpend(orgId);
+
+        assertEquals(new BigDecimal("1000.00"), result);
+    }
+
+    /** Custom 30-day interval: ceil(365/30) = 13 occurrences. */
+    @Test
+    void customIntervalRoundsUpOccurrences() {
+        MaintenanceSchedule schedule = schedule(Frequency.CUSTOM, 30,
+                new BigDecimal("10.00"));
+        stubOrgWithSchedules(List.of(schedule));
+
+        BigDecimal result = ledgerService.projectedAnnualSpend(orgId);
+
+        // ceil(365 / 30) = 13
+        assertEquals(new BigDecimal("130.00"), result);
+    }
+
+    /** Custom 365-day interval: exactly 1 occurrence per year. */
+    @Test
+    void customInterval365DaysGivesOneOccurrence() {
+        MaintenanceSchedule schedule = schedule(Frequency.CUSTOM, 365,
+                new BigDecimal("500.00"));
+        stubOrgWithSchedules(List.of(schedule));
+
+        BigDecimal result = ledgerService.projectedAnnualSpend(orgId);
+
+        assertEquals(new BigDecimal("500.00"), result);
+    }
+
+    /** Custom 7-day interval: exactly 52 occurrences per year (ceil(365/7)=53). */
+    @Test
+    void customInterval7DaysCeilsCorrectly() {
+        MaintenanceSchedule schedule = schedule(Frequency.CUSTOM, 7,
+                new BigDecimal("10.00"));
+        stubOrgWithSchedules(List.of(schedule));
+
+        // ceil(365 / 7) = ceil(52.14...) = 53
+        BigDecimal result = ledgerService.projectedAnnualSpend(orgId);
+
+        assertEquals(new BigDecimal("530.00"), result);
+    }
+
+    /** Schedules with null estimatedCost are excluded from the total. */
+    @Test
+    void schedulesWithNullEstimatedCostAreIgnored() {
+        MaintenanceSchedule withCost = schedule(Frequency.ANNUAL, null,
+                new BigDecimal("100.00"));
+        MaintenanceSchedule withoutCost = schedule(Frequency.MONTHLY, null, null);
+        stubOrgWithSchedules(List.of(withCost, withoutCost));
+
+        BigDecimal result = ledgerService.projectedAnnualSpend(orgId);
+
+        assertEquals(new BigDecimal("100.00"), result);
+    }
+
+    /** Multiple schedules across a single property are summed correctly. */
+    @Test
+    void multipleSchedulesAreSummed() {
+        MaintenanceSchedule weekly = schedule(Frequency.WEEKLY, null,
+                new BigDecimal("5.00"));
+        MaintenanceSchedule annual = schedule(Frequency.ANNUAL, null,
+                new BigDecimal("100.00"));
+        stubOrgWithSchedules(List.of(weekly, annual));
+
+        // 5 * 52 + 100 * 1 = 260 + 100 = 360
+        BigDecimal result = ledgerService.projectedAnnualSpend(orgId);
+
+        assertEquals(new BigDecimal("360.00"), result);
+    }
+
+    /** Returns zero when the organization has no properties. */
+    @Test
+    void returnsZeroWhenNoProperties() {
+        when(propertyRepository.findByOrganizationId(orgId))
+                .thenReturn(List.of());
+
+        BigDecimal result = ledgerService.projectedAnnualSpend(orgId);
+
+        assertEquals(BigDecimal.ZERO, result);
+    }
+
+    private MaintenanceSchedule schedule(Frequency frequency,
+                                         Integer customIntervalDays,
+                                         BigDecimal estimatedCost) {
+        var s = new MaintenanceSchedule();
+        s.setId(UUID.randomUUID());
+        s.setPropertyId(propertyId);
+        s.setDescription("Test schedule");
+        s.setFrequency(frequency);
+        s.setCustomIntervalDays(customIntervalDays);
+        s.setNextDue(LocalDate.now().plusDays(30));
+        s.setEstimatedCost(estimatedCost);
+        return s;
+    }
+
+    private void stubOrgWithSchedules(List<MaintenanceSchedule> schedules) {
+        when(propertyRepository.findByOrganizationId(orgId))
+                .thenReturn(List.of(property));
+        when(maintenanceScheduleRepository.findByPropertyId(propertyId))
+                .thenReturn(schedules);
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `estimated_cost` column to `maintenance_schedules` via Flyway migration V11
- Extends `MaintenanceSchedule` domain model, JPA entity, and mapper with `estimatedCost` (BigDecimal)
- Adds `projectedAnnualSpend(UUID organizationId)` to `QuerySpendUseCase` inbound port
- Implements projection in `LedgerService`: for each org property, sums `estimatedCost × occurrences-per-year` across all schedules (WEEKLY=52, MONTHLY=12, QUARTERLY=4, SEMI_ANNUAL=2, ANNUAL=1, CUSTOM=ceil(365/intervalDays)); schedules with null cost are skipped
- Exposes `GET /api/ledger/organizations/{organizationId}/projected-annual` in `LedgerController`
- 10 unit tests in `ProjectedAnnualSpendTest` cover all frequencies, CUSTOM rounding, null-cost exclusion, multi-schedule summation, and empty-org zero return
- `./mvnw validate` passes with 0 Checkstyle violations

Closes #75

## Test plan

- [ ] `./mvnw test -Dtest=ProjectedAnnualSpendTest` — all 10 tests green
- [ ] `./mvnw test -Dtest=LedgerServiceTest` — existing tests still green (constructor updated)
- [ ] `./mvnw validate` — 0 Checkstyle violations
- [ ] Smoke test `GET /api/ledger/organizations/{id}/projected-annual` returns a numeric value

🤖 Generated with [Claude Code](https://claude.com/claude-code)