### PR TITLE
Add bulk CSV import for properties

### DIFF
--- a/src/main/java/com/majordomo/adapter/in/web/steward/ImportResult.java
+++ b/src/main/java/com/majordomo/adapter/in/web/steward/ImportResult.java
@@ -1,0 +1,26 @@
+package com.majordomo.adapter.in.web.steward;
+
+import java.util.List;
+
+/**
+ * Result of a bulk property import operation.
+ *
+ * @param total   total rows processed
+ * @param created number of properties created
+ * @param skipped number of rows skipped
+ * @param errors  list of row-level errors
+ */
+public record ImportResult(
+    int total,
+    int created,
+    int skipped,
+    List<ImportError> errors
+) {
+    /**
+     * A single row-level error encountered during import.
+     *
+     * @param row     the 1-based row number
+     * @param message the error description
+     */
+    public record ImportError(int row, String message) { }
+}

--- a/src/main/java/com/majordomo/adapter/in/web/steward/PropertyImportController.java
+++ b/src/main/java/com/majordomo/adapter/in/web/steward/PropertyImportController.java
@@ -1,0 +1,220 @@
+package com.majordomo.adapter.in.web.steward;
+
+import com.majordomo.application.identity.OrganizationAccessService;
+import com.majordomo.domain.model.steward.Property;
+import com.majordomo.domain.model.steward.PropertyStatus;
+import com.majordomo.domain.port.in.steward.ManagePropertyUseCase;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDate;
+import java.time.format.DateTimeParseException;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * REST controller for bulk CSV import of properties in the Steward domain.
+ *
+ * <p>Parses an uploaded CSV file and delegates property creation to
+ * {@link ManagePropertyUseCase#create(Property)}. CSV parsing is an adapter-layer
+ * concern, keeping the domain free of file-format knowledge.</p>
+ */
+@RestController
+@RequestMapping("/api/properties")
+@Tag(name = "Steward", description = "Property management")
+public class PropertyImportController {
+
+    private static final Logger LOG = LoggerFactory.getLogger(PropertyImportController.class);
+
+    private final ManagePropertyUseCase propertyUseCase;
+    private final OrganizationAccessService organizationAccessService;
+
+    /**
+     * Constructs the controller with required dependencies.
+     *
+     * @param propertyUseCase           the inbound port for property management
+     * @param organizationAccessService the service for verifying organization membership
+     */
+    public PropertyImportController(ManagePropertyUseCase propertyUseCase,
+                                    OrganizationAccessService organizationAccessService) {
+        this.propertyUseCase = propertyUseCase;
+        this.organizationAccessService = organizationAccessService;
+    }
+
+    /**
+     * Imports properties from a CSV file upload.
+     *
+     * <p>Expected CSV columns (header row required):
+     * {@code name,description,serialNumber,modelNumber,manufacturer,category,location,
+     * status,acquiredOn,warrantyExpiresOn,purchasePrice}. Only {@code name} is required;
+     * rows missing a name are skipped and reported as errors.</p>
+     *
+     * @param organizationId the target organization UUID
+     * @param file           the CSV file to import
+     * @return the import result with counts and per-row errors
+     * @throws IOException if the file cannot be read
+     */
+    @PostMapping(value = "/import", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<ImportResult> importCsv(
+            @RequestParam UUID organizationId,
+            @RequestParam("file") MultipartFile file) throws IOException {
+        organizationAccessService.verifyAccess(organizationId);
+
+        List<Map<String, String>> rows = parseCsv(file);
+        ImportResult result = processRows(organizationId, rows);
+        return ResponseEntity.ok(result);
+    }
+
+    /**
+     * Parses a CSV file into a list of field maps keyed by header column names.
+     *
+     * @param file the uploaded CSV file
+     * @return list of row maps (one per data row)
+     * @throws IOException if reading fails
+     */
+    List<Map<String, String>> parseCsv(MultipartFile file) throws IOException {
+        List<Map<String, String>> rows = new ArrayList<>();
+        try (BufferedReader reader = new BufferedReader(
+                new InputStreamReader(file.getInputStream(), StandardCharsets.UTF_8))) {
+
+            String headerLine = reader.readLine();
+            if (headerLine == null) {
+                return rows;
+            }
+            String[] headers = headerLine.split(",", -1);
+            for (int i = 0; i < headers.length; i++) {
+                headers[i] = headers[i].trim();
+            }
+
+            String line;
+            while ((line = reader.readLine()) != null) {
+                if (line.isBlank()) {
+                    continue;
+                }
+                String[] values = line.split(",", -1);
+                Map<String, String> row = new LinkedHashMap<>();
+                for (int i = 0; i < headers.length; i++) {
+                    String value = i < values.length ? values[i].trim() : "";
+                    row.put(headers[i], value);
+                }
+                rows.add(row);
+            }
+        }
+        return rows;
+    }
+
+    /**
+     * Processes parsed CSV rows, creating properties and collecting errors.
+     *
+     * @param organizationId the target organization
+     * @param rows           the parsed CSV rows
+     * @return the import result
+     */
+    ImportResult processRows(UUID organizationId, List<Map<String, String>> rows) {
+        int created = 0;
+        int skipped = 0;
+        List<ImportResult.ImportError> errors = new ArrayList<>();
+
+        for (int i = 0; i < rows.size(); i++) {
+            int rowNum = i + 1;
+            Map<String, String> row = rows.get(i);
+
+            String name = row.getOrDefault("name", "").trim();
+            if (name.isEmpty()) {
+                errors.add(new ImportResult.ImportError(rowNum, "Missing required field: name"));
+                skipped++;
+                continue;
+            }
+
+            try {
+                Property property = mapRowToProperty(organizationId, row);
+                propertyUseCase.create(property);
+                created++;
+            } catch (IllegalArgumentException e) {
+                errors.add(new ImportResult.ImportError(rowNum, e.getMessage()));
+                skipped++;
+            }
+        }
+
+        LOG.info("CSV import complete for org {}: total={}, created={}, skipped={}",
+                organizationId, rows.size(), created, skipped);
+
+        return new ImportResult(rows.size(), created, skipped, errors);
+    }
+
+    private Property mapRowToProperty(UUID organizationId, Map<String, String> row) {
+        Property property = new Property();
+        property.setOrganizationId(organizationId);
+        property.setName(row.getOrDefault("name", "").trim());
+        property.setDescription(blankToNull(row.get("description")));
+        property.setSerialNumber(blankToNull(row.get("serialNumber")));
+        property.setModelNumber(blankToNull(row.get("modelNumber")));
+        property.setManufacturer(blankToNull(row.get("manufacturer")));
+        property.setCategory(blankToNull(row.get("category")));
+        property.setLocation(blankToNull(row.get("location")));
+
+        String statusStr = blankToNull(row.get("status"));
+        if (statusStr != null) {
+            try {
+                property.setStatus(PropertyStatus.valueOf(statusStr.toUpperCase()));
+            } catch (IllegalArgumentException e) {
+                throw new IllegalArgumentException("Invalid status: " + statusStr);
+            }
+        }
+
+        String acquiredOn = blankToNull(row.get("acquiredOn"));
+        if (acquiredOn != null) {
+            try {
+                property.setAcquiredOn(LocalDate.parse(acquiredOn));
+            } catch (DateTimeParseException e) {
+                throw new IllegalArgumentException("Invalid acquiredOn date: " + acquiredOn);
+            }
+        }
+
+        String warrantyExpires = blankToNull(row.get("warrantyExpiresOn"));
+        if (warrantyExpires != null) {
+            try {
+                property.setWarrantyExpiresOn(LocalDate.parse(warrantyExpires));
+            } catch (DateTimeParseException e) {
+                throw new IllegalArgumentException(
+                        "Invalid warrantyExpiresOn date: " + warrantyExpires);
+            }
+        }
+
+        String priceStr = blankToNull(row.get("purchasePrice"));
+        if (priceStr != null) {
+            try {
+                property.setPurchasePrice(new BigDecimal(priceStr));
+            } catch (NumberFormatException e) {
+                throw new IllegalArgumentException("Invalid purchasePrice: " + priceStr);
+            }
+        }
+
+        return property;
+    }
+
+    private String blankToNull(String value) {
+        if (value == null || value.trim().isEmpty()) {
+            return null;
+        }
+        return value.trim();
+    }
+}

--- a/src/test/java/com/majordomo/adapter/in/web/steward/PropertyImportControllerTest.java
+++ b/src/test/java/com/majordomo/adapter/in/web/steward/PropertyImportControllerTest.java
@@ -1,0 +1,240 @@
+package com.majordomo.adapter.in.web.steward;
+
+import com.majordomo.application.identity.OrganizationAccessService;
+import com.majordomo.domain.model.steward.Property;
+import com.majordomo.domain.model.steward.PropertyStatus;
+import com.majordomo.domain.port.in.steward.ManagePropertyUseCase;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
+
+import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class PropertyImportControllerTest {
+
+    @Mock
+    private ManagePropertyUseCase propertyUseCase;
+
+    @Mock
+    private OrganizationAccessService organizationAccessService;
+
+    private PropertyImportController controller;
+
+    private static final UUID ORG_ID = UUID.randomUUID();
+
+    @BeforeEach
+    void setUp() {
+        controller = new PropertyImportController(propertyUseCase, organizationAccessService);
+    }
+
+    @Test
+    void parseCsvReturnsRowMaps() throws Exception {
+        String csv = "name,description,category\nDesk,A wooden desk,Furniture\nChair,,Furniture\n";
+        MockMultipartFile file = csvFile(csv);
+
+        List<Map<String, String>> rows = controller.parseCsv(file);
+
+        assertEquals(2, rows.size());
+        assertEquals("Desk", rows.get(0).get("name"));
+        assertEquals("A wooden desk", rows.get(0).get("description"));
+        assertEquals("Chair", rows.get(1).get("name"));
+        assertEquals("", rows.get(1).get("description"));
+    }
+
+    @Test
+    void parseCsvSkipsBlankLines() throws Exception {
+        String csv = "name\nDesk\n\nChair\n";
+        MockMultipartFile file = csvFile(csv);
+
+        List<Map<String, String>> rows = controller.parseCsv(file);
+
+        assertEquals(2, rows.size());
+    }
+
+    @Test
+    void parseCsvEmptyFileReturnsEmptyList() throws Exception {
+        MockMultipartFile file = csvFile("");
+
+        List<Map<String, String>> rows = controller.parseCsv(file);
+
+        assertEquals(0, rows.size());
+    }
+
+    @Test
+    void processRowsCreatesPropertyForValidRow() {
+        when(propertyUseCase.create(any(Property.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        List<Map<String, String>> rows = List.of(
+                Map.of("name", "Desk", "category", "Furniture")
+        );
+
+        ImportResult result = controller.processRows(ORG_ID, rows);
+
+        assertEquals(1, result.total());
+        assertEquals(1, result.created());
+        assertEquals(0, result.skipped());
+        assertEquals(0, result.errors().size());
+
+        ArgumentCaptor<Property> captor = ArgumentCaptor.forClass(Property.class);
+        verify(propertyUseCase).create(captor.capture());
+        assertEquals("Desk", captor.getValue().getName());
+        assertEquals("Furniture", captor.getValue().getCategory());
+        assertEquals(ORG_ID, captor.getValue().getOrganizationId());
+    }
+
+    @Test
+    void processRowsSkipsRowMissingName() {
+        List<Map<String, String>> rows = List.of(
+                Map.of("name", "", "category", "Furniture")
+        );
+
+        ImportResult result = controller.processRows(ORG_ID, rows);
+
+        assertEquals(1, result.total());
+        assertEquals(0, result.created());
+        assertEquals(1, result.skipped());
+        assertEquals(1, result.errors().size());
+        assertEquals(1, result.errors().get(0).row());
+        assertEquals("Missing required field: name", result.errors().get(0).message());
+        verify(propertyUseCase, never()).create(any());
+    }
+
+    @Test
+    void processRowsSetsStatusFromCsv() {
+        when(propertyUseCase.create(any(Property.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        List<Map<String, String>> rows = List.of(
+                Map.of("name", "Laptop", "status", "IN_SERVICE")
+        );
+
+        controller.processRows(ORG_ID, rows);
+
+        ArgumentCaptor<Property> captor = ArgumentCaptor.forClass(Property.class);
+        verify(propertyUseCase).create(captor.capture());
+        assertEquals(PropertyStatus.IN_SERVICE, captor.getValue().getStatus());
+    }
+
+    @Test
+    void processRowsReportsInvalidStatus() {
+        List<Map<String, String>> rows = List.of(
+                Map.of("name", "Laptop", "status", "BOGUS")
+        );
+
+        ImportResult result = controller.processRows(ORG_ID, rows);
+
+        assertEquals(1, result.skipped());
+        assertEquals("Invalid status: BOGUS", result.errors().get(0).message());
+    }
+
+    @Test
+    void processRowsParsesDatesAndPrice() {
+        when(propertyUseCase.create(any(Property.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        List<Map<String, String>> rows = List.of(
+                Map.of("name", "Laptop",
+                        "acquiredOn", "2025-06-15",
+                        "warrantyExpiresOn", "2027-06-15",
+                        "purchasePrice", "1299.99")
+        );
+
+        controller.processRows(ORG_ID, rows);
+
+        ArgumentCaptor<Property> captor = ArgumentCaptor.forClass(Property.class);
+        verify(propertyUseCase).create(captor.capture());
+        Property created = captor.getValue();
+        assertEquals(LocalDate.of(2025, 6, 15), created.getAcquiredOn());
+        assertEquals(LocalDate.of(2027, 6, 15), created.getWarrantyExpiresOn());
+        assertEquals(new BigDecimal("1299.99"), created.getPurchasePrice());
+    }
+
+    @Test
+    void processRowsReportsInvalidDate() {
+        List<Map<String, String>> rows = List.of(
+                Map.of("name", "Desk", "acquiredOn", "not-a-date")
+        );
+
+        ImportResult result = controller.processRows(ORG_ID, rows);
+
+        assertEquals(1, result.skipped());
+        assertEquals("Invalid acquiredOn date: not-a-date", result.errors().get(0).message());
+    }
+
+    @Test
+    void processRowsReportsInvalidPrice() {
+        List<Map<String, String>> rows = List.of(
+                Map.of("name", "Desk", "purchasePrice", "abc")
+        );
+
+        ImportResult result = controller.processRows(ORG_ID, rows);
+
+        assertEquals(1, result.skipped());
+        assertEquals("Invalid purchasePrice: abc", result.errors().get(0).message());
+    }
+
+    @Test
+    void processRowsMixedValidAndInvalid() {
+        when(propertyUseCase.create(any(Property.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        List<Map<String, String>> rows = List.of(
+                Map.of("name", "Desk"),
+                Map.of("name", ""),
+                Map.of("name", "Chair", "status", "BAD_STATUS"),
+                Map.of("name", "Lamp")
+        );
+
+        ImportResult result = controller.processRows(ORG_ID, rows);
+
+        assertEquals(4, result.total());
+        assertEquals(2, result.created());
+        assertEquals(2, result.skipped());
+        assertEquals(2, result.errors().size());
+        verify(propertyUseCase, times(2)).create(any());
+    }
+
+    @Test
+    void processRowsLeavesOptionalFieldsNull() {
+        when(propertyUseCase.create(any(Property.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        List<Map<String, String>> rows = List.of(
+                Map.of("name", "Desk")
+        );
+
+        controller.processRows(ORG_ID, rows);
+
+        ArgumentCaptor<Property> captor = ArgumentCaptor.forClass(Property.class);
+        verify(propertyUseCase).create(captor.capture());
+        Property created = captor.getValue();
+        assertNull(created.getDescription());
+        assertNull(created.getSerialNumber());
+        assertNull(created.getStatus());
+        assertNull(created.getAcquiredOn());
+        assertNull(created.getPurchasePrice());
+    }
+
+    private MockMultipartFile csvFile(String content) {
+        return new MockMultipartFile(
+                "file",
+                "import.csv",
+                "text/csv",
+                content.getBytes(StandardCharsets.UTF_8));
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `POST /api/properties/import` endpoint accepting a CSV file upload and an `organizationId` parameter
- Parses CSV in the adapter layer (hexagonal architecture) and delegates to `ManagePropertyUseCase.create()` for each valid row
- Returns an `ImportResult` with total/created/skipped counts and per-row error details
- Supports all Property fields: name, description, serialNumber, modelNumber, manufacturer, category, location, status, acquiredOn, warrantyExpiresOn, purchasePrice

## Test plan
- [x] Unit tests for CSV parsing (valid rows, blank lines, empty file)
- [x] Unit tests for row processing (valid creation, missing name, invalid status/date/price, mixed batches)
- [x] Checkstyle passes (`./mvnw validate`)

Closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)