### PR TITLE
Add property image gallery

### DIFF
--- a/src/main/java/com/majordomo/adapter/in/web/AttachmentController.java
+++ b/src/main/java/com/majordomo/adapter/in/web/AttachmentController.java
@@ -13,6 +13,8 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -141,4 +143,48 @@ public class AttachmentController {
         attachmentUseCase.archive(id);
         return ResponseEntity.noContent().build();
     }
+
+    /**
+     * Returns the ordered image gallery for a property.
+     *
+     * @param id the property UUID
+     * @return image attachments ordered by sort_order ascending
+     */
+    @GetMapping("/properties/{id}/gallery")
+    public List<Attachment> getPropertyGallery(@PathVariable UUID id) {
+        return attachmentUseCase.listImages("property", id);
+    }
+
+    /**
+     * Marks an attachment as the primary image for its entity.
+     * Clears the primary flag on any previously-primary attachment for the same entity.
+     *
+     * @param id the attachment UUID
+     * @return the updated attachment metadata
+     */
+    @PutMapping("/attachments/{id}/primary")
+    public Attachment setAsPrimary(@PathVariable UUID id) {
+        return attachmentUseCase.setPrimary(id);
+    }
+
+    /**
+     * Updates the sort order of an attachment within its entity's gallery.
+     *
+     * @param id      the attachment UUID
+     * @param request a JSON object containing {@code sortOrder}
+     * @return the updated attachment metadata
+     */
+    @PutMapping("/attachments/{id}/order")
+    public Attachment updateOrder(
+            @PathVariable UUID id,
+            @RequestBody SortOrderRequest request) {
+        return attachmentUseCase.updateSortOrder(id, request.sortOrder());
+    }
+
+    /**
+     * Request body for updating sort order.
+     *
+     * @param sortOrder the new sort order value
+     */
+    record SortOrderRequest(int sortOrder) { }
 }

--- a/src/main/java/com/majordomo/adapter/out/persistence/attachment/AttachmentEntity.java
+++ b/src/main/java/com/majordomo/adapter/out/persistence/attachment/AttachmentEntity.java
@@ -42,6 +42,12 @@ public class AttachmentEntity {
     @Column(name = "archived_at")
     private Instant archivedAt;
 
+    @Column(name = "is_primary", nullable = false)
+    private boolean isPrimary;
+
+    @Column(name = "sort_order", nullable = false)
+    private int sortOrder;
+
     public UUID getId() { return id; }
     public void setId(UUID id) { this.id = id; }
 
@@ -71,4 +77,10 @@ public class AttachmentEntity {
 
     public Instant getArchivedAt() { return archivedAt; }
     public void setArchivedAt(Instant archivedAt) { this.archivedAt = archivedAt; }
+
+    public boolean isPrimary() { return isPrimary; }
+    public void setPrimary(boolean primary) { this.isPrimary = primary; }
+
+    public int getSortOrder() { return sortOrder; }
+    public void setSortOrder(int sortOrder) { this.sortOrder = sortOrder; }
 }

--- a/src/main/java/com/majordomo/adapter/out/persistence/attachment/AttachmentMapper.java
+++ b/src/main/java/com/majordomo/adapter/out/persistence/attachment/AttachmentMapper.java
@@ -18,6 +18,8 @@ final class AttachmentMapper {
         entity.setCreatedAt(attachment.getCreatedAt());
         entity.setUpdatedAt(attachment.getUpdatedAt());
         entity.setArchivedAt(attachment.getArchivedAt());
+        entity.setPrimary(attachment.isPrimary());
+        entity.setSortOrder(attachment.getSortOrder());
         return entity;
     }
 
@@ -33,6 +35,8 @@ final class AttachmentMapper {
         attachment.setCreatedAt(entity.getCreatedAt());
         attachment.setUpdatedAt(entity.getUpdatedAt());
         attachment.setArchivedAt(entity.getArchivedAt());
+        attachment.setPrimary(entity.isPrimary());
+        attachment.setSortOrder(entity.getSortOrder());
         return attachment;
     }
 }

--- a/src/main/java/com/majordomo/adapter/out/persistence/attachment/AttachmentRepositoryAdapter.java
+++ b/src/main/java/com/majordomo/adapter/out/persistence/attachment/AttachmentRepositoryAdapter.java
@@ -45,4 +45,21 @@ public class AttachmentRepositoryAdapter implements AttachmentRepository {
                 .map(AttachmentMapper::toDomain)
                 .toList();
     }
+
+    @Override
+    public List<Attachment> findImagesByEntityTypeAndEntityId(String entityType, UUID entityId) {
+        return jpa.findImagesByEntityTypeAndEntityId(entityType, entityId)
+                .stream()
+                .map(AttachmentMapper::toDomain)
+                .toList();
+    }
+
+    @Override
+    public List<Attachment> findByEntityTypeAndEntityIdAndArchivedAtIsNull(
+            String entityType, UUID entityId) {
+        return jpa.findByEntityTypeAndEntityIdAndArchivedAtIsNull(entityType, entityId)
+                .stream()
+                .map(AttachmentMapper::toDomain)
+                .toList();
+    }
 }

--- a/src/main/java/com/majordomo/adapter/out/persistence/attachment/JpaAttachmentRepository.java
+++ b/src/main/java/com/majordomo/adapter/out/persistence/attachment/JpaAttachmentRepository.java
@@ -1,6 +1,8 @@
 package com.majordomo.adapter.out.persistence.attachment;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.UUID;
@@ -18,4 +20,28 @@ public interface JpaAttachmentRepository extends JpaRepository<AttachmentEntity,
      * @return list of attachment entities
      */
     List<AttachmentEntity> findByEntityTypeAndEntityId(String entityType, UUID entityId);
+
+    /**
+     * Returns all non-archived attachments for a given entity type and entity ID.
+     *
+     * @param entityType the entity type
+     * @param entityId   the entity ID
+     * @return list of non-archived attachment entities
+     */
+    List<AttachmentEntity> findByEntityTypeAndEntityIdAndArchivedAtIsNull(
+            String entityType, UUID entityId);
+
+    /**
+     * Returns image attachments for the given entity, ordered by sort_order ascending.
+     * Only non-archived attachments with a content type starting with {@code image/}
+     * are included.
+     *
+     * @param type the entity type
+     * @param id   the entity ID
+     * @return ordered list of image attachment entities
+     */
+    @Query("SELECT a FROM AttachmentEntity a WHERE a.entityType = :type AND a.entityId = :id "
+        + "AND a.contentType LIKE 'image/%' AND a.archivedAt IS NULL ORDER BY a.sortOrder")
+    List<AttachmentEntity> findImagesByEntityTypeAndEntityId(
+            @Param("type") String type, @Param("id") UUID id);
 }

--- a/src/main/java/com/majordomo/application/AttachmentService.java
+++ b/src/main/java/com/majordomo/application/AttachmentService.java
@@ -105,4 +105,40 @@ public class AttachmentService implements ManageAttachmentUseCase {
         existing.setUpdatedAt(Instant.now());
         attachmentRepository.save(existing);
     }
+
+    @Override
+    public List<Attachment> listImages(String entityType, UUID entityId) {
+        return attachmentRepository.findImagesByEntityTypeAndEntityId(entityType, entityId);
+    }
+
+    @Override
+    public Attachment setPrimary(UUID id) {
+        Attachment target = attachmentRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException("Attachment", id));
+
+        // Clear primary flag on all current images for the same entity
+        attachmentRepository
+                .findByEntityTypeAndEntityIdAndArchivedAtIsNull(
+                        target.getEntityType(), target.getEntityId())
+                .stream()
+                .filter(Attachment::isPrimary)
+                .forEach(a -> {
+                    a.setPrimary(false);
+                    a.setUpdatedAt(Instant.now());
+                    attachmentRepository.save(a);
+                });
+
+        target.setPrimary(true);
+        target.setUpdatedAt(Instant.now());
+        return attachmentRepository.save(target);
+    }
+
+    @Override
+    public Attachment updateSortOrder(UUID id, int sortOrder) {
+        Attachment existing = attachmentRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException("Attachment", id));
+        existing.setSortOrder(sortOrder);
+        existing.setUpdatedAt(Instant.now());
+        return attachmentRepository.save(existing);
+    }
 }

--- a/src/main/java/com/majordomo/domain/model/Attachment.java
+++ b/src/main/java/com/majordomo/domain/model/Attachment.java
@@ -19,6 +19,8 @@ public class Attachment {
     private Instant createdAt;
     private Instant updatedAt;
     private Instant archivedAt;
+    private boolean isPrimary;
+    private int sortOrder;
 
     public Attachment() { }
 
@@ -51,4 +53,32 @@ public class Attachment {
 
     public Instant getArchivedAt() { return archivedAt; }
     public void setArchivedAt(Instant archivedAt) { this.archivedAt = archivedAt; }
+
+    /**
+     * Returns whether this attachment is the primary (hero) image for its entity.
+     *
+     * @return {@code true} if this is the primary image
+     */
+    public boolean isPrimary() { return isPrimary; }
+
+    /**
+     * Sets whether this attachment is the primary image for its entity.
+     *
+     * @param primary {@code true} to mark as primary
+     */
+    public void setPrimary(boolean primary) { this.isPrimary = primary; }
+
+    /**
+     * Returns the display order position of this attachment within the gallery.
+     *
+     * @return the zero-based sort order
+     */
+    public int getSortOrder() { return sortOrder; }
+
+    /**
+     * Sets the display order position of this attachment within the gallery.
+     *
+     * @param sortOrder the zero-based sort order
+     */
+    public void setSortOrder(int sortOrder) { this.sortOrder = sortOrder; }
 }

--- a/src/main/java/com/majordomo/domain/port/in/ManageAttachmentUseCase.java
+++ b/src/main/java/com/majordomo/domain/port/in/ManageAttachmentUseCase.java
@@ -56,4 +56,31 @@ public interface ManageAttachmentUseCase {
      * @param id the attachment ID
      */
     void archive(UUID id);
+
+    /**
+     * Returns the ordered gallery of image attachments for a property.
+     *
+     * @param entityType the entity type (e.g. "property")
+     * @param entityId   the entity ID
+     * @return image attachments ordered by sort_order ascending
+     */
+    List<Attachment> listImages(String entityType, UUID entityId);
+
+    /**
+     * Marks the given attachment as the primary image for its entity,
+     * clearing the primary flag on any previously-primary attachment for the same entity.
+     *
+     * @param id the attachment ID to promote to primary
+     * @return the updated attachment
+     */
+    Attachment setPrimary(UUID id);
+
+    /**
+     * Updates the sort order of an attachment within its entity's gallery.
+     *
+     * @param id        the attachment ID
+     * @param sortOrder the new sort order value
+     * @return the updated attachment
+     */
+    Attachment updateSortOrder(UUID id, int sortOrder);
 }

--- a/src/main/java/com/majordomo/domain/port/out/AttachmentRepository.java
+++ b/src/main/java/com/majordomo/domain/port/out/AttachmentRepository.java
@@ -35,4 +35,26 @@ public interface AttachmentRepository {
      * @return list of attachments, or an empty list if none exist
      */
     List<Attachment> findByEntityTypeAndEntityId(String entityType, UUID entityId);
+
+    /**
+     * Returns image attachments (content type starting with {@code image/}) for a given
+     * entity type and entity ID, ordered by {@code sortOrder} ascending.
+     * Archived attachments are excluded.
+     *
+     * @param entityType the type of entity (e.g. "property")
+     * @param entityId   the entity ID
+     * @return ordered list of image attachments, or an empty list if none exist
+     */
+    List<Attachment> findImagesByEntityTypeAndEntityId(String entityType, UUID entityId);
+
+    /**
+     * Returns all non-archived image attachments for the same entity as the given
+     * attachment, i.e. sharing the same {@code entityType} and {@code entityId}.
+     *
+     * @param entityType the entity type
+     * @param entityId   the entity ID
+     * @return list of attachments for the entity, including non-image types
+     */
+    List<Attachment> findByEntityTypeAndEntityIdAndArchivedAtIsNull(
+            String entityType, UUID entityId);
 }

--- a/src/main/resources/db/migration/V13__add_gallery_fields.sql
+++ b/src/main/resources/db/migration/V13__add_gallery_fields.sql
@@ -1,0 +1,2 @@
+ALTER TABLE attachments ADD COLUMN is_primary BOOLEAN NOT NULL DEFAULT false;
+ALTER TABLE attachments ADD COLUMN sort_order INT NOT NULL DEFAULT 0;

--- a/src/test/java/com/majordomo/application/AttachmentGalleryServiceTest.java
+++ b/src/test/java/com/majordomo/application/AttachmentGalleryServiceTest.java
@@ -1,0 +1,210 @@
+package com.majordomo.application;
+
+import com.majordomo.domain.model.Attachment;
+import com.majordomo.domain.model.EntityNotFoundException;
+import com.majordomo.domain.port.out.AttachmentRepository;
+import com.majordomo.domain.port.out.FileStoragePort;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for gallery ordering and primary-image selection within
+ * {@link AttachmentService}.
+ */
+@ExtendWith(MockitoExtension.class)
+class AttachmentGalleryServiceTest {
+
+    @Mock
+    private AttachmentRepository attachmentRepository;
+
+    @Mock
+    private FileStoragePort fileStorage;
+
+    private AttachmentService attachmentService;
+
+    @BeforeEach
+    void setUp() {
+        attachmentService = new AttachmentService(
+                attachmentRepository, fileStorage,
+                10_485_760L,
+                "image/jpeg,image/png,application/pdf,text/plain");
+    }
+
+    // -----------------------------------------------------------------------
+    // listImages
+    // -----------------------------------------------------------------------
+
+    @Test
+    void listImagesDelegatesToRepositoryAndReturnsOrderedList() {
+        UUID entityId = UUID.randomUUID();
+        Attachment img1 = imageAttachment(entityId, 0);
+        Attachment img2 = imageAttachment(entityId, 1);
+
+        when(attachmentRepository.findImagesByEntityTypeAndEntityId("property", entityId))
+                .thenReturn(List.of(img1, img2));
+
+        List<Attachment> result = attachmentService.listImages("property", entityId);
+
+        assertEquals(2, result.size());
+        assertEquals(0, result.get(0).getSortOrder());
+        assertEquals(1, result.get(1).getSortOrder());
+        verify(attachmentRepository).findImagesByEntityTypeAndEntityId("property", entityId);
+    }
+
+    @Test
+    void listImagesReturnsEmptyListWhenNoneExist() {
+        UUID entityId = UUID.randomUUID();
+        when(attachmentRepository.findImagesByEntityTypeAndEntityId("property", entityId))
+                .thenReturn(List.of());
+
+        List<Attachment> result = attachmentService.listImages("property", entityId);
+
+        assertTrue(result.isEmpty());
+    }
+
+    // -----------------------------------------------------------------------
+    // setPrimary
+    // -----------------------------------------------------------------------
+
+    @Test
+    void setPrimaryMarkesTargetAndClearsPreviousPrimary() {
+        UUID entityId = UUID.randomUUID();
+        UUID oldPrimaryId = UUID.randomUUID();
+        UUID newPrimaryId = UUID.randomUUID();
+
+        Attachment oldPrimary = imageAttachment(entityId, 0);
+        oldPrimary.setId(oldPrimaryId);
+        oldPrimary.setPrimary(true);
+
+        Attachment newPrimary = imageAttachment(entityId, 1);
+        newPrimary.setId(newPrimaryId);
+        newPrimary.setPrimary(false);
+
+        when(attachmentRepository.findById(newPrimaryId))
+                .thenReturn(Optional.of(newPrimary));
+        when(attachmentRepository.findByEntityTypeAndEntityIdAndArchivedAtIsNull(
+                "property", entityId))
+                .thenReturn(List.of(oldPrimary, newPrimary));
+        when(attachmentRepository.save(any(Attachment.class)))
+                .thenAnswer(inv -> inv.getArgument(0));
+
+        Attachment result = attachmentService.setPrimary(newPrimaryId);
+
+        assertTrue(result.isPrimary());
+        assertFalse(oldPrimary.isPrimary());
+
+        // save called: once to clear old primary, once to set new primary
+        ArgumentCaptor<Attachment> captor = ArgumentCaptor.forClass(Attachment.class);
+        verify(attachmentRepository, times(2)).save(captor.capture());
+        List<Attachment> saved = captor.getAllValues();
+        // first save clears old primary
+        assertFalse(saved.get(0).isPrimary());
+        // second save sets new primary
+        assertTrue(saved.get(1).isPrimary());
+    }
+
+    @Test
+    void setPrimaryWhenNoPreviousPrimaryOnlySetsTarget() {
+        UUID entityId = UUID.randomUUID();
+        UUID targetId = UUID.randomUUID();
+
+        Attachment target = imageAttachment(entityId, 0);
+        target.setId(targetId);
+        target.setPrimary(false);
+
+        Attachment other = imageAttachment(entityId, 1);
+        other.setId(UUID.randomUUID());
+        other.setPrimary(false);
+
+        when(attachmentRepository.findById(targetId))
+                .thenReturn(Optional.of(target));
+        when(attachmentRepository.findByEntityTypeAndEntityIdAndArchivedAtIsNull(
+                "property", entityId))
+                .thenReturn(List.of(target, other));
+        when(attachmentRepository.save(any(Attachment.class)))
+                .thenAnswer(inv -> inv.getArgument(0));
+
+        Attachment result = attachmentService.setPrimary(targetId);
+
+        assertTrue(result.isPrimary());
+        // only one save — the target itself
+        verify(attachmentRepository, times(1)).save(any());
+    }
+
+    @Test
+    void setPrimaryNonexistentAttachmentThrowsException() {
+        UUID id = UUID.randomUUID();
+        when(attachmentRepository.findById(id)).thenReturn(Optional.empty());
+
+        assertThrows(EntityNotFoundException.class, () -> attachmentService.setPrimary(id));
+    }
+
+    // -----------------------------------------------------------------------
+    // updateSortOrder
+    // -----------------------------------------------------------------------
+
+    @Test
+    void updateSortOrderPersistsNewValue() {
+        UUID id = UUID.randomUUID();
+        Attachment existing = imageAttachment(UUID.randomUUID(), 5);
+        existing.setId(id);
+
+        when(attachmentRepository.findById(id)).thenReturn(Optional.of(existing));
+        when(attachmentRepository.save(any(Attachment.class)))
+                .thenAnswer(inv -> inv.getArgument(0));
+
+        Attachment result = attachmentService.updateSortOrder(id, 3);
+
+        assertEquals(3, result.getSortOrder());
+        ArgumentCaptor<Attachment> captor = ArgumentCaptor.forClass(Attachment.class);
+        verify(attachmentRepository).save(captor.capture());
+        assertEquals(3, captor.getValue().getSortOrder());
+    }
+
+    @Test
+    void updateSortOrderNonexistentAttachmentThrowsException() {
+        UUID id = UUID.randomUUID();
+        when(attachmentRepository.findById(id)).thenReturn(Optional.empty());
+
+        assertThrows(EntityNotFoundException.class,
+                () -> attachmentService.updateSortOrder(id, 0));
+    }
+
+    // -----------------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------------
+
+    private Attachment imageAttachment(UUID entityId, int sortOrder) {
+        Attachment a = new Attachment();
+        a.setId(UUID.randomUUID());
+        a.setEntityType("property");
+        a.setEntityId(entityId);
+        a.setFilename("photo.jpg");
+        a.setContentType("image/jpeg");
+        a.setSizeBytes(1024L);
+        a.setStoragePath("property/" + entityId + "/photo.jpg");
+        a.setCreatedAt(Instant.now());
+        a.setUpdatedAt(Instant.now());
+        a.setSortOrder(sortOrder);
+        return a;
+    }
+}


### PR DESCRIPTION
## Summary

- **Flyway V13** (`V13__add_gallery_fields.sql`): adds `is_primary BOOLEAN` and `sort_order INT` columns to `attachments` table
- **Domain model** (`Attachment`): `isPrimary` / `sortOrder` fields with full Javadoc
- **Persistence layer** (`AttachmentEntity`, `AttachmentMapper`, `JpaAttachmentRepository`, `AttachmentRepositoryAdapter`): maps both columns; adds a JPQL `@Query` that filters `image/*` content types, excludes archived rows, and orders by `sort_order`
- **Port interfaces** (`AttachmentRepository`, `ManageAttachmentUseCase`): `findImagesByEntityTypeAndEntityId`, `listImages`, `setPrimary`, `updateSortOrder`
- **Application service** (`AttachmentService`): implements `setPrimary` (atomically clears prior primary for the same entity), `updateSortOrder`, and `listImages`
- **REST controller** (`AttachmentController`): three new endpoints:
  - `GET /api/properties/{id}/gallery` — returns ordered image gallery
  - `PUT /api/attachments/{id}/primary` — promotes an attachment to primary image
  - `PUT /api/attachments/{id}/order` — updates sort position (`{"sortOrder": N}`)
- **Unit tests** (`AttachmentGalleryServiceTest`): covers gallery listing, primary promotion with prior-primary clearing, no-prior-primary case, sort order update, and 404 paths

## Test plan

- [ ] `./mvnw validate` passes (Checkstyle)
- [ ] `./mvnw test -Dtest=AttachmentGalleryServiceTest` — all gallery tests green
- [ ] `./mvnw test -Dtest=AttachmentServiceTest` — existing tests still pass
- [ ] Flyway migration applies cleanly against a local PostgreSQL instance
- [ ] `GET /api/properties/{id}/gallery` returns only image/* attachments, ordered by `sort_order`
- [ ] `PUT /api/attachments/{id}/primary` clears the previous primary and sets the new one
- [ ] `PUT /api/attachments/{id}/order` updates `sort_order` and the gallery re-orders accordingly

Closes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)