### PR TITLE
Add user preferences and notification settings

### DIFF
--- a/src/main/java/com/majordomo/adapter/in/web/identity/UserPreferencesController.java
+++ b/src/main/java/com/majordomo/adapter/in/web/identity/UserPreferencesController.java
@@ -1,0 +1,61 @@
+package com.majordomo.adapter.in.web.identity;
+
+import com.majordomo.domain.model.identity.UserPreferences;
+import com.majordomo.domain.port.in.identity.ManageUserPreferencesUseCase;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.UUID;
+
+/**
+ * REST controller for managing user notification preferences.
+ */
+@RestController
+@RequestMapping("/api/users/{userId}/preferences")
+@Tag(name = "Identity", description = "User preferences management")
+public class UserPreferencesController {
+
+    private final ManageUserPreferencesUseCase useCase;
+
+    /**
+     * Constructs the controller with the required use case.
+     *
+     * @param useCase the inbound port for managing preferences
+     */
+    public UserPreferencesController(ManageUserPreferencesUseCase useCase) {
+        this.useCase = useCase;
+    }
+
+    /**
+     * Retrieves the preferences for a user, creating defaults if none exist.
+     *
+     * @param userId the user ID
+     * @return the user preferences
+     */
+    @GetMapping
+    public ResponseEntity<UserPreferences> getPreferences(@PathVariable UUID userId) {
+        return ResponseEntity.ok(useCase.getPreferences(userId));
+    }
+
+    /**
+     * Updates the preferences for a user.
+     *
+     * @param userId      the user ID
+     * @param preferences the updated preferences
+     * @return the saved preferences
+     */
+    @PutMapping
+    public ResponseEntity<UserPreferences> updatePreferences(
+            @PathVariable UUID userId,
+            @RequestBody UserPreferences preferences) {
+        return ResponseEntity.ok(useCase.updatePreferences(userId, preferences));
+    }
+}

--- a/src/main/java/com/majordomo/adapter/out/persistence/identity/JpaUserPreferencesRepository.java
+++ b/src/main/java/com/majordomo/adapter/out/persistence/identity/JpaUserPreferencesRepository.java
@@ -1,0 +1,15 @@
+package com.majordomo.adapter.out.persistence.identity;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * Spring Data JPA repository for {@link UserPreferencesEntity}, providing persistence
+ * operations used by {@link UserPreferencesRepositoryAdapter}.
+ */
+public interface JpaUserPreferencesRepository extends JpaRepository<UserPreferencesEntity, UUID> {
+
+    Optional<UserPreferencesEntity> findByUserId(UUID userId);
+}

--- a/src/main/java/com/majordomo/adapter/out/persistence/identity/UserPreferencesEntity.java
+++ b/src/main/java/com/majordomo/adapter/out/persistence/identity/UserPreferencesEntity.java
@@ -1,0 +1,77 @@
+package com.majordomo.adapter.out.persistence.identity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+@Entity
+@Table(name = "user_preferences")
+public class UserPreferencesEntity {
+
+    @Id
+    private UUID id;
+
+    @Column(name = "user_id", nullable = false, unique = true)
+    private UUID userId;
+
+    @Column(name = "notification_email")
+    private String notificationEmail;
+
+    @Column(name = "notifications_enabled", nullable = false)
+    private boolean notificationsEnabled;
+
+    @JdbcTypeCode(SqlTypes.ARRAY)
+    @Column(name = "notification_categories_disabled", columnDefinition = "text[]")
+    private List<String> notificationCategoriesDisabled;
+
+    @Column(name = "timezone")
+    private String timezone;
+
+    @Column(name = "locale")
+    private String locale;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
+
+    public UUID getId() { return id; }
+    public void setId(UUID id) { this.id = id; }
+
+    public UUID getUserId() { return userId; }
+    public void setUserId(UUID userId) { this.userId = userId; }
+
+    public String getNotificationEmail() { return notificationEmail; }
+    public void setNotificationEmail(String notificationEmail) { this.notificationEmail = notificationEmail; }
+
+    public boolean isNotificationsEnabled() { return notificationsEnabled; }
+    public void setNotificationsEnabled(boolean notificationsEnabled) {
+        this.notificationsEnabled = notificationsEnabled;
+    }
+
+    public List<String> getNotificationCategoriesDisabled() { return notificationCategoriesDisabled; }
+    public void setNotificationCategoriesDisabled(List<String> notificationCategoriesDisabled) {
+        this.notificationCategoriesDisabled = notificationCategoriesDisabled;
+    }
+
+    public String getTimezone() { return timezone; }
+    public void setTimezone(String timezone) { this.timezone = timezone; }
+
+    public String getLocale() { return locale; }
+    public void setLocale(String locale) { this.locale = locale; }
+
+    public Instant getCreatedAt() { return createdAt; }
+    public void setCreatedAt(Instant createdAt) { this.createdAt = createdAt; }
+
+    public Instant getUpdatedAt() { return updatedAt; }
+    public void setUpdatedAt(Instant updatedAt) { this.updatedAt = updatedAt; }
+}

--- a/src/main/java/com/majordomo/adapter/out/persistence/identity/UserPreferencesMapper.java
+++ b/src/main/java/com/majordomo/adapter/out/persistence/identity/UserPreferencesMapper.java
@@ -1,0 +1,44 @@
+package com.majordomo.adapter.out.persistence.identity;
+
+import com.majordomo.domain.model.identity.UserPreferences;
+
+import java.util.ArrayList;
+
+final class UserPreferencesMapper {
+
+    private UserPreferencesMapper() { }
+
+    static UserPreferencesEntity toEntity(UserPreferences prefs) {
+        var entity = new UserPreferencesEntity();
+        entity.setId(prefs.getId());
+        entity.setUserId(prefs.getUserId());
+        entity.setNotificationEmail(prefs.getNotificationEmail());
+        entity.setNotificationsEnabled(prefs.isNotificationsEnabled());
+        entity.setNotificationCategoriesDisabled(
+                prefs.getNotificationCategoriesDisabled() != null
+                        ? new ArrayList<>(prefs.getNotificationCategoriesDisabled())
+                        : new ArrayList<>());
+        entity.setTimezone(prefs.getTimezone());
+        entity.setLocale(prefs.getLocale());
+        entity.setCreatedAt(prefs.getCreatedAt());
+        entity.setUpdatedAt(prefs.getUpdatedAt());
+        return entity;
+    }
+
+    static UserPreferences toDomain(UserPreferencesEntity entity) {
+        var prefs = new UserPreferences();
+        prefs.setId(entity.getId());
+        prefs.setUserId(entity.getUserId());
+        prefs.setNotificationEmail(entity.getNotificationEmail());
+        prefs.setNotificationsEnabled(entity.isNotificationsEnabled());
+        prefs.setNotificationCategoriesDisabled(
+                entity.getNotificationCategoriesDisabled() != null
+                        ? new ArrayList<>(entity.getNotificationCategoriesDisabled())
+                        : new ArrayList<>());
+        prefs.setTimezone(entity.getTimezone());
+        prefs.setLocale(entity.getLocale());
+        prefs.setCreatedAt(entity.getCreatedAt());
+        prefs.setUpdatedAt(entity.getUpdatedAt());
+        return prefs;
+    }
+}

--- a/src/main/java/com/majordomo/adapter/out/persistence/identity/UserPreferencesRepositoryAdapter.java
+++ b/src/main/java/com/majordomo/adapter/out/persistence/identity/UserPreferencesRepositoryAdapter.java
@@ -1,0 +1,40 @@
+package com.majordomo.adapter.out.persistence.identity;
+
+import com.majordomo.domain.model.identity.UserPreferences;
+import com.majordomo.domain.port.out.identity.UserPreferencesRepository;
+
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * Persistence adapter that fulfills the
+ * {@link com.majordomo.domain.port.out.identity.UserPreferencesRepository}
+ * output port by delegating to {@link JpaUserPreferencesRepository}.
+ */
+@Repository
+public class UserPreferencesRepositoryAdapter implements UserPreferencesRepository {
+
+    private final JpaUserPreferencesRepository jpa;
+
+    /**
+     * Constructs the adapter with the JPA repository.
+     *
+     * @param jpa the Spring Data JPA repository
+     */
+    public UserPreferencesRepositoryAdapter(JpaUserPreferencesRepository jpa) {
+        this.jpa = jpa;
+    }
+
+    @Override
+    public UserPreferences save(UserPreferences preferences) {
+        var entity = UserPreferencesMapper.toEntity(preferences);
+        return UserPreferencesMapper.toDomain(jpa.save(entity));
+    }
+
+    @Override
+    public Optional<UserPreferences> findByUserId(UUID userId) {
+        return jpa.findByUserId(userId).map(UserPreferencesMapper::toDomain);
+    }
+}

--- a/src/main/java/com/majordomo/application/herald/MaintenanceNotificationService.java
+++ b/src/main/java/com/majordomo/application/herald/MaintenanceNotificationService.java
@@ -1,9 +1,11 @@
 package com.majordomo.application.herald;
 
 import com.majordomo.domain.model.identity.MemberRole;
+import com.majordomo.domain.model.identity.NotificationCategory;
 import com.majordomo.domain.port.out.herald.MaintenanceScheduleRepository;
 import com.majordomo.domain.port.out.herald.NotificationPort;
 import com.majordomo.domain.port.out.identity.MembershipRepository;
+import com.majordomo.domain.port.out.identity.UserPreferencesRepository;
 import com.majordomo.domain.port.out.identity.UserRepository;
 import com.majordomo.domain.port.out.steward.PropertyRepository;
 
@@ -28,6 +30,7 @@ public class MaintenanceNotificationService {
     private final PropertyRepository propertyRepository;
     private final MembershipRepository membershipRepository;
     private final UserRepository userRepository;
+    private final UserPreferencesRepository preferencesRepository;
     private final NotificationPort notificationPort;
 
     /**
@@ -37,17 +40,20 @@ public class MaintenanceNotificationService {
      * @param propertyRepository   repository for properties
      * @param membershipRepository repository for organization memberships
      * @param userRepository       repository for users
+     * @param preferencesRepository repository for user notification preferences
      * @param notificationPort     outbound port for sending notifications
      */
     public MaintenanceNotificationService(MaintenanceScheduleRepository scheduleRepository,
                                           PropertyRepository propertyRepository,
                                           MembershipRepository membershipRepository,
                                           UserRepository userRepository,
+                                          UserPreferencesRepository preferencesRepository,
                                           NotificationPort notificationPort) {
         this.scheduleRepository = scheduleRepository;
         this.propertyRepository = propertyRepository;
         this.membershipRepository = membershipRepository;
         this.userRepository = userRepository;
+        this.preferencesRepository = preferencesRepository;
         this.notificationPort = notificationPort;
     }
 
@@ -75,11 +81,18 @@ public class MaintenanceNotificationService {
                     continue;
                 }
                 var user = userRepository.findById(membership.getUserId());
-                user.ifPresent(u -> notificationPort.send(
-                        u.getEmail(),
-                        "Upcoming maintenance: " + schedule.getDescription(),
-                        "Maintenance for " + property.get().getName()
-                                + " is due on " + schedule.getNextDue()));
+                user.ifPresent(u -> {
+                    var prefs = preferencesRepository.findByUserId(u.getId());
+                    if (prefs.isPresent()
+                            && !prefs.get().isCategoryEnabled(NotificationCategory.MAINTENANCE_DUE)) {
+                        return;
+                    }
+                    notificationPort.send(
+                            u.getEmail(),
+                            "Upcoming maintenance: " + schedule.getDescription(),
+                            "Maintenance for " + property.get().getName()
+                                    + " is due on " + schedule.getNextDue());
+                });
             }
 
             schedule.setNotificationSentAt(Instant.now());

--- a/src/main/java/com/majordomo/application/identity/UserPreferencesService.java
+++ b/src/main/java/com/majordomo/application/identity/UserPreferencesService.java
@@ -1,0 +1,70 @@
+package com.majordomo.application.identity;
+
+import com.majordomo.domain.model.UuidFactory;
+import com.majordomo.domain.model.identity.UserPreferences;
+import com.majordomo.domain.port.in.identity.ManageUserPreferencesUseCase;
+import com.majordomo.domain.port.out.identity.UserPreferencesRepository;
+
+import org.springframework.stereotype.Service;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.UUID;
+
+/**
+ * Application service for managing user notification preferences.
+ * Creates sensible defaults when no preferences exist for a user.
+ */
+@Service
+public class UserPreferencesService implements ManageUserPreferencesUseCase {
+
+    private final UserPreferencesRepository preferencesRepository;
+
+    /**
+     * Constructs the service with the required repository.
+     *
+     * @param preferencesRepository the outbound port for persisting preferences
+     */
+    public UserPreferencesService(UserPreferencesRepository preferencesRepository) {
+        this.preferencesRepository = preferencesRepository;
+    }
+
+    @Override
+    public UserPreferences getPreferences(UUID userId) {
+        return preferencesRepository.findByUserId(userId)
+                .orElseGet(() -> createDefaults(userId));
+    }
+
+    @Override
+    public UserPreferences updatePreferences(UUID userId, UserPreferences preferences) {
+        var existing = preferencesRepository.findByUserId(userId)
+                .orElseGet(() -> createDefaults(userId));
+
+        existing.setNotificationEmail(preferences.getNotificationEmail());
+        existing.setNotificationsEnabled(preferences.isNotificationsEnabled());
+        existing.setNotificationCategoriesDisabled(
+                preferences.getNotificationCategoriesDisabled() != null
+                        ? preferences.getNotificationCategoriesDisabled()
+                        : new ArrayList<>());
+        existing.setTimezone(preferences.getTimezone() != null
+                ? preferences.getTimezone() : "UTC");
+        existing.setLocale(preferences.getLocale() != null
+                ? preferences.getLocale() : "en");
+        existing.setUpdatedAt(Instant.now());
+
+        return preferencesRepository.save(existing);
+    }
+
+    private UserPreferences createDefaults(UUID userId) {
+        var prefs = new UserPreferences();
+        prefs.setId(UuidFactory.newId());
+        prefs.setUserId(userId);
+        prefs.setNotificationsEnabled(true);
+        prefs.setNotificationCategoriesDisabled(new ArrayList<>());
+        prefs.setTimezone("UTC");
+        prefs.setLocale("en");
+        prefs.setCreatedAt(Instant.now());
+        prefs.setUpdatedAt(Instant.now());
+        return preferencesRepository.save(prefs);
+    }
+}

--- a/src/main/java/com/majordomo/application/steward/WarrantyAlertService.java
+++ b/src/main/java/com/majordomo/application/steward/WarrantyAlertService.java
@@ -1,8 +1,10 @@
 package com.majordomo.application.steward;
 
 import com.majordomo.domain.model.identity.MemberRole;
+import com.majordomo.domain.model.identity.NotificationCategory;
 import com.majordomo.domain.port.out.herald.NotificationPort;
 import com.majordomo.domain.port.out.identity.MembershipRepository;
+import com.majordomo.domain.port.out.identity.UserPreferencesRepository;
 import com.majordomo.domain.port.out.identity.UserRepository;
 import com.majordomo.domain.port.out.steward.PropertyRepository;
 
@@ -26,23 +28,27 @@ public class WarrantyAlertService {
     private final PropertyRepository propertyRepository;
     private final MembershipRepository membershipRepository;
     private final UserRepository userRepository;
+    private final UserPreferencesRepository preferencesRepository;
     private final NotificationPort notificationPort;
 
     /**
      * Constructs the warranty alert service with required dependencies.
      *
-     * @param propertyRepository   repository for properties
-     * @param membershipRepository repository for organization memberships
-     * @param userRepository       repository for users
-     * @param notificationPort     outbound port for sending notifications
+     * @param propertyRepository    repository for properties
+     * @param membershipRepository  repository for organization memberships
+     * @param userRepository        repository for users
+     * @param preferencesRepository repository for user notification preferences
+     * @param notificationPort      outbound port for sending notifications
      */
     public WarrantyAlertService(PropertyRepository propertyRepository,
                                 MembershipRepository membershipRepository,
                                 UserRepository userRepository,
+                                UserPreferencesRepository preferencesRepository,
                                 NotificationPort notificationPort) {
         this.propertyRepository = propertyRepository;
         this.membershipRepository = membershipRepository;
         this.userRepository = userRepository;
+        this.preferencesRepository = preferencesRepository;
         this.notificationPort = notificationPort;
     }
 
@@ -67,12 +73,19 @@ public class WarrantyAlertService {
                     continue;
                 }
                 var user = userRepository.findById(membership.getUserId());
-                user.ifPresent(u -> notificationPort.send(
-                        u.getEmail(),
-                        "Warranty expiring soon: " + property.getName(),
-                        "The warranty for " + property.getName()
-                                + " expires on " + property.getWarrantyExpiresOn()
-                                + ". Please take action if renewal or replacement is needed."));
+                user.ifPresent(u -> {
+                    var prefs = preferencesRepository.findByUserId(u.getId());
+                    if (prefs.isPresent()
+                            && !prefs.get().isCategoryEnabled(NotificationCategory.WARRANTY_EXPIRING)) {
+                        return;
+                    }
+                    notificationPort.send(
+                            u.getEmail(),
+                            "Warranty expiring soon: " + property.getName(),
+                            "The warranty for " + property.getName()
+                                    + " expires on " + property.getWarrantyExpiresOn()
+                                    + ". Please take action if renewal or replacement is needed.");
+                });
             }
 
             property.setWarrantyNotificationSentAt(Instant.now());

--- a/src/main/java/com/majordomo/domain/model/identity/NotificationCategory.java
+++ b/src/main/java/com/majordomo/domain/model/identity/NotificationCategory.java
@@ -1,0 +1,13 @@
+package com.majordomo.domain.model.identity;
+
+/**
+ * Categories of notifications that can be individually disabled per user.
+ */
+public enum NotificationCategory {
+    /** Upcoming maintenance reminders. */
+    MAINTENANCE_DUE,
+    /** Property warranty expiration alerts. */
+    WARRANTY_EXPIRING,
+    /** System announcements and new features. */
+    SITE_UPDATES
+}

--- a/src/main/java/com/majordomo/domain/model/identity/UserPreferences.java
+++ b/src/main/java/com/majordomo/domain/model/identity/UserPreferences.java
@@ -1,0 +1,66 @@
+package com.majordomo.domain.model.identity;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * User-specific preferences for notifications, timezone, and locale.
+ */
+public class UserPreferences {
+
+    private UUID id;
+    private UUID userId;
+    private String notificationEmail;
+    private boolean notificationsEnabled;
+    private List<String> notificationCategoriesDisabled;
+    private String timezone;
+    private String locale;
+    private Instant createdAt;
+    private Instant updatedAt;
+
+    public UserPreferences() { }
+
+    public UUID getId() { return id; }
+    public void setId(UUID id) { this.id = id; }
+
+    public UUID getUserId() { return userId; }
+    public void setUserId(UUID userId) { this.userId = userId; }
+
+    public String getNotificationEmail() { return notificationEmail; }
+    public void setNotificationEmail(String notificationEmail) { this.notificationEmail = notificationEmail; }
+
+    public boolean isNotificationsEnabled() { return notificationsEnabled; }
+    public void setNotificationsEnabled(boolean notificationsEnabled) {
+        this.notificationsEnabled = notificationsEnabled;
+    }
+
+    public List<String> getNotificationCategoriesDisabled() { return notificationCategoriesDisabled; }
+    public void setNotificationCategoriesDisabled(List<String> notificationCategoriesDisabled) {
+        this.notificationCategoriesDisabled = notificationCategoriesDisabled;
+    }
+
+    public String getTimezone() { return timezone; }
+    public void setTimezone(String timezone) { this.timezone = timezone; }
+
+    public String getLocale() { return locale; }
+    public void setLocale(String locale) { this.locale = locale; }
+
+    public Instant getCreatedAt() { return createdAt; }
+    public void setCreatedAt(Instant createdAt) { this.createdAt = createdAt; }
+
+    public Instant getUpdatedAt() { return updatedAt; }
+    public void setUpdatedAt(Instant updatedAt) { this.updatedAt = updatedAt; }
+
+    /**
+     * Checks if notifications are enabled for the given category.
+     *
+     * @param category the notification category
+     * @return true if enabled
+     */
+    public boolean isCategoryEnabled(NotificationCategory category) {
+        return notificationsEnabled
+            && (notificationCategoriesDisabled == null
+                || !notificationCategoriesDisabled.contains(category.name()));
+    }
+}

--- a/src/main/java/com/majordomo/domain/port/in/identity/ManageUserPreferencesUseCase.java
+++ b/src/main/java/com/majordomo/domain/port/in/identity/ManageUserPreferencesUseCase.java
@@ -1,0 +1,28 @@
+package com.majordomo.domain.port.in.identity;
+
+import com.majordomo.domain.model.identity.UserPreferences;
+
+import java.util.UUID;
+
+/**
+ * Inbound port for managing user notification preferences.
+ */
+public interface ManageUserPreferencesUseCase {
+
+    /**
+     * Retrieves preferences for the given user, creating defaults if none exist.
+     *
+     * @param userId the user ID
+     * @return the user preferences
+     */
+    UserPreferences getPreferences(UUID userId);
+
+    /**
+     * Updates preferences for the given user.
+     *
+     * @param userId      the user ID
+     * @param preferences the updated preferences
+     * @return the saved preferences
+     */
+    UserPreferences updatePreferences(UUID userId, UserPreferences preferences);
+}

--- a/src/main/java/com/majordomo/domain/port/out/identity/UserPreferencesRepository.java
+++ b/src/main/java/com/majordomo/domain/port/out/identity/UserPreferencesRepository.java
@@ -1,0 +1,28 @@
+package com.majordomo.domain.port.out.identity;
+
+import com.majordomo.domain.model.identity.UserPreferences;
+
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * Outbound port for persisting and retrieving user notification preferences.
+ */
+public interface UserPreferencesRepository {
+
+    /**
+     * Persists user preferences, inserting or updating as needed.
+     *
+     * @param preferences the preferences to save
+     * @return the saved preferences, including any generated or updated fields
+     */
+    UserPreferences save(UserPreferences preferences);
+
+    /**
+     * Retrieves preferences for a given user.
+     *
+     * @param userId the user ID
+     * @return the preferences, or empty if none have been created yet
+     */
+    Optional<UserPreferences> findByUserId(UUID userId);
+}

--- a/src/main/resources/db/migration/V12__add_user_preferences.sql
+++ b/src/main/resources/db/migration/V12__add_user_preferences.sql
@@ -1,0 +1,13 @@
+CREATE TABLE user_preferences (
+    id                              UUID PRIMARY KEY,
+    user_id                         UUID         NOT NULL UNIQUE REFERENCES users(id),
+    notification_email              VARCHAR(255),
+    notifications_enabled           BOOLEAN      NOT NULL DEFAULT true,
+    notification_categories_disabled TEXT[]       DEFAULT '{}',
+    timezone                        VARCHAR(100) DEFAULT 'UTC',
+    locale                          VARCHAR(20)  DEFAULT 'en',
+    created_at                      TIMESTAMPTZ  NOT NULL DEFAULT now(),
+    updated_at                      TIMESTAMPTZ  NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_user_preferences_user_id ON user_preferences(user_id);

--- a/src/test/java/com/majordomo/application/herald/MaintenanceNotificationServiceTest.java
+++ b/src/test/java/com/majordomo/application/herald/MaintenanceNotificationServiceTest.java
@@ -5,10 +5,12 @@ import com.majordomo.domain.model.herald.MaintenanceSchedule;
 import com.majordomo.domain.model.identity.MemberRole;
 import com.majordomo.domain.model.identity.Membership;
 import com.majordomo.domain.model.identity.User;
+import com.majordomo.domain.model.identity.UserPreferences;
 import com.majordomo.domain.model.steward.Property;
 import com.majordomo.domain.port.out.herald.MaintenanceScheduleRepository;
 import com.majordomo.domain.port.out.herald.NotificationPort;
 import com.majordomo.domain.port.out.identity.MembershipRepository;
+import com.majordomo.domain.port.out.identity.UserPreferencesRepository;
 import com.majordomo.domain.port.out.identity.UserRepository;
 import com.majordomo.domain.port.out.steward.PropertyRepository;
 
@@ -47,6 +49,9 @@ class MaintenanceNotificationServiceTest {
     private UserRepository userRepository;
 
     @Mock
+    private UserPreferencesRepository preferencesRepository;
+
+    @Mock
     private NotificationPort notificationPort;
 
     private MaintenanceNotificationService service;
@@ -55,7 +60,7 @@ class MaintenanceNotificationServiceTest {
     void setUp() {
         service = new MaintenanceNotificationService(
                 scheduleRepository, propertyRepository, membershipRepository,
-                userRepository, notificationPort);
+                userRepository, preferencesRepository, notificationPort);
     }
 
     @Test
@@ -88,6 +93,8 @@ class MaintenanceNotificationServiceTest {
                 .thenReturn(List.of(membership));
         when(userRepository.findById(userId))
                 .thenReturn(Optional.of(user));
+        when(preferencesRepository.findByUserId(userId))
+                .thenReturn(Optional.empty());
         when(scheduleRepository.save(any(MaintenanceSchedule.class)))
                 .thenReturn(schedule);
 
@@ -128,5 +135,48 @@ class MaintenanceNotificationServiceTest {
 
         verify(notificationPort, never()).send(anyString(), anyString(), anyString());
         verify(scheduleRepository, never()).save(any());
+    }
+
+    @Test
+    void checkAndNotifySkipsUserWithMaintenanceDueDisabled() {
+        var propertyId = UUID.randomUUID();
+        var orgId = UUID.randomUUID();
+        var userId = UUID.randomUUID();
+
+        var schedule = new MaintenanceSchedule();
+        schedule.setId(UUID.randomUUID());
+        schedule.setPropertyId(propertyId);
+        schedule.setDescription("HVAC filter replacement");
+        schedule.setFrequency(Frequency.MONTHLY);
+        schedule.setNextDue(LocalDate.now().plusDays(3));
+
+        var property = new Property();
+        property.setId(propertyId);
+        property.setOrganizationId(orgId);
+        property.setName("Main Building");
+
+        var membership = new Membership(UUID.randomUUID(), userId, orgId, MemberRole.OWNER);
+        var user = new User(userId, "admin", "admin@example.com");
+
+        var prefs = new UserPreferences();
+        prefs.setNotificationsEnabled(true);
+        prefs.setNotificationCategoriesDisabled(List.of("MAINTENANCE_DUE"));
+
+        when(scheduleRepository.findDueBefore(any(LocalDate.class)))
+                .thenReturn(List.of(schedule));
+        when(propertyRepository.findById(propertyId))
+                .thenReturn(Optional.of(property));
+        when(membershipRepository.findByOrganizationId(orgId))
+                .thenReturn(List.of(membership));
+        when(userRepository.findById(userId))
+                .thenReturn(Optional.of(user));
+        when(preferencesRepository.findByUserId(userId))
+                .thenReturn(Optional.of(prefs));
+        when(scheduleRepository.save(any(MaintenanceSchedule.class)))
+                .thenReturn(schedule);
+
+        service.checkAndNotify();
+
+        verify(notificationPort, never()).send(anyString(), anyString(), anyString());
     }
 }

--- a/src/test/java/com/majordomo/application/identity/UserPreferencesServiceTest.java
+++ b/src/test/java/com/majordomo/application/identity/UserPreferencesServiceTest.java
@@ -1,0 +1,109 @@
+package com.majordomo.application.identity;
+
+import com.majordomo.domain.model.identity.UserPreferences;
+import com.majordomo.domain.port.out.identity.UserPreferencesRepository;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class UserPreferencesServiceTest {
+
+    @Mock
+    private UserPreferencesRepository preferencesRepository;
+
+    private UserPreferencesService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new UserPreferencesService(preferencesRepository);
+    }
+
+    @Test
+    void getPreferencesReturnsExistingPreferences() {
+        var userId = UUID.randomUUID();
+        var existing = new UserPreferences();
+        existing.setId(UUID.randomUUID());
+        existing.setUserId(userId);
+        existing.setTimezone("America/New_York");
+
+        when(preferencesRepository.findByUserId(userId))
+                .thenReturn(Optional.of(existing));
+
+        var result = service.getPreferences(userId);
+
+        assertEquals("America/New_York", result.getTimezone());
+        assertEquals(userId, result.getUserId());
+    }
+
+    @Test
+    void getPreferencesCreatesDefaultsWhenNoneExist() {
+        var userId = UUID.randomUUID();
+
+        when(preferencesRepository.findByUserId(userId))
+                .thenReturn(Optional.empty());
+        when(preferencesRepository.save(any(UserPreferences.class)))
+                .thenAnswer(inv -> inv.getArgument(0));
+
+        var result = service.getPreferences(userId);
+
+        assertNotNull(result.getId());
+        assertEquals(userId, result.getUserId());
+        assertTrue(result.isNotificationsEnabled());
+        assertEquals("UTC", result.getTimezone());
+        assertEquals("en", result.getLocale());
+        assertTrue(result.getNotificationCategoriesDisabled().isEmpty());
+    }
+
+    @Test
+    void updatePreferencesMergesIntoExisting() {
+        var userId = UUID.randomUUID();
+        var existingId = UUID.randomUUID();
+
+        var existing = new UserPreferences();
+        existing.setId(existingId);
+        existing.setUserId(userId);
+        existing.setNotificationsEnabled(true);
+        existing.setTimezone("UTC");
+        existing.setLocale("en");
+
+        var updated = new UserPreferences();
+        updated.setNotificationsEnabled(true);
+        updated.setNotificationCategoriesDisabled(List.of("SITE_UPDATES"));
+        updated.setTimezone("Europe/London");
+        updated.setLocale("en-GB");
+        updated.setNotificationEmail("custom@example.com");
+
+        when(preferencesRepository.findByUserId(userId))
+                .thenReturn(Optional.of(existing));
+        when(preferencesRepository.save(any(UserPreferences.class)))
+                .thenAnswer(inv -> inv.getArgument(0));
+
+        var result = service.updatePreferences(userId, updated);
+
+        assertEquals(existingId, result.getId());
+        assertEquals("Europe/London", result.getTimezone());
+        assertEquals("en-GB", result.getLocale());
+        assertEquals(List.of("SITE_UPDATES"), result.getNotificationCategoriesDisabled());
+        assertEquals("custom@example.com", result.getNotificationEmail());
+
+        var captor = ArgumentCaptor.forClass(UserPreferences.class);
+        verify(preferencesRepository).save(captor.capture());
+        assertNotNull(captor.getValue().getUpdatedAt());
+    }
+}

--- a/src/test/java/com/majordomo/application/steward/WarrantyAlertServiceTest.java
+++ b/src/test/java/com/majordomo/application/steward/WarrantyAlertServiceTest.java
@@ -3,9 +3,11 @@ package com.majordomo.application.steward;
 import com.majordomo.domain.model.identity.MemberRole;
 import com.majordomo.domain.model.identity.Membership;
 import com.majordomo.domain.model.identity.User;
+import com.majordomo.domain.model.identity.UserPreferences;
 import com.majordomo.domain.model.steward.Property;
 import com.majordomo.domain.port.out.herald.NotificationPort;
 import com.majordomo.domain.port.out.identity.MembershipRepository;
+import com.majordomo.domain.port.out.identity.UserPreferencesRepository;
 import com.majordomo.domain.port.out.identity.UserRepository;
 import com.majordomo.domain.port.out.steward.PropertyRepository;
 
@@ -41,6 +43,9 @@ class WarrantyAlertServiceTest {
     private UserRepository userRepository;
 
     @Mock
+    private UserPreferencesRepository preferencesRepository;
+
+    @Mock
     private NotificationPort notificationPort;
 
     private WarrantyAlertService service;
@@ -48,7 +53,8 @@ class WarrantyAlertServiceTest {
     @BeforeEach
     void setUp() {
         service = new WarrantyAlertService(
-                propertyRepository, membershipRepository, userRepository, notificationPort);
+                propertyRepository, membershipRepository, userRepository,
+                preferencesRepository, notificationPort);
     }
 
     @Test
@@ -72,6 +78,8 @@ class WarrantyAlertServiceTest {
                 .thenReturn(List.of(membership));
         when(userRepository.findById(userId))
                 .thenReturn(Optional.of(user));
+        when(preferencesRepository.findByUserId(userId))
+                .thenReturn(Optional.empty());
         when(propertyRepository.save(any(Property.class)))
                 .thenReturn(property);
 
@@ -111,5 +119,40 @@ class WarrantyAlertServiceTest {
 
         verify(notificationPort, never()).send(anyString(), anyString(), anyString());
         verify(propertyRepository, never()).save(any());
+    }
+
+    @Test
+    void checkAndNotifySkipsUserWithWarrantyExpiringDisabled() {
+        var propertyId = UUID.randomUUID();
+        var orgId = UUID.randomUUID();
+        var userId = UUID.randomUUID();
+
+        var property = new Property();
+        property.setId(propertyId);
+        property.setOrganizationId(orgId);
+        property.setName("HVAC Unit");
+        property.setWarrantyExpiresOn(LocalDate.now().plusDays(15));
+
+        var membership = new Membership(UUID.randomUUID(), userId, orgId, MemberRole.ADMIN);
+        var user = new User(userId, "admin", "admin@example.com");
+
+        var prefs = new UserPreferences();
+        prefs.setNotificationsEnabled(true);
+        prefs.setNotificationCategoriesDisabled(List.of("WARRANTY_EXPIRING"));
+
+        when(propertyRepository.findWithWarrantyExpiringBefore(any(LocalDate.class)))
+                .thenReturn(List.of(property));
+        when(membershipRepository.findByOrganizationId(orgId))
+                .thenReturn(List.of(membership));
+        when(userRepository.findById(userId))
+                .thenReturn(Optional.of(user));
+        when(preferencesRepository.findByUserId(userId))
+                .thenReturn(Optional.of(prefs));
+        when(propertyRepository.save(any(Property.class)))
+                .thenReturn(property);
+
+        service.checkAndNotify();
+
+        verify(notificationPort, never()).send(anyString(), anyString(), anyString());
     }
 }

--- a/src/test/java/com/majordomo/domain/model/identity/UserPreferencesTest.java
+++ b/src/test/java/com/majordomo/domain/model/identity/UserPreferencesTest.java
@@ -1,0 +1,75 @@
+package com.majordomo.domain.model.identity;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class UserPreferencesTest {
+
+    @Test
+    void isCategoryEnabledReturnsTrueWhenAllEnabled() {
+        var prefs = new UserPreferences();
+        prefs.setNotificationsEnabled(true);
+        prefs.setNotificationCategoriesDisabled(new ArrayList<>());
+
+        assertTrue(prefs.isCategoryEnabled(NotificationCategory.MAINTENANCE_DUE));
+        assertTrue(prefs.isCategoryEnabled(NotificationCategory.WARRANTY_EXPIRING));
+        assertTrue(prefs.isCategoryEnabled(NotificationCategory.SITE_UPDATES));
+    }
+
+    @Test
+    void isCategoryEnabledReturnsFalseWhenGloballyDisabled() {
+        var prefs = new UserPreferences();
+        prefs.setNotificationsEnabled(false);
+        prefs.setNotificationCategoriesDisabled(new ArrayList<>());
+
+        assertFalse(prefs.isCategoryEnabled(NotificationCategory.MAINTENANCE_DUE));
+        assertFalse(prefs.isCategoryEnabled(NotificationCategory.SITE_UPDATES));
+    }
+
+    @Test
+    void isCategoryEnabledReturnsFalseForDisabledCategory() {
+        var prefs = new UserPreferences();
+        prefs.setNotificationsEnabled(true);
+        prefs.setNotificationCategoriesDisabled(List.of("SITE_UPDATES"));
+
+        assertTrue(prefs.isCategoryEnabled(NotificationCategory.MAINTENANCE_DUE));
+        assertFalse(prefs.isCategoryEnabled(NotificationCategory.SITE_UPDATES));
+    }
+
+    @Test
+    void isCategoryEnabledReturnsFalseWhenMaintenanceDueDisabled() {
+        var prefs = new UserPreferences();
+        prefs.setNotificationsEnabled(true);
+        prefs.setNotificationCategoriesDisabled(List.of("MAINTENANCE_DUE"));
+
+        assertFalse(prefs.isCategoryEnabled(NotificationCategory.MAINTENANCE_DUE));
+        assertTrue(prefs.isCategoryEnabled(NotificationCategory.WARRANTY_EXPIRING));
+    }
+
+    @Test
+    void isCategoryEnabledReturnsTrueWhenDisabledListIsNull() {
+        var prefs = new UserPreferences();
+        prefs.setNotificationsEnabled(true);
+        prefs.setNotificationCategoriesDisabled(null);
+
+        assertTrue(prefs.isCategoryEnabled(NotificationCategory.MAINTENANCE_DUE));
+        assertTrue(prefs.isCategoryEnabled(NotificationCategory.SITE_UPDATES));
+    }
+
+    @Test
+    void isCategoryEnabledReturnsFalseWhenMultipleCategoriesDisabled() {
+        var prefs = new UserPreferences();
+        prefs.setNotificationsEnabled(true);
+        prefs.setNotificationCategoriesDisabled(
+                List.of("MAINTENANCE_DUE", "WARRANTY_EXPIRING", "SITE_UPDATES"));
+
+        assertFalse(prefs.isCategoryEnabled(NotificationCategory.MAINTENANCE_DUE));
+        assertFalse(prefs.isCategoryEnabled(NotificationCategory.WARRANTY_EXPIRING));
+        assertFalse(prefs.isCategoryEnabled(NotificationCategory.SITE_UPDATES));
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `user_preferences` table (Flyway V12) with PostgreSQL `text[]` array for per-category notification opt-out
- Introduces `NotificationCategory` enum with `MAINTENANCE_DUE`, `WARRANTY_EXPIRING`, and `SITE_UPDATES` as separately disableable categories
- Full hexagonal architecture: domain model, inbound/outbound ports, JPA entity (with `@JdbcTypeCode(SqlTypes.ARRAY)`), mapper, repository adapter, application service, REST controller
- REST API: `GET/PUT /api/users/{userId}/preferences` — auto-creates defaults on first access
- `MaintenanceNotificationService` and `WarrantyAlertService` now check user preferences before sending, skipping users who have opted out of the relevant category
- Unit tests for `UserPreferences.isCategoryEnabled()`, `UserPreferencesService`, and preference-based notification filtering in both notification services

Closes #77

## Test plan
- [ ] Verify `UserPreferencesTest` passes all 6 isCategoryEnabled scenarios
- [ ] Verify `UserPreferencesServiceTest` covers get (existing/default) and update flows
- [ ] Verify `MaintenanceNotificationServiceTest` skips notification when MAINTENANCE_DUE is disabled
- [ ] Verify `WarrantyAlertServiceTest` skips notification when WARRANTY_EXPIRING is disabled
- [ ] Verify Checkstyle passes (`./mvnw validate`)
- [ ] Verify Flyway migration applies cleanly against PostgreSQL

🤖 Generated with [Claude Code](https://claude.com/claude-code)