### PR TITLE
Add responsive dashboard web page

### DIFF
--- a/src/main/java/com/majordomo/adapter/in/web/DashboardPageController.java
+++ b/src/main/java/com/majordomo/adapter/in/web/DashboardPageController.java
@@ -1,0 +1,58 @@
+package com.majordomo.adapter.in.web;
+
+import com.majordomo.domain.port.in.DashboardUseCase;
+import com.majordomo.domain.port.out.identity.MembershipRepository;
+import com.majordomo.domain.port.out.identity.UserRepository;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+
+/**
+ * Serves the web dashboard page showing an organization overview.
+ */
+@Controller
+public class DashboardPageController {
+
+    private final DashboardUseCase dashboardUseCase;
+    private final UserRepository userRepository;
+    private final MembershipRepository membershipRepository;
+
+    /**
+     * Constructs the dashboard page controller.
+     *
+     * @param dashboardUseCase     the inbound port for dashboard data retrieval
+     * @param userRepository       the outbound port for user lookups
+     * @param membershipRepository the outbound port for membership lookups
+     */
+    public DashboardPageController(DashboardUseCase dashboardUseCase,
+                                   UserRepository userRepository,
+                                   MembershipRepository membershipRepository) {
+        this.dashboardUseCase = dashboardUseCase;
+        this.userRepository = userRepository;
+        this.membershipRepository = membershipRepository;
+    }
+
+    /**
+     * Renders the dashboard page for the authenticated user's organization.
+     *
+     * @param principal the authenticated user
+     * @param model     the Thymeleaf model
+     * @return the dashboard template name, or a redirect if the user has no organization
+     */
+    @GetMapping("/dashboard")
+    public String dashboard(@AuthenticationPrincipal UserDetails principal, Model model) {
+        var user = userRepository.findByUsername(principal.getUsername()).orElseThrow();
+        var memberships = membershipRepository.findByUserId(user.getId());
+        if (memberships.isEmpty()) {
+            return "redirect:/";
+        }
+        var orgId = memberships.get(0).getOrganizationId();
+        var summary = dashboardUseCase.getSummary(orgId);
+        model.addAttribute("summary", summary);
+        model.addAttribute("username", user.getUsername());
+        return "dashboard";
+    }
+}

--- a/src/main/resources/templates/dashboard.html
+++ b/src/main/resources/templates/dashboard.html
@@ -1,0 +1,147 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Dashboard - Majordomo</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-gray-100 min-h-screen">
+
+    <!-- Header -->
+    <nav class="bg-indigo-700 shadow-lg">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="flex items-center justify-between h-16">
+                <div class="flex items-center">
+                    <a href="/" class="text-white text-xl font-bold tracking-wide">Majordomo</a>
+                </div>
+                <div class="flex items-center space-x-4">
+                    <span class="text-indigo-200 text-sm" th:text="'Signed in as ' + ${username}">Signed in as user</span>
+                    <form th:action="@{/logout}" method="post" class="inline">
+                        <button type="submit"
+                                class="bg-indigo-600 hover:bg-indigo-500 text-white text-sm px-4 py-2 rounded-md transition">
+                            Sign out
+                        </button>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </nav>
+
+    <main class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+
+        <h1 class="text-2xl font-bold text-gray-900 mb-6">Dashboard</h1>
+
+        <!-- Stat Cards -->
+        <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 mb-8">
+
+            <!-- Property Count -->
+            <div class="bg-white rounded-lg shadow p-6">
+                <div class="text-sm font-medium text-gray-500 uppercase tracking-wide">Properties</div>
+                <div class="mt-2 text-3xl font-bold text-indigo-700" th:text="${summary.propertyCount()}">0</div>
+            </div>
+
+            <!-- Contact Count -->
+            <div class="bg-white rounded-lg shadow p-6">
+                <div class="text-sm font-medium text-gray-500 uppercase tracking-wide">Contacts</div>
+                <div class="mt-2 text-3xl font-bold text-indigo-700" th:text="${summary.contactCount()}">0</div>
+            </div>
+
+            <!-- Total Spend -->
+            <div class="bg-white rounded-lg shadow p-6">
+                <div class="text-sm font-medium text-gray-500 uppercase tracking-wide">Total Spend</div>
+                <div class="mt-2 text-3xl font-bold text-indigo-700">
+                    $<span th:text="${#numbers.formatDecimal(summary.totalSpend(), 1, 2)}">0.00</span>
+                </div>
+            </div>
+
+        </div>
+
+        <!-- Two-column layout for maintenance sections -->
+        <div class="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-8">
+
+            <!-- Upcoming Maintenance -->
+            <div class="bg-white rounded-lg shadow">
+                <div class="px-6 py-4 border-b border-gray-200">
+                    <h2 class="text-lg font-semibold text-gray-900">Upcoming Maintenance</h2>
+                </div>
+                <div class="p-6">
+                    <p th:if="${#lists.isEmpty(summary.upcomingMaintenance())}" class="text-gray-400 text-sm">
+                        No upcoming maintenance items.
+                    </p>
+                    <ul class="space-y-3" th:unless="${#lists.isEmpty(summary.upcomingMaintenance())}">
+                        <li th:each="item : ${summary.upcomingMaintenance()}"
+                            class="flex items-center justify-between p-3 rounded-md bg-yellow-50 border border-yellow-200">
+                            <div>
+                                <span class="font-medium text-gray-800" th:text="${item.description}">Task</span>
+                                <span class="block text-sm text-yellow-700" th:text="'Due: ' + ${item.nextDue}">Due date</span>
+                            </div>
+                            <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-yellow-100 text-yellow-800">
+                                Upcoming
+                            </span>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+
+            <!-- Overdue Items -->
+            <div class="bg-white rounded-lg shadow">
+                <div class="px-6 py-4 border-b border-gray-200">
+                    <h2 class="text-lg font-semibold text-gray-900">Overdue Items</h2>
+                </div>
+                <div class="p-6">
+                    <p th:if="${#lists.isEmpty(summary.overdueItems())}" class="text-gray-400 text-sm">
+                        No overdue items.
+                    </p>
+                    <ul class="space-y-3" th:unless="${#lists.isEmpty(summary.overdueItems())}">
+                        <li th:each="item : ${summary.overdueItems()}"
+                            class="flex items-center justify-between p-3 rounded-md bg-red-50 border border-red-200">
+                            <div>
+                                <span class="font-medium text-gray-800" th:text="${item.description}">Task</span>
+                                <span class="block text-sm text-red-700" th:text="'Due: ' + ${item.nextDue}">Due date</span>
+                            </div>
+                            <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-red-100 text-red-800">
+                                Overdue
+                            </span>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+
+        </div>
+
+        <!-- Recent Service Records -->
+        <div class="bg-white rounded-lg shadow">
+            <div class="px-6 py-4 border-b border-gray-200">
+                <h2 class="text-lg font-semibold text-gray-900">Recent Service Records</h2>
+            </div>
+            <div class="p-6">
+                <p th:if="${#lists.isEmpty(summary.recentServiceRecords())}" class="text-gray-400 text-sm">
+                    No recent service records.
+                </p>
+                <div th:unless="${#lists.isEmpty(summary.recentServiceRecords())}" class="overflow-x-auto">
+                    <table class="min-w-full divide-y divide-gray-200">
+                        <thead class="bg-gray-50">
+                            <tr>
+                                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Date</th>
+                                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Description</th>
+                                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Cost</th>
+                            </tr>
+                        </thead>
+                        <tbody class="bg-white divide-y divide-gray-200">
+                            <tr th:each="record : ${summary.recentServiceRecords()}">
+                                <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-700" th:text="${record.performedOn}">2026-01-01</td>
+                                <td class="px-6 py-4 text-sm text-gray-700" th:text="${record.description}">Service performed</td>
+                                <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-700"
+                                    th:text="${record.cost != null} ? '$' + ${#numbers.formatDecimal(record.cost, 1, 2)} : '-'">$0.00</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+
+    </main>
+
+</body>
+</html>

--- a/src/main/resources/templates/home.html
+++ b/src/main/resources/templates/home.html
@@ -11,6 +11,7 @@
     </div>
     <div sec:authorize="isAuthenticated()">
         <p>Welcome, <span sec:authentication="name">User</span></p>
+        <p><a href="/dashboard">Go to Dashboard</a></p>
         <form th:action="@{/logout}" method="post">
             <button type="submit">Sign out</button>
         </form>

--- a/src/test/java/com/majordomo/adapter/in/web/DashboardPageControllerTest.java
+++ b/src/test/java/com/majordomo/adapter/in/web/DashboardPageControllerTest.java
@@ -1,0 +1,92 @@
+package com.majordomo.adapter.in.web;
+
+import com.majordomo.domain.model.DashboardSummary;
+import com.majordomo.domain.model.identity.Membership;
+import com.majordomo.domain.model.identity.MemberRole;
+import com.majordomo.domain.model.identity.User;
+import com.majordomo.domain.port.in.DashboardUseCase;
+import com.majordomo.domain.port.out.identity.MembershipRepository;
+import com.majordomo.domain.port.out.identity.UserRepository;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.model;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
+
+/**
+ * Tests for {@link DashboardPageController}.
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+class DashboardPageControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private DashboardUseCase dashboardUseCase;
+
+    @MockitoBean
+    private UserRepository userRepository;
+
+    @MockitoBean
+    private MembershipRepository membershipRepository;
+
+    /** Authenticated user with an organization membership sees the dashboard. */
+    @Test
+    @WithMockUser(username = "testuser")
+    void dashboardReturns200ForAuthenticatedUser() throws Exception {
+        UUID userId = UUID.randomUUID();
+        UUID orgId = UUID.randomUUID();
+
+        User user = new User(userId, "testuser", "test@example.com");
+        Membership membership = new Membership(UUID.randomUUID(), userId, orgId, MemberRole.OWNER);
+        DashboardSummary summary = new DashboardSummary(
+                3, 5, List.of(), List.of(), List.of(), new BigDecimal("1200.00"));
+
+        when(userRepository.findByUsername("testuser")).thenReturn(Optional.of(user));
+        when(membershipRepository.findByUserId(userId)).thenReturn(List.of(membership));
+        when(dashboardUseCase.getSummary(orgId)).thenReturn(summary);
+
+        mockMvc.perform(get("/dashboard"))
+                .andExpect(status().isOk())
+                .andExpect(view().name("dashboard"))
+                .andExpect(model().attributeExists("summary"))
+                .andExpect(model().attributeExists("username"));
+    }
+
+    /** Unauthenticated access to dashboard redirects to login. */
+    @Test
+    void dashboardRequiresAuthentication() throws Exception {
+        mockMvc.perform(get("/dashboard"))
+                .andExpect(status().is3xxRedirection());
+    }
+
+    /** User with no memberships is redirected to the home page. */
+    @Test
+    @WithMockUser(username = "nomember")
+    void dashboardRedirectsWhenNoMembership() throws Exception {
+        UUID userId = UUID.randomUUID();
+        User user = new User(userId, "nomember", "nomember@example.com");
+
+        when(userRepository.findByUsername("nomember")).thenReturn(Optional.of(user));
+        when(membershipRepository.findByUserId(userId)).thenReturn(List.of());
+
+        mockMvc.perform(get("/dashboard"))
+                .andExpect(status().is3xxRedirection());
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `DashboardPageController` serving a Thymeleaf page at `/dashboard` that resolves the authenticated user's organization and renders the `DashboardSummary` data
- Creates a responsive `dashboard.html` template using Tailwind CSS via CDN (per ADR-0019) with stat cards, upcoming/overdue maintenance lists, and a recent service records table
- Adds a "Go to Dashboard" link on `home.html` for authenticated users
- Includes `DashboardPageControllerTest` verifying authenticated access returns 200, unauthenticated access redirects, and users without memberships are redirected home

Closes #79

## Test plan
- [ ] Verify `GET /dashboard` returns 200 for an authenticated user with an organization membership
- [ ] Verify `GET /dashboard` redirects to login for unauthenticated users
- [ ] Verify `GET /dashboard` redirects to `/` for users without memberships
- [ ] Verify the dashboard page is responsive (cards stack on mobile, grid on desktop)
- [ ] Verify overdue items appear in red and upcoming items in yellow

🤖 Generated with [Claude Code](https://claude.com/claude-code)