### PR TITLE
Reduce query duplication with JPA Specifications

### DIFF
--- a/src/main/java/com/majordomo/adapter/out/persistence/CursorSpecifications.java
+++ b/src/main/java/com/majordomo/adapter/out/persistence/CursorSpecifications.java
@@ -1,0 +1,73 @@
+package com.majordomo.adapter.out.persistence;
+
+import jakarta.persistence.criteria.Predicate;
+import org.springframework.data.jpa.domain.Specification;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Shared JPA Specifications for cursor-based queries.
+ * Eliminates duplicate with/without cursor query methods.
+ */
+public final class CursorSpecifications {
+
+    private CursorSpecifications() {
+    }
+
+    /**
+     * Creates a specification for cursor-based pagination.
+     *
+     * @param cursor the exclusive start cursor (null for first page)
+     * @param <T>    the entity type
+     * @return a specification that filters by id greater than cursor
+     */
+    public static <T> Specification<T> afterCursor(UUID cursor) {
+        return (root, query, cb) -> {
+            if (cursor == null) {
+                return cb.conjunction();
+            }
+            return cb.greaterThan(root.get("id"), cursor);
+        };
+    }
+
+    /**
+     * Creates a specification matching an entity field.
+     *
+     * @param field the field name
+     * @param value the value to match
+     * @param <T>   the entity type
+     * @return a specification, or conjunction if value is null
+     */
+    public static <T> Specification<T> fieldEquals(String field, Object value) {
+        return (root, query, cb) -> {
+            if (value == null) {
+                return cb.conjunction();
+            }
+            return cb.equal(root.get(field), value);
+        };
+    }
+
+    /**
+     * Creates a case-insensitive LIKE specification across multiple fields.
+     *
+     * @param query  the search term
+     * @param fields the fields to search
+     * @param <T>    the entity type
+     * @return a specification matching any field
+     */
+    public static <T> Specification<T> searchAcrossFields(String query, String... fields) {
+        return (root, q, cb) -> {
+            if (query == null || query.isBlank()) {
+                return cb.conjunction();
+            }
+            String pattern = "%" + query.toLowerCase() + "%";
+            List<Predicate> predicates = new ArrayList<>();
+            for (String field : fields) {
+                predicates.add(cb.like(cb.lower(root.get(field)), pattern));
+            }
+            return cb.or(predicates.toArray(new Predicate[0]));
+        };
+    }
+}

--- a/src/main/java/com/majordomo/adapter/out/persistence/concierge/ContactRepositoryAdapter.java
+++ b/src/main/java/com/majordomo/adapter/out/persistence/concierge/ContactRepositoryAdapter.java
@@ -1,9 +1,12 @@
 package com.majordomo.adapter.out.persistence.concierge;
 
+import com.majordomo.adapter.out.persistence.CursorSpecifications;
 import com.majordomo.domain.model.concierge.Contact;
 import com.majordomo.domain.port.out.concierge.ContactRepository;
 
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -41,26 +44,20 @@ public class ContactRepositoryAdapter implements ContactRepository {
 
     @Override
     public List<Contact> findByOrganizationId(UUID organizationId, UUID cursor, int limit) {
-        List<ContactEntity> entities;
-        if (cursor == null) {
-            entities = jpa.findByOrganizationIdOrderById(organizationId, PageRequest.of(0, limit));
-        } else {
-            entities = jpa.findByOrganizationIdAndIdGreaterThanOrderById(
-                    organizationId, cursor, PageRequest.of(0, limit));
-        }
-        return entities.stream().map(ContactMapper::toDomain).toList();
+        var spec = Specification.where(
+                        CursorSpecifications.<ContactEntity>fieldEquals("organizationId", organizationId))
+                .and(CursorSpecifications.afterCursor(cursor));
+        var page = jpa.findAll(spec, PageRequest.of(0, limit, Sort.by("id")));
+        return page.stream().map(ContactMapper::toDomain).toList();
     }
 
     @Override
     public List<Contact> search(UUID organizationId, String query, UUID cursor, int limit) {
-        List<ContactEntity> entities;
-        if (cursor == null) {
-            entities = jpa.searchByOrganizationIdOrderById(
-                    organizationId, query, PageRequest.of(0, limit));
-        } else {
-            entities = jpa.searchByOrganizationIdAndIdGreaterThanOrderById(
-                    organizationId, query, cursor, PageRequest.of(0, limit));
-        }
-        return entities.stream().map(ContactMapper::toDomain).toList();
+        var spec = Specification.where(
+                        CursorSpecifications.<ContactEntity>fieldEquals("organizationId", organizationId))
+                .and(CursorSpecifications.afterCursor(cursor))
+                .and(CursorSpecifications.searchAcrossFields(query, "formattedName", "givenName", "familyName"));
+        var page = jpa.findAll(spec, PageRequest.of(0, limit, Sort.by("id")));
+        return page.stream().map(ContactMapper::toDomain).toList();
     }
 }

--- a/src/main/java/com/majordomo/adapter/out/persistence/concierge/JpaContactRepository.java
+++ b/src/main/java/com/majordomo/adapter/out/persistence/concierge/JpaContactRepository.java
@@ -1,9 +1,7 @@
 package com.majordomo.adapter.out.persistence.concierge;
 
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
 import java.util.List;
 import java.util.UUID;
@@ -12,63 +10,14 @@ import java.util.UUID;
  * Spring Data JPA repository for {@link ContactEntity}, providing persistence operations
  * used by {@link ContactRepositoryAdapter}.
  */
-public interface JpaContactRepository extends JpaRepository<ContactEntity, UUID> {
+public interface JpaContactRepository extends JpaRepository<ContactEntity, UUID>,
+        JpaSpecificationExecutor<ContactEntity> {
 
+    /**
+     * Returns all contacts for an organization (unbounded, for internal use).
+     *
+     * @param organizationId the organization ID
+     * @return list of all contact entities for the organization
+     */
     List<ContactEntity> findByOrganizationId(UUID organizationId);
-
-    /**
-     * Returns contacts for an organization ordered by ID.
-     *
-     * @param organizationId the organization ID
-     * @param pageable       pagination information
-     * @return list of contact entities ordered by ID
-     */
-    List<ContactEntity> findByOrganizationIdOrderById(UUID organizationId, Pageable pageable);
-
-    /**
-     * Returns contacts for an organization with ID greater than the given cursor, ordered by ID.
-     *
-     * @param organizationId the organization ID
-     * @param id             the cursor ID (exclusive lower bound)
-     * @param pageable       pagination information
-     * @return list of contact entities after the cursor, ordered by ID
-     */
-    List<ContactEntity> findByOrganizationIdAndIdGreaterThanOrderById(
-            UUID organizationId, UUID id, Pageable pageable);
-
-    /**
-     * Searches contacts by organization with a case-insensitive query, ordered by ID.
-     *
-     * @param orgId    the organization ID
-     * @param query    the search term
-     * @param pageable pagination information
-     * @return list of matching contact entities ordered by ID
-     */
-    @Query("SELECT c FROM ContactEntity c WHERE c.organizationId = :orgId "
-            + "AND (LOWER(c.formattedName) LIKE LOWER(CONCAT('%', :q, '%')) "
-            + "OR LOWER(c.givenName) LIKE LOWER(CONCAT('%', :q, '%')) "
-            + "OR LOWER(c.familyName) LIKE LOWER(CONCAT('%', :q, '%')))"
-            + " ORDER BY c.id")
-    List<ContactEntity> searchByOrganizationIdOrderById(
-            @Param("orgId") UUID orgId, @Param("q") String query, Pageable pageable);
-
-    /**
-     * Searches contacts by organization with a case-insensitive query and cursor,
-     * ordered by ID.
-     *
-     * @param orgId    the organization ID
-     * @param query    the search term
-     * @param cursor   the cursor ID (exclusive lower bound)
-     * @param pageable pagination information
-     * @return list of matching contact entities after the cursor, ordered by ID
-     */
-    @Query("SELECT c FROM ContactEntity c WHERE c.organizationId = :orgId "
-            + "AND c.id > :cursor "
-            + "AND (LOWER(c.formattedName) LIKE LOWER(CONCAT('%', :q, '%')) "
-            + "OR LOWER(c.givenName) LIKE LOWER(CONCAT('%', :q, '%')) "
-            + "OR LOWER(c.familyName) LIKE LOWER(CONCAT('%', :q, '%')))"
-            + " ORDER BY c.id")
-    List<ContactEntity> searchByOrganizationIdAndIdGreaterThanOrderById(
-            @Param("orgId") UUID orgId, @Param("q") String query,
-            @Param("cursor") UUID cursor, Pageable pageable);
 }

--- a/src/main/java/com/majordomo/adapter/out/persistence/herald/JpaMaintenanceScheduleRepository.java
+++ b/src/main/java/com/majordomo/adapter/out/persistence/herald/JpaMaintenanceScheduleRepository.java
@@ -1,11 +1,7 @@
 package com.majordomo.adapter.out.persistence.herald;
 
-import com.majordomo.domain.model.herald.Frequency;
-
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -15,68 +11,22 @@ import java.util.UUID;
  * Spring Data JPA repository for {@link MaintenanceScheduleEntity}, providing persistence operations
  * used by {@link MaintenanceScheduleRepositoryAdapter}.
  */
-public interface JpaMaintenanceScheduleRepository extends JpaRepository<MaintenanceScheduleEntity, UUID> {
+public interface JpaMaintenanceScheduleRepository extends JpaRepository<MaintenanceScheduleEntity, UUID>,
+        JpaSpecificationExecutor<MaintenanceScheduleEntity> {
 
+    /**
+     * Returns all schedules for a property (unbounded, for internal use).
+     *
+     * @param propertyId the property ID
+     * @return list of all schedule entities for the property
+     */
     List<MaintenanceScheduleEntity> findByPropertyId(UUID propertyId);
 
+    /**
+     * Returns all schedules whose next due date is before the given date.
+     *
+     * @param date the upper bound date
+     * @return list of matching schedule entities
+     */
     List<MaintenanceScheduleEntity> findByNextDueBefore(LocalDate date);
-
-    /**
-     * Returns schedules for a property ordered by ID.
-     *
-     * @param propertyId the property ID
-     * @param pageable   pagination information
-     * @return list of schedule entities ordered by ID
-     */
-    List<MaintenanceScheduleEntity> findByPropertyIdOrderById(UUID propertyId, Pageable pageable);
-
-    /**
-     * Returns schedules for a property with ID greater than the given cursor, ordered by ID.
-     *
-     * @param propertyId the property ID
-     * @param id         the cursor ID (exclusive lower bound)
-     * @param pageable   pagination information
-     * @return list of schedule entities after the cursor, ordered by ID
-     */
-    List<MaintenanceScheduleEntity> findByPropertyIdAndIdGreaterThanOrderById(
-            UUID propertyId, UUID id, Pageable pageable);
-
-    /**
-     * Searches schedules by property with a case-insensitive query and optional
-     * frequency filter, ordered by ID.
-     *
-     * @param propertyId the property ID
-     * @param query      the search term
-     * @param frequency  optional frequency filter (null matches all)
-     * @param pageable   pagination information
-     * @return list of matching schedule entities ordered by ID
-     */
-    @Query("SELECT s FROM MaintenanceScheduleEntity s WHERE s.propertyId = :propId "
-            + "AND LOWER(s.description) LIKE LOWER(CONCAT('%', :q, '%')) "
-            + "AND (:frequency IS NULL OR s.frequency = :frequency) "
-            + "ORDER BY s.id")
-    List<MaintenanceScheduleEntity> searchByPropertyIdOrderById(
-            @Param("propId") UUID propertyId, @Param("q") String query,
-            @Param("frequency") Frequency frequency, Pageable pageable);
-
-    /**
-     * Searches schedules by property with a case-insensitive query, optional
-     * frequency filter, and cursor, ordered by ID.
-     *
-     * @param propertyId the property ID
-     * @param query      the search term
-     * @param frequency  optional frequency filter (null matches all)
-     * @param cursor     the cursor ID (exclusive lower bound)
-     * @param pageable   pagination information
-     * @return list of matching schedule entities after the cursor, ordered by ID
-     */
-    @Query("SELECT s FROM MaintenanceScheduleEntity s WHERE s.propertyId = :propId "
-            + "AND s.id > :cursor "
-            + "AND LOWER(s.description) LIKE LOWER(CONCAT('%', :q, '%')) "
-            + "AND (:frequency IS NULL OR s.frequency = :frequency) "
-            + "ORDER BY s.id")
-    List<MaintenanceScheduleEntity> searchByPropertyIdAndIdGreaterThanOrderById(
-            @Param("propId") UUID propertyId, @Param("q") String query,
-            @Param("frequency") Frequency frequency, @Param("cursor") UUID cursor,
-            Pageable pageable);
 }

--- a/src/main/java/com/majordomo/adapter/out/persistence/herald/MaintenanceScheduleRepositoryAdapter.java
+++ b/src/main/java/com/majordomo/adapter/out/persistence/herald/MaintenanceScheduleRepositoryAdapter.java
@@ -1,10 +1,13 @@
 package com.majordomo.adapter.out.persistence.herald;
 
+import com.majordomo.adapter.out.persistence.CursorSpecifications;
 import com.majordomo.domain.model.herald.Frequency;
 import com.majordomo.domain.model.herald.MaintenanceSchedule;
 import com.majordomo.domain.port.out.herald.MaintenanceScheduleRepository;
 
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDate;
@@ -43,14 +46,11 @@ public class MaintenanceScheduleRepositoryAdapter implements MaintenanceSchedule
 
     @Override
     public List<MaintenanceSchedule> findByPropertyId(UUID propertyId, UUID cursor, int limit) {
-        List<MaintenanceScheduleEntity> entities;
-        if (cursor == null) {
-            entities = jpa.findByPropertyIdOrderById(propertyId, PageRequest.of(0, limit));
-        } else {
-            entities = jpa.findByPropertyIdAndIdGreaterThanOrderById(
-                    propertyId, cursor, PageRequest.of(0, limit));
-        }
-        return entities.stream().map(MaintenanceScheduleMapper::toDomain).toList();
+        var spec = Specification.where(
+                        CursorSpecifications.<MaintenanceScheduleEntity>fieldEquals("propertyId", propertyId))
+                .and(CursorSpecifications.afterCursor(cursor));
+        var page = jpa.findAll(spec, PageRequest.of(0, limit, Sort.by("id")));
+        return page.stream().map(MaintenanceScheduleMapper::toDomain).toList();
     }
 
     @Override
@@ -62,14 +62,12 @@ public class MaintenanceScheduleRepositoryAdapter implements MaintenanceSchedule
     public List<MaintenanceSchedule> search(UUID propertyId, String query, String frequency,
                                             UUID cursor, int limit) {
         var freqEnum = frequency != null ? Frequency.valueOf(frequency) : null;
-        List<MaintenanceScheduleEntity> entities;
-        if (cursor == null) {
-            entities = jpa.searchByPropertyIdOrderById(
-                    propertyId, query, freqEnum, PageRequest.of(0, limit));
-        } else {
-            entities = jpa.searchByPropertyIdAndIdGreaterThanOrderById(
-                    propertyId, query, freqEnum, cursor, PageRequest.of(0, limit));
-        }
-        return entities.stream().map(MaintenanceScheduleMapper::toDomain).toList();
+        var spec = Specification.where(
+                        CursorSpecifications.<MaintenanceScheduleEntity>fieldEquals("propertyId", propertyId))
+                .and(CursorSpecifications.afterCursor(cursor))
+                .and(CursorSpecifications.searchAcrossFields(query, "description"))
+                .and(CursorSpecifications.fieldEquals("frequency", freqEnum));
+        var page = jpa.findAll(spec, PageRequest.of(0, limit, Sort.by("id")));
+        return page.stream().map(MaintenanceScheduleMapper::toDomain).toList();
     }
 }

--- a/src/main/java/com/majordomo/adapter/out/persistence/steward/JpaPropertyRepository.java
+++ b/src/main/java/com/majordomo/adapter/out/persistence/steward/JpaPropertyRepository.java
@@ -1,9 +1,7 @@
 package com.majordomo.adapter.out.persistence.steward;
 
-import com.majordomo.domain.model.steward.PropertyStatus;
-
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -15,79 +13,24 @@ import java.util.UUID;
  * Spring Data JPA repository for {@link PropertyEntity}, providing persistence operations
  * used by {@link PropertyRepositoryAdapter}.
  */
-public interface JpaPropertyRepository extends JpaRepository<PropertyEntity, UUID> {
+public interface JpaPropertyRepository extends JpaRepository<PropertyEntity, UUID>,
+        JpaSpecificationExecutor<PropertyEntity> {
 
+    /**
+     * Returns all properties for an organization (unbounded, for internal use).
+     *
+     * @param organizationId the organization ID
+     * @return list of all property entities for the organization
+     */
     List<PropertyEntity> findByOrganizationId(UUID organizationId);
 
+    /**
+     * Returns all properties with the given parent ID.
+     *
+     * @param parentId the parent property ID
+     * @return list of child property entities
+     */
     List<PropertyEntity> findByParentId(UUID parentId);
-
-    /**
-     * Returns properties for an organization ordered by ID.
-     *
-     * @param organizationId the organization ID
-     * @param pageable       pagination information
-     * @return list of property entities ordered by ID
-     */
-    List<PropertyEntity> findByOrganizationIdOrderById(UUID organizationId, Pageable pageable);
-
-    /**
-     * Returns properties for an organization with ID greater than the given cursor, ordered by ID.
-     *
-     * @param organizationId the organization ID
-     * @param id             the cursor ID (exclusive lower bound)
-     * @param pageable       pagination information
-     * @return list of property entities after the cursor, ordered by ID
-     */
-    List<PropertyEntity> findByOrganizationIdAndIdGreaterThanOrderById(
-            UUID organizationId, UUID id, Pageable pageable);
-
-    /**
-     * Searches properties by organization with a case-insensitive query and optional
-     * category/status filters, ordered by ID.
-     *
-     * @param orgId    the organization ID
-     * @param query    the search term
-     * @param category optional category filter (null matches all)
-     * @param status   optional status filter (null matches all)
-     * @param pageable pagination information
-     * @return list of matching property entities ordered by ID
-     */
-    @Query("SELECT p FROM PropertyEntity p WHERE p.organizationId = :orgId "
-            + "AND (LOWER(p.name) LIKE LOWER(CONCAT('%', :q, '%')) "
-            + "OR LOWER(p.description) LIKE LOWER(CONCAT('%', :q, '%')) "
-            + "OR LOWER(p.location) LIKE LOWER(CONCAT('%', :q, '%'))) "
-            + "AND (:category IS NULL OR p.category = :category) "
-            + "AND (:status IS NULL OR p.status = :status) "
-            + "ORDER BY p.id")
-    List<PropertyEntity> searchByOrganizationIdOrderById(
-            @Param("orgId") UUID orgId, @Param("q") String query,
-            @Param("category") String category, @Param("status") PropertyStatus status,
-            Pageable pageable);
-
-    /**
-     * Searches properties by organization with a case-insensitive query, optional
-     * category/status filters, and cursor, ordered by ID.
-     *
-     * @param orgId    the organization ID
-     * @param query    the search term
-     * @param category optional category filter (null matches all)
-     * @param status   optional status filter (null matches all)
-     * @param cursor   the cursor ID (exclusive lower bound)
-     * @param pageable pagination information
-     * @return list of matching property entities after the cursor, ordered by ID
-     */
-    @Query("SELECT p FROM PropertyEntity p WHERE p.organizationId = :orgId "
-            + "AND p.id > :cursor "
-            + "AND (LOWER(p.name) LIKE LOWER(CONCAT('%', :q, '%')) "
-            + "OR LOWER(p.description) LIKE LOWER(CONCAT('%', :q, '%')) "
-            + "OR LOWER(p.location) LIKE LOWER(CONCAT('%', :q, '%'))) "
-            + "AND (:category IS NULL OR p.category = :category) "
-            + "AND (:status IS NULL OR p.status = :status) "
-            + "ORDER BY p.id")
-    List<PropertyEntity> searchByOrganizationIdAndIdGreaterThanOrderById(
-            @Param("orgId") UUID orgId, @Param("q") String query,
-            @Param("category") String category, @Param("status") PropertyStatus status,
-            @Param("cursor") UUID cursor, Pageable pageable);
 
     /**
      * Returns all properties whose warranty expires before the given date

--- a/src/main/java/com/majordomo/adapter/out/persistence/steward/PropertyRepositoryAdapter.java
+++ b/src/main/java/com/majordomo/adapter/out/persistence/steward/PropertyRepositoryAdapter.java
@@ -1,10 +1,13 @@
 package com.majordomo.adapter.out.persistence.steward;
 
+import com.majordomo.adapter.out.persistence.CursorSpecifications;
 import com.majordomo.domain.model.steward.Property;
 import com.majordomo.domain.model.steward.PropertyStatus;
 import com.majordomo.domain.port.out.steward.PropertyRepository;
 
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDate;
@@ -43,14 +46,11 @@ public class PropertyRepositoryAdapter implements PropertyRepository {
 
     @Override
     public List<Property> findByOrganizationId(UUID organizationId, UUID cursor, int limit) {
-        List<PropertyEntity> entities;
-        if (cursor == null) {
-            entities = jpa.findByOrganizationIdOrderById(organizationId, PageRequest.of(0, limit));
-        } else {
-            entities = jpa.findByOrganizationIdAndIdGreaterThanOrderById(
-                    organizationId, cursor, PageRequest.of(0, limit));
-        }
-        return entities.stream().map(PropertyMapper::toDomain).toList();
+        var spec = Specification.where(
+                        CursorSpecifications.<PropertyEntity>fieldEquals("organizationId", organizationId))
+                .and(CursorSpecifications.afterCursor(cursor));
+        var page = jpa.findAll(spec, PageRequest.of(0, limit, Sort.by("id")));
+        return page.stream().map(PropertyMapper::toDomain).toList();
     }
 
     @Override
@@ -67,14 +67,13 @@ public class PropertyRepositoryAdapter implements PropertyRepository {
     public List<Property> search(UUID organizationId, String query, String category,
                                  String status, UUID cursor, int limit) {
         var statusEnum = status != null ? PropertyStatus.valueOf(status) : null;
-        List<PropertyEntity> entities;
-        if (cursor == null) {
-            entities = jpa.searchByOrganizationIdOrderById(
-                    organizationId, query, category, statusEnum, PageRequest.of(0, limit));
-        } else {
-            entities = jpa.searchByOrganizationIdAndIdGreaterThanOrderById(
-                    organizationId, query, category, statusEnum, cursor, PageRequest.of(0, limit));
-        }
-        return entities.stream().map(PropertyMapper::toDomain).toList();
+        var spec = Specification.where(
+                        CursorSpecifications.<PropertyEntity>fieldEquals("organizationId", organizationId))
+                .and(CursorSpecifications.afterCursor(cursor))
+                .and(CursorSpecifications.searchAcrossFields(query, "name", "description", "location"))
+                .and(CursorSpecifications.fieldEquals("category", category))
+                .and(CursorSpecifications.fieldEquals("status", statusEnum));
+        var page = jpa.findAll(spec, PageRequest.of(0, limit, Sort.by("id")));
+        return page.stream().map(PropertyMapper::toDomain).toList();
     }
 }


### PR DESCRIPTION
## Summary

Closes #86.

- Added `JpaSpecificationExecutor<T>` to `JpaContactRepository`, `JpaPropertyRepository`, and `JpaMaintenanceScheduleRepository`
- Created shared `CursorSpecifications` utility with three composable builders: `afterCursor`, `fieldEquals`, and `searchAcrossFields`
- Refactored all three repository adapters to compose specifications dynamically, removing six paired JPQL query methods (three with-cursor / three without-cursor pairs)
- Property and maintenance schedule adapters chain additional `fieldEquals` specs for their optional category/status/frequency filters

## Test plan

- [ ] `./mvnw validate` passes with 0 Checkstyle violations (verified)
- [ ] Existing unit tests for use cases continue to pass (port interfaces unchanged)
- [ ] Manual smoke test: list/search contacts, properties, and maintenance schedules with and without a cursor value to confirm both code paths work via the single specification-based method

🤖 Generated with [Claude Code](https://claude.com/claude-code)