### PR TITLE
Add property transfer between organizations

### DIFF
--- a/src/main/java/com/majordomo/adapter/in/web/steward/PropertyController.java
+++ b/src/main/java/com/majordomo/adapter/in/web/steward/PropertyController.java
@@ -143,4 +143,22 @@ public class PropertyController {
         propertyUseCase.archive(id);
         return ResponseEntity.noContent().build();
     }
+
+    /**
+     * Transfers a property and all associated data to another organization.
+     * The authenticated user must be OWNER of the source organization and
+     * OWNER or ADMIN of the target organization.
+     *
+     * @param id               the UUID of the property to transfer
+     * @param toOrganizationId the UUID of the target organization
+     * @return {@code 200 OK} with the updated property
+     */
+    @PostMapping("/{id}/transfer")
+    public ResponseEntity<Property> transfer(
+            @PathVariable UUID id,
+            @RequestParam UUID toOrganizationId) {
+        UUID callerUserId = organizationAccessService.getAuthenticatedUserId();
+        var transferred = propertyUseCase.transfer(id, toOrganizationId, callerUserId);
+        return ResponseEntity.ok(transferred);
+    }
 }

--- a/src/main/java/com/majordomo/application/steward/PropertyService.java
+++ b/src/main/java/com/majordomo/application/steward/PropertyService.java
@@ -3,14 +3,21 @@ package com.majordomo.application.steward;
 import com.majordomo.domain.model.EntityNotFoundException;
 import com.majordomo.domain.model.Page;
 import com.majordomo.domain.model.event.PropertyArchived;
+import com.majordomo.domain.model.event.PropertyTransferred;
+import com.majordomo.domain.model.identity.MemberRole;
 import com.majordomo.domain.model.steward.Property;
 import com.majordomo.domain.model.steward.PropertyStatus;
 import com.majordomo.domain.port.in.steward.ManagePropertyUseCase;
 import com.majordomo.domain.port.out.EventPublisher;
+import com.majordomo.domain.port.out.herald.MaintenanceScheduleRepository;
+import com.majordomo.domain.port.out.herald.ServiceRecordRepository;
+import com.majordomo.domain.port.out.identity.MembershipRepository;
+import com.majordomo.domain.port.out.steward.PropertyContactRepository;
 import com.majordomo.domain.port.out.steward.PropertyRepository;
 
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 
 import com.majordomo.domain.model.UuidFactory;
@@ -29,17 +36,33 @@ public class PropertyService implements ManagePropertyUseCase {
 
     private final PropertyRepository propertyRepository;
     private final EventPublisher eventPublisher;
+    private final MembershipRepository membershipRepository;
+    private final PropertyContactRepository propertyContactRepository;
+    private final MaintenanceScheduleRepository maintenanceScheduleRepository;
+    private final ServiceRecordRepository serviceRecordRepository;
 
     /**
-     * Constructs the service with the property repository port.
+     * Constructs the service with required outbound ports.
      *
-     * @param propertyRepository the outbound port for property persistence
-     * @param eventPublisher     the outbound port for publishing domain events
+     * @param propertyRepository            the outbound port for property persistence
+     * @param eventPublisher                the outbound port for publishing domain events
+     * @param membershipRepository          the outbound port for membership lookup
+     * @param propertyContactRepository     the outbound port for property-contact persistence
+     * @param maintenanceScheduleRepository the outbound port for maintenance schedule persistence
+     * @param serviceRecordRepository       the outbound port for service record persistence
      */
     public PropertyService(PropertyRepository propertyRepository,
-                           EventPublisher eventPublisher) {
+                           EventPublisher eventPublisher,
+                           MembershipRepository membershipRepository,
+                           PropertyContactRepository propertyContactRepository,
+                           MaintenanceScheduleRepository maintenanceScheduleRepository,
+                           ServiceRecordRepository serviceRecordRepository) {
         this.propertyRepository = propertyRepository;
         this.eventPublisher = eventPublisher;
+        this.membershipRepository = membershipRepository;
+        this.propertyContactRepository = propertyContactRepository;
+        this.maintenanceScheduleRepository = maintenanceScheduleRepository;
+        this.serviceRecordRepository = serviceRecordRepository;
     }
 
     @Override
@@ -107,5 +130,74 @@ public class PropertyService implements ManagePropertyUseCase {
         eventPublisher.publish(new PropertyArchived(
                 existing.getId(), existing.getOrganizationId(),
                 existing.getArchivedAt()));
+    }
+
+    @Override
+    @CacheEvict(value = "properties", allEntries = true)
+    public Property transfer(UUID propertyId, UUID toOrganizationId, UUID callerUserId) {
+        var property = propertyRepository.findById(propertyId)
+                .orElseThrow(() -> new EntityNotFoundException("Property", propertyId));
+
+        UUID fromOrgId = property.getOrganizationId();
+
+        verifyCallerIsOwner(callerUserId, fromOrgId);
+        verifyCallerIsOwnerOrAdmin(callerUserId, toOrganizationId);
+
+        updateOrganization(property, toOrganizationId);
+        transferChildren(propertyId, toOrganizationId);
+
+        eventPublisher.publish(new PropertyTransferred(
+                propertyId, fromOrgId, toOrganizationId, Instant.now()));
+
+        return property;
+    }
+
+    private void verifyCallerIsOwner(UUID userId, UUID organizationId) {
+        boolean isOwner = membershipRepository.findByUserId(userId).stream()
+                .anyMatch(m -> m.getOrganizationId().equals(organizationId)
+                        && m.getRole() == MemberRole.OWNER);
+        if (!isOwner) {
+            throw new AccessDeniedException(
+                    "Caller must be OWNER of source organization: " + organizationId);
+        }
+    }
+
+    private void verifyCallerIsOwnerOrAdmin(UUID userId, UUID organizationId) {
+        boolean hasAccess = membershipRepository.findByUserId(userId).stream()
+                .anyMatch(m -> m.getOrganizationId().equals(organizationId)
+                        && (m.getRole() == MemberRole.OWNER
+                            || m.getRole() == MemberRole.ADMIN));
+        if (!hasAccess) {
+            throw new AccessDeniedException(
+                    "Caller must be OWNER or ADMIN of target organization: " + organizationId);
+        }
+    }
+
+    private void updateOrganization(Property property, UUID toOrganizationId) {
+        property.setOrganizationId(toOrganizationId);
+        property.setUpdatedAt(Instant.now());
+        propertyRepository.save(property);
+
+        for (var contact : propertyContactRepository.findByPropertyId(property.getId())) {
+            contact.setUpdatedAt(Instant.now());
+            propertyContactRepository.save(contact);
+        }
+
+        for (var schedule : maintenanceScheduleRepository.findByPropertyId(property.getId())) {
+            schedule.setUpdatedAt(Instant.now());
+            maintenanceScheduleRepository.save(schedule);
+        }
+
+        for (var record : serviceRecordRepository.findByPropertyId(property.getId())) {
+            record.setUpdatedAt(Instant.now());
+            serviceRecordRepository.save(record);
+        }
+    }
+
+    private void transferChildren(UUID parentId, UUID toOrganizationId) {
+        for (var child : propertyRepository.findByParentId(parentId)) {
+            updateOrganization(child, toOrganizationId);
+            transferChildren(child.getId(), toOrganizationId);
+        }
     }
 }

--- a/src/main/java/com/majordomo/domain/model/event/PropertyTransferred.java
+++ b/src/main/java/com/majordomo/domain/model/event/PropertyTransferred.java
@@ -1,0 +1,19 @@
+package com.majordomo.domain.model.event;
+
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * Published when a property is transferred from one organization to another.
+ *
+ * @param propertyId the ID of the transferred property
+ * @param fromOrgId  the source organization ID
+ * @param toOrgId    the target organization ID
+ * @param occurredAt when the transfer occurred
+ */
+public record PropertyTransferred(
+    UUID propertyId,
+    UUID fromOrgId,
+    UUID toOrgId,
+    Instant occurredAt
+) { }

--- a/src/main/java/com/majordomo/domain/port/in/steward/ManagePropertyUseCase.java
+++ b/src/main/java/com/majordomo/domain/port/in/steward/ManagePropertyUseCase.java
@@ -84,4 +84,16 @@ public interface ManagePropertyUseCase {
      * @param id the property ID
      */
     void archive(UUID id);
+
+    /**
+     * Transfers a property and all its associated data from its current organization
+     * to a target organization. The caller must be OWNER of the source organization
+     * and OWNER or ADMIN of the target organization.
+     *
+     * @param propertyId       the ID of the property to transfer
+     * @param toOrganizationId the target organization ID
+     * @param callerUserId     the ID of the user initiating the transfer
+     * @return the updated property with the new organization ID
+     */
+    Property transfer(UUID propertyId, UUID toOrganizationId, UUID callerUserId);
 }

--- a/src/test/java/com/majordomo/application/steward/PropertyServiceEventTest.java
+++ b/src/test/java/com/majordomo/application/steward/PropertyServiceEventTest.java
@@ -3,6 +3,10 @@ package com.majordomo.application.steward;
 import com.majordomo.domain.model.event.PropertyArchived;
 import com.majordomo.domain.model.steward.Property;
 import com.majordomo.domain.port.out.EventPublisher;
+import com.majordomo.domain.port.out.herald.MaintenanceScheduleRepository;
+import com.majordomo.domain.port.out.herald.ServiceRecordRepository;
+import com.majordomo.domain.port.out.identity.MembershipRepository;
+import com.majordomo.domain.port.out.steward.PropertyContactRepository;
 import com.majordomo.domain.port.out.steward.PropertyRepository;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -34,12 +38,26 @@ class PropertyServiceEventTest {
     @Mock
     private EventPublisher eventPublisher;
 
+    @Mock
+    private MembershipRepository membershipRepository;
+
+    @Mock
+    private PropertyContactRepository propertyContactRepository;
+
+    @Mock
+    private MaintenanceScheduleRepository maintenanceScheduleRepository;
+
+    @Mock
+    private ServiceRecordRepository serviceRecordRepository;
+
     private PropertyService propertyService;
 
     /** Sets up the service under test with mocked dependencies. */
     @BeforeEach
     void setUp() {
-        propertyService = new PropertyService(propertyRepository, eventPublisher);
+        propertyService = new PropertyService(propertyRepository, eventPublisher,
+                membershipRepository, propertyContactRepository,
+                maintenanceScheduleRepository, serviceRecordRepository);
     }
 
     /** Verifies that archive publishes a PropertyArchived event. */

--- a/src/test/java/com/majordomo/application/steward/PropertyServicePaginationTest.java
+++ b/src/test/java/com/majordomo/application/steward/PropertyServicePaginationTest.java
@@ -3,6 +3,10 @@ package com.majordomo.application.steward;
 import com.majordomo.domain.model.Page;
 import com.majordomo.domain.model.steward.Property;
 import com.majordomo.domain.port.out.EventPublisher;
+import com.majordomo.domain.port.out.herald.MaintenanceScheduleRepository;
+import com.majordomo.domain.port.out.herald.ServiceRecordRepository;
+import com.majordomo.domain.port.out.identity.MembershipRepository;
+import com.majordomo.domain.port.out.steward.PropertyContactRepository;
 import com.majordomo.domain.port.out.steward.PropertyRepository;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -32,11 +36,25 @@ class PropertyServicePaginationTest {
     @Mock
     private EventPublisher eventPublisher;
 
+    @Mock
+    private MembershipRepository membershipRepository;
+
+    @Mock
+    private PropertyContactRepository propertyContactRepository;
+
+    @Mock
+    private MaintenanceScheduleRepository maintenanceScheduleRepository;
+
+    @Mock
+    private ServiceRecordRepository serviceRecordRepository;
+
     private PropertyService propertyService;
 
     @BeforeEach
     void setUp() {
-        propertyService = new PropertyService(propertyRepository, eventPublisher);
+        propertyService = new PropertyService(propertyRepository, eventPublisher,
+                membershipRepository, propertyContactRepository,
+                maintenanceScheduleRepository, serviceRecordRepository);
     }
 
     @Test

--- a/src/test/java/com/majordomo/application/steward/PropertyServiceSearchTest.java
+++ b/src/test/java/com/majordomo/application/steward/PropertyServiceSearchTest.java
@@ -3,6 +3,10 @@ package com.majordomo.application.steward;
 import com.majordomo.domain.model.Page;
 import com.majordomo.domain.model.steward.Property;
 import com.majordomo.domain.port.out.EventPublisher;
+import com.majordomo.domain.port.out.herald.MaintenanceScheduleRepository;
+import com.majordomo.domain.port.out.herald.ServiceRecordRepository;
+import com.majordomo.domain.port.out.identity.MembershipRepository;
+import com.majordomo.domain.port.out.steward.PropertyContactRepository;
 import com.majordomo.domain.port.out.steward.PropertyRepository;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -35,11 +39,25 @@ class PropertyServiceSearchTest {
     @Mock
     private EventPublisher eventPublisher;
 
+    @Mock
+    private MembershipRepository membershipRepository;
+
+    @Mock
+    private PropertyContactRepository propertyContactRepository;
+
+    @Mock
+    private MaintenanceScheduleRepository maintenanceScheduleRepository;
+
+    @Mock
+    private ServiceRecordRepository serviceRecordRepository;
+
     private PropertyService propertyService;
 
     @BeforeEach
     void setUp() {
-        propertyService = new PropertyService(propertyRepository, eventPublisher);
+        propertyService = new PropertyService(propertyRepository, eventPublisher,
+                membershipRepository, propertyContactRepository,
+                maintenanceScheduleRepository, serviceRecordRepository);
     }
 
     @Test

--- a/src/test/java/com/majordomo/application/steward/PropertyServiceTest.java
+++ b/src/test/java/com/majordomo/application/steward/PropertyServiceTest.java
@@ -4,6 +4,10 @@ import com.majordomo.domain.model.EntityNotFoundException;
 import com.majordomo.domain.model.steward.Property;
 import com.majordomo.domain.model.steward.PropertyStatus;
 import com.majordomo.domain.port.out.EventPublisher;
+import com.majordomo.domain.port.out.herald.MaintenanceScheduleRepository;
+import com.majordomo.domain.port.out.herald.ServiceRecordRepository;
+import com.majordomo.domain.port.out.identity.MembershipRepository;
+import com.majordomo.domain.port.out.steward.PropertyContactRepository;
 import com.majordomo.domain.port.out.steward.PropertyRepository;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -33,11 +37,25 @@ class PropertyServiceTest {
     @Mock
     private EventPublisher eventPublisher;
 
+    @Mock
+    private MembershipRepository membershipRepository;
+
+    @Mock
+    private PropertyContactRepository propertyContactRepository;
+
+    @Mock
+    private MaintenanceScheduleRepository maintenanceScheduleRepository;
+
+    @Mock
+    private ServiceRecordRepository serviceRecordRepository;
+
     private PropertyService propertyService;
 
     @BeforeEach
     void setUp() {
-        propertyService = new PropertyService(propertyRepository, eventPublisher);
+        propertyService = new PropertyService(propertyRepository, eventPublisher,
+                membershipRepository, propertyContactRepository,
+                maintenanceScheduleRepository, serviceRecordRepository);
     }
 
     @Test

--- a/src/test/java/com/majordomo/application/steward/PropertyServiceTransferTest.java
+++ b/src/test/java/com/majordomo/application/steward/PropertyServiceTransferTest.java
@@ -1,0 +1,234 @@
+package com.majordomo.application.steward;
+
+import com.majordomo.domain.model.EntityNotFoundException;
+import com.majordomo.domain.model.event.PropertyTransferred;
+import com.majordomo.domain.model.herald.MaintenanceSchedule;
+import com.majordomo.domain.model.herald.ServiceRecord;
+import com.majordomo.domain.model.identity.MemberRole;
+import com.majordomo.domain.model.identity.Membership;
+import com.majordomo.domain.model.steward.Property;
+import com.majordomo.domain.model.steward.PropertyContact;
+import com.majordomo.domain.port.out.EventPublisher;
+import com.majordomo.domain.port.out.herald.MaintenanceScheduleRepository;
+import com.majordomo.domain.port.out.herald.ServiceRecordRepository;
+import com.majordomo.domain.port.out.identity.MembershipRepository;
+import com.majordomo.domain.port.out.steward.PropertyContactRepository;
+import com.majordomo.domain.port.out.steward.PropertyRepository;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import org.springframework.security.access.AccessDeniedException;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for the property transfer use case in {@link PropertyService}.
+ */
+@ExtendWith(MockitoExtension.class)
+class PropertyServiceTransferTest {
+
+    @Mock
+    private PropertyRepository propertyRepository;
+
+    @Mock
+    private EventPublisher eventPublisher;
+
+    @Mock
+    private MembershipRepository membershipRepository;
+
+    @Mock
+    private PropertyContactRepository propertyContactRepository;
+
+    @Mock
+    private MaintenanceScheduleRepository maintenanceScheduleRepository;
+
+    @Mock
+    private ServiceRecordRepository serviceRecordRepository;
+
+    private PropertyService propertyService;
+
+    private UUID propertyId;
+    private UUID fromOrgId;
+    private UUID toOrgId;
+    private UUID callerUserId;
+
+    /** Sets up the service under test with mocked dependencies. */
+    @BeforeEach
+    void setUp() {
+        propertyService = new PropertyService(propertyRepository, eventPublisher,
+                membershipRepository, propertyContactRepository,
+                maintenanceScheduleRepository, serviceRecordRepository);
+
+        propertyId = UUID.randomUUID();
+        fromOrgId = UUID.randomUUID();
+        toOrgId = UUID.randomUUID();
+        callerUserId = UUID.randomUUID();
+    }
+
+    /** Verifies a successful transfer updates the property and publishes an event. */
+    @Test
+    void transferSuccessfullyUpdatesPropertyAndPublishesEvent() {
+        var property = buildProperty(propertyId, fromOrgId);
+        when(propertyRepository.findById(propertyId)).thenReturn(Optional.of(property));
+        when(propertyRepository.save(any(Property.class)))
+                .thenAnswer(inv -> inv.getArgument(0));
+        stubOwnerOf(callerUserId, fromOrgId);
+        stubAdminOf(callerUserId, toOrgId);
+        when(propertyRepository.findByParentId(propertyId)).thenReturn(List.of());
+        when(propertyContactRepository.findByPropertyId(propertyId)).thenReturn(List.of());
+        when(maintenanceScheduleRepository.findByPropertyId(propertyId)).thenReturn(List.of());
+        when(serviceRecordRepository.findByPropertyId(propertyId)).thenReturn(List.of());
+
+        Property result = propertyService.transfer(propertyId, toOrgId, callerUserId);
+
+        assertEquals(toOrgId, result.getOrganizationId());
+        assertNotNull(result.getUpdatedAt());
+
+        ArgumentCaptor<Object> captor = ArgumentCaptor.forClass(Object.class);
+        verify(eventPublisher).publish(captor.capture());
+        var event = assertInstanceOf(PropertyTransferred.class, captor.getValue());
+        assertEquals(propertyId, event.propertyId());
+        assertEquals(fromOrgId, event.fromOrgId());
+        assertEquals(toOrgId, event.toOrgId());
+        assertNotNull(event.occurredAt());
+    }
+
+    /** Verifies that transfer also updates child properties recursively. */
+    @Test
+    void transferUpdatesChildPropertiesRecursively() {
+        var property = buildProperty(propertyId, fromOrgId);
+        UUID childId = UUID.randomUUID();
+        var child = buildProperty(childId, fromOrgId);
+
+        when(propertyRepository.findById(propertyId)).thenReturn(Optional.of(property));
+        when(propertyRepository.save(any(Property.class)))
+                .thenAnswer(inv -> inv.getArgument(0));
+        stubOwnerOf(callerUserId, fromOrgId);
+        stubAdminOf(callerUserId, toOrgId);
+
+        when(propertyRepository.findByParentId(propertyId)).thenReturn(List.of(child));
+        when(propertyRepository.findByParentId(childId)).thenReturn(List.of());
+        when(propertyContactRepository.findByPropertyId(any())).thenReturn(List.of());
+        when(maintenanceScheduleRepository.findByPropertyId(any())).thenReturn(List.of());
+        when(serviceRecordRepository.findByPropertyId(any())).thenReturn(List.of());
+
+        propertyService.transfer(propertyId, toOrgId, callerUserId);
+
+        assertEquals(toOrgId, child.getOrganizationId());
+    }
+
+    /** Verifies that transfer updates associated contacts, schedules, and service records. */
+    @Test
+    void transferUpdatesAssociatedEntities() {
+        var property = buildProperty(propertyId, fromOrgId);
+        var contact = new PropertyContact();
+        contact.setId(UUID.randomUUID());
+        var schedule = new MaintenanceSchedule();
+        schedule.setId(UUID.randomUUID());
+        var record = new ServiceRecord();
+        record.setId(UUID.randomUUID());
+
+        when(propertyRepository.findById(propertyId)).thenReturn(Optional.of(property));
+        when(propertyRepository.save(any(Property.class)))
+                .thenAnswer(inv -> inv.getArgument(0));
+        stubOwnerOf(callerUserId, fromOrgId);
+        stubAdminOf(callerUserId, toOrgId);
+
+        when(propertyRepository.findByParentId(propertyId)).thenReturn(List.of());
+        when(propertyContactRepository.findByPropertyId(propertyId)).thenReturn(List.of(contact));
+        when(maintenanceScheduleRepository.findByPropertyId(propertyId))
+                .thenReturn(List.of(schedule));
+        when(serviceRecordRepository.findByPropertyId(propertyId)).thenReturn(List.of(record));
+        when(propertyContactRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+        when(maintenanceScheduleRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+        when(serviceRecordRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        propertyService.transfer(propertyId, toOrgId, callerUserId);
+
+        verify(propertyContactRepository).save(contact);
+        verify(maintenanceScheduleRepository).save(schedule);
+        verify(serviceRecordRepository).save(record);
+    }
+
+    /** Verifies that a caller who is not OWNER of the source org gets a 403. */
+    @Test
+    void transferThrowsAccessDeniedWhenCallerNotOwnerOfSource() {
+        var property = buildProperty(propertyId, fromOrgId);
+        when(propertyRepository.findById(propertyId)).thenReturn(Optional.of(property));
+        stubMemberOf(callerUserId, fromOrgId);
+
+        assertThrows(AccessDeniedException.class,
+                () -> propertyService.transfer(propertyId, toOrgId, callerUserId));
+
+        verify(eventPublisher, never()).publish(any());
+    }
+
+    /** Verifies that a caller who is not OWNER or ADMIN of the target org gets a 403. */
+    @Test
+    void transferThrowsAccessDeniedWhenCallerNotMemberOfTarget() {
+        var property = buildProperty(propertyId, fromOrgId);
+        when(propertyRepository.findById(propertyId)).thenReturn(Optional.of(property));
+        stubOwnerOf(callerUserId, fromOrgId);
+        // No membership in target org
+        when(membershipRepository.findByUserId(callerUserId))
+                .thenReturn(List.of(new Membership(UUID.randomUUID(), callerUserId,
+                        fromOrgId, MemberRole.OWNER)));
+
+        assertThrows(AccessDeniedException.class,
+                () -> propertyService.transfer(propertyId, toOrgId, callerUserId));
+
+        verify(eventPublisher, never()).publish(any());
+    }
+
+    /** Verifies that transferring a non-existent property throws 404. */
+    @Test
+    void transferThrowsEntityNotFoundWhenPropertyMissing() {
+        when(propertyRepository.findById(propertyId)).thenReturn(Optional.empty());
+
+        assertThrows(EntityNotFoundException.class,
+                () -> propertyService.transfer(propertyId, toOrgId, callerUserId));
+
+        verify(eventPublisher, never()).publish(any());
+    }
+
+    private Property buildProperty(UUID id, UUID orgId) {
+        var property = new Property();
+        property.setId(id);
+        property.setOrganizationId(orgId);
+        property.setName("Test Property");
+        return property;
+    }
+
+    private void stubOwnerOf(UUID userId, UUID orgId) {
+        var ownerMembership = new Membership(UUID.randomUUID(), userId, orgId, MemberRole.OWNER);
+        when(membershipRepository.findByUserId(userId)).thenReturn(List.of(ownerMembership));
+    }
+
+    private void stubAdminOf(UUID userId, UUID orgId) {
+        var ownerMembership = new Membership(UUID.randomUUID(), userId, fromOrgId, MemberRole.OWNER);
+        var adminMembership = new Membership(UUID.randomUUID(), userId, orgId, MemberRole.ADMIN);
+        when(membershipRepository.findByUserId(userId))
+                .thenReturn(List.of(ownerMembership, adminMembership));
+    }
+
+    private void stubMemberOf(UUID userId, UUID orgId) {
+        var memberMembership = new Membership(UUID.randomUUID(), userId, orgId, MemberRole.MEMBER);
+        when(membershipRepository.findByUserId(userId)).thenReturn(List.of(memberMembership));
+    }
+}


### PR DESCRIPTION
## Summary

- Add `PropertyTransferred` domain event record for cross-org property transfers
- Add `transfer(propertyId, toOrganizationId, callerUserId)` to `ManagePropertyUseCase` inbound port
- Implement transfer logic in `PropertyService`: authorization checks (caller must be OWNER of source org, OWNER or ADMIN of target), recursive child property transfer, and update of all associated property contacts, maintenance schedules, and service records
- Add `POST /api/properties/{id}/transfer?toOrganizationId=` endpoint in `PropertyController`
- Add unit tests covering successful transfer, recursive child transfer, associated entity updates, caller not owner of source (403), caller not member of target (403), and property not found (404)

Closes #78

## Test plan

- [x] Successful transfer updates property organizationId and publishes PropertyTransferred event
- [x] Child properties are transferred recursively
- [x] Associated contacts, schedules, and service records are updated
- [x] Caller not OWNER of source org throws AccessDeniedException
- [x] Caller not OWNER/ADMIN of target org throws AccessDeniedException
- [x] Non-existent property throws EntityNotFoundException
- [x] Checkstyle passes (`./mvnw validate`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)