### PR TITLE
Add navigation layout with sidebar

### DIFF
--- a/src/main/resources/templates/dashboard.html
+++ b/src/main/resources/templates/dashboard.html
@@ -1,5 +1,7 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org" lang="en">
+<html xmlns:th="http://www.thymeleaf.org"
+      xmlns:sec="http://www.thymeleaf.org/extras/spring-security"
+      lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -8,27 +10,12 @@
 </head>
 <body class="bg-gray-100 min-h-screen">
 
-    <!-- Header -->
-    <nav class="bg-indigo-700 shadow-lg">
-        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-            <div class="flex items-center justify-between h-16">
-                <div class="flex items-center">
-                    <a href="/" class="text-white text-xl font-bold tracking-wide">Majordomo</a>
-                </div>
-                <div class="flex items-center space-x-4">
-                    <span class="text-indigo-200 text-sm" th:text="'Signed in as ' + ${username}">Signed in as user</span>
-                    <form th:action="@{/logout}" method="post" class="inline">
-                        <button type="submit"
-                                class="bg-indigo-600 hover:bg-indigo-500 text-white text-sm px-4 py-2 rounded-md transition">
-                            Sign out
-                        </button>
-                    </form>
-                </div>
-            </div>
-        </div>
-    </nav>
+    <div th:replace="~{fragments/header :: header}"></div>
 
-    <main class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+    <div class="flex min-h-screen">
+        <div th:replace="~{fragments/sidebar :: sidebar('dashboard')}"></div>
+
+        <main class="flex-1 p-6">
 
         <h1 class="text-2xl font-bold text-gray-900 mb-6">Dashboard</h1>
 
@@ -141,7 +128,8 @@
             </div>
         </div>
 
-    </main>
+        </main>
+    </div>
 
 </body>
 </html>

--- a/src/main/resources/templates/fragments/header.html
+++ b/src/main/resources/templates/fragments/header.html
@@ -1,0 +1,12 @@
+<header th:fragment="header"
+        xmlns:th="http://www.thymeleaf.org"
+        xmlns:sec="http://www.thymeleaf.org/extras/spring-security"
+        class="bg-indigo-600 text-white px-6 py-3 flex items-center justify-between">
+    <a th:href="@{/dashboard}" class="text-xl font-bold hover:text-indigo-200">Majordomo</a>
+    <div class="flex items-center gap-4" sec:authorize="isAuthenticated()">
+        <span sec:authentication="name" class="text-sm">User</span>
+        <form th:action="@{/logout}" method="post" class="inline">
+            <button type="submit" class="text-indigo-200 hover:text-white text-sm">Sign out</button>
+        </form>
+    </div>
+</header>

--- a/src/main/resources/templates/fragments/sidebar.html
+++ b/src/main/resources/templates/fragments/sidebar.html
@@ -1,0 +1,21 @@
+<nav th:fragment="sidebar(currentPage)"
+     xmlns:th="http://www.thymeleaf.org"
+     class="w-64 bg-white shadow-md hidden md:block shrink-0">
+    <ul class="py-4">
+        <li><a th:href="@{/dashboard}"
+               th:classappend="${currentPage == 'dashboard'} ? 'bg-indigo-50 text-indigo-600 border-l-4 border-indigo-600' : 'text-gray-700 hover:bg-gray-50'"
+               class="block px-6 py-3 font-medium">Dashboard</a></li>
+        <li><a th:href="@{/properties}"
+               th:classappend="${currentPage == 'properties'} ? 'bg-indigo-50 text-indigo-600 border-l-4 border-indigo-600' : 'text-gray-700 hover:bg-gray-50'"
+               class="block px-6 py-3 font-medium">Properties</a></li>
+        <li><a th:href="@{/contacts}"
+               th:classappend="${currentPage == 'contacts'} ? 'bg-indigo-50 text-indigo-600 border-l-4 border-indigo-600' : 'text-gray-700 hover:bg-gray-50'"
+               class="block px-6 py-3 font-medium">Contacts</a></li>
+        <li><a th:href="@{/schedules}"
+               th:classappend="${currentPage == 'schedules'} ? 'bg-indigo-50 text-indigo-600 border-l-4 border-indigo-600' : 'text-gray-700 hover:bg-gray-50'"
+               class="block px-6 py-3 font-medium">Schedules</a></li>
+        <li><a th:href="@{/ledger}"
+               th:classappend="${currentPage == 'ledger'} ? 'bg-indigo-50 text-indigo-600 border-l-4 border-indigo-600' : 'text-gray-700 hover:bg-gray-50'"
+               class="block px-6 py-3 font-medium">Ledger</a></li>
+    </ul>
+</nav>

--- a/src/main/resources/templates/home.html
+++ b/src/main/resources/templates/home.html
@@ -1,20 +1,30 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org" xmlns:sec="http://www.thymeleaf.org/extras/spring-security">
+<html xmlns:th="http://www.thymeleaf.org"
+      xmlns:sec="http://www.thymeleaf.org/extras/spring-security"
+      lang="en">
 <head>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Majordomo</title>
+    <script src="https://cdn.tailwindcss.com"></script>
 </head>
-<body>
-    <h1>Majordomo</h1>
-    <div sec:authorize="!isAuthenticated()">
-        <p><a href="/login">Sign in</a></p>
+<body class="bg-gray-100 min-h-screen">
+
+    <div th:replace="~{fragments/header :: header}"></div>
+
+    <div class="flex min-h-screen">
+        <div th:replace="~{fragments/sidebar :: sidebar('')}"></div>
+
+        <main class="flex-1 p-6">
+            <div sec:authorize="!isAuthenticated()">
+                <p><a href="/login" class="text-indigo-600 hover:underline font-medium">Sign in</a></p>
+            </div>
+            <div sec:authorize="isAuthenticated()">
+                <p class="mb-4">Welcome, <span sec:authentication="name" class="font-semibold">User</span></p>
+                <p><a th:href="@{/dashboard}" class="text-indigo-600 hover:underline font-medium">Go to Dashboard</a></p>
+            </div>
+        </main>
     </div>
-    <div sec:authorize="isAuthenticated()">
-        <p>Welcome, <span sec:authentication="name">User</span></p>
-        <p><a href="/dashboard">Go to Dashboard</a></p>
-        <form th:action="@{/logout}" method="post">
-            <button type="submit">Sign out</button>
-        </form>
-    </div>
+
 </body>
 </html>


### PR DESCRIPTION
## Summary

- Adds `fragments/header.html`: reusable top-bar fragment with Majordomo logo link and authenticated-user sign-out (Spring Security `sec:authorize`)
- Adds `fragments/sidebar.html`: reusable sidebar fragment with parameterised `currentPage` to highlight the active nav item; links to Dashboard, Properties, Contacts, Schedules, Ledger
- Updates `dashboard.html` to replace inline nav with `fragments/header` and `fragments/sidebar` (active: `'dashboard'`)
- Updates `home.html` to use the same fragments (no active item), with Tailwind CSS added

Closes #81

## Test plan

- [ ] Visit `/dashboard` — header with logo and sign-out, sidebar with Dashboard highlighted
- [ ] Visit `/` — header and sidebar rendered, no sidebar item highlighted
- [ ] On mobile (< md breakpoint) — sidebar hidden, header still visible
- [ ] Sign out button in header works (POST /logout)
- [ ] `./mvnw validate` passes with 0 Checkstyle violations

Generated with [Claude Code](https://claude.com/claude-code)