### PR TITLE
Add property detail web page

### DIFF
--- a/src/main/java/com/majordomo/adapter/in/web/steward/PropertyPageController.java
+++ b/src/main/java/com/majordomo/adapter/in/web/steward/PropertyPageController.java
@@ -1,0 +1,118 @@
+package com.majordomo.adapter.in.web.steward;
+
+import com.majordomo.domain.model.concierge.Contact;
+import com.majordomo.domain.model.steward.Property;
+import com.majordomo.domain.model.steward.PropertyContact;
+import com.majordomo.domain.port.in.ManageAttachmentUseCase;
+import com.majordomo.domain.port.in.concierge.ManageContactUseCase;
+import com.majordomo.domain.port.in.herald.ManageScheduleUseCase;
+import com.majordomo.domain.port.in.steward.ManagePropertyUseCase;
+import com.majordomo.domain.port.out.identity.MembershipRepository;
+import com.majordomo.domain.port.out.identity.UserRepository;
+import com.majordomo.domain.port.out.steward.PropertyContactRepository;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Serves the property detail web page for authenticated users.
+ *
+ * <p>Loads all data associated with a single property — child properties, linked
+ * contacts, maintenance schedules, and file attachments — and exposes it to the
+ * Thymeleaf template via the model.</p>
+ */
+@Controller
+@RequestMapping("/properties")
+public class PropertyPageController {
+
+    private final ManagePropertyUseCase propertyUseCase;
+    private final ManageScheduleUseCase scheduleUseCase;
+    private final ManageContactUseCase contactUseCase;
+    private final ManageAttachmentUseCase attachmentUseCase;
+    private final PropertyContactRepository propertyContactRepository;
+    private final UserRepository userRepository;
+    private final MembershipRepository membershipRepository;
+
+    /**
+     * Constructs the property page controller.
+     *
+     * @param propertyUseCase           the inbound port for property management
+     * @param scheduleUseCase           the inbound port for maintenance schedule management
+     * @param contactUseCase            the inbound port for contact management
+     * @param attachmentUseCase         the inbound port for attachment management
+     * @param propertyContactRepository the outbound port for property-contact associations
+     * @param userRepository            the outbound port for user lookups
+     * @param membershipRepository      the outbound port for membership lookups
+     */
+    public PropertyPageController(ManagePropertyUseCase propertyUseCase,
+                                  ManageScheduleUseCase scheduleUseCase,
+                                  ManageContactUseCase contactUseCase,
+                                  ManageAttachmentUseCase attachmentUseCase,
+                                  PropertyContactRepository propertyContactRepository,
+                                  UserRepository userRepository,
+                                  MembershipRepository membershipRepository) {
+        this.propertyUseCase = propertyUseCase;
+        this.scheduleUseCase = scheduleUseCase;
+        this.contactUseCase = contactUseCase;
+        this.attachmentUseCase = attachmentUseCase;
+        this.propertyContactRepository = propertyContactRepository;
+        this.userRepository = userRepository;
+        this.membershipRepository = membershipRepository;
+    }
+
+    /**
+     * Renders the property detail page for the given property ID.
+     *
+     * @param id        the UUID of the property to display
+     * @param principal the authenticated user
+     * @param model     the Thymeleaf model
+     * @return the property-detail template name, or a redirect if the property is not found
+     */
+    @GetMapping("/{id}")
+    public String detail(@PathVariable UUID id,
+                         @AuthenticationPrincipal UserDetails principal,
+                         Model model) {
+        var propertyOpt = propertyUseCase.findById(id);
+        if (propertyOpt.isEmpty()) {
+            return "redirect:/dashboard";
+        }
+        Property property = propertyOpt.get();
+
+        Property parent = null;
+        if (property.getParentId() != null) {
+            parent = propertyUseCase.findById(property.getParentId()).orElse(null);
+        }
+
+        List<Property> children = propertyUseCase.findByParentId(id);
+
+        List<PropertyContact> propertyContacts = propertyContactRepository.findByPropertyId(id);
+        List<Contact> contacts = propertyContacts.stream()
+                .map(pc -> contactUseCase.findById(pc.getContactId()).orElse(null))
+                .filter(c -> c != null)
+                .toList();
+
+        var schedules = scheduleUseCase.findByPropertyId(id);
+        var attachments = attachmentUseCase.list("property", id);
+
+        var user = userRepository.findByUsername(principal.getUsername()).orElseThrow();
+
+        model.addAttribute("property", property);
+        model.addAttribute("parent", parent);
+        model.addAttribute("children", children);
+        model.addAttribute("propertyContacts", propertyContacts);
+        model.addAttribute("contacts", contacts);
+        model.addAttribute("schedules", schedules);
+        model.addAttribute("attachments", attachments);
+        model.addAttribute("username", user.getUsername());
+
+        return "property-detail";
+    }
+}

--- a/src/main/resources/templates/property-detail.html
+++ b/src/main/resources/templates/property-detail.html
@@ -1,0 +1,239 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title th:text="'${property.name} - Majordomo'">Property Detail - Majordomo</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-gray-100 min-h-screen">
+
+    <!-- Header -->
+    <nav class="bg-indigo-700 shadow-lg">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="flex items-center justify-between h-16">
+                <div class="flex items-center">
+                    <a href="/" class="text-white text-xl font-bold tracking-wide">Majordomo</a>
+                </div>
+                <div class="flex items-center space-x-4">
+                    <span class="text-indigo-200 text-sm" th:text="'Signed in as ' + ${username}">Signed in as user</span>
+                    <form th:action="@{/logout}" method="post" class="inline">
+                        <button type="submit"
+                                class="bg-indigo-600 hover:bg-indigo-500 text-white text-sm px-4 py-2 rounded-md transition">
+                            Sign out
+                        </button>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </nav>
+
+    <main class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+
+        <!-- Breadcrumb -->
+        <nav class="mb-6" aria-label="Breadcrumb">
+            <ol class="flex items-center space-x-2 text-sm text-gray-500">
+                <li>
+                    <a href="/" class="hover:text-indigo-600 transition">Home</a>
+                </li>
+                <li class="flex items-center space-x-2">
+                    <span>&rsaquo;</span>
+                    <a href="/dashboard" class="hover:text-indigo-600 transition">Properties</a>
+                </li>
+                <li class="flex items-center space-x-2">
+                    <span>&rsaquo;</span>
+                    <span class="text-gray-900 font-medium" th:text="${property.name}">Property Name</span>
+                </li>
+            </ol>
+        </nav>
+
+        <!-- Property Info Card -->
+        <div class="bg-white rounded-lg shadow mb-6">
+            <div class="px-6 py-4 border-b border-gray-200 flex items-center justify-between">
+                <h1 class="text-2xl font-bold text-gray-900" th:text="${property.name}">Property Name</h1>
+                <!-- Status badge -->
+                <span th:if="${property.status != null}"
+                      th:text="${property.status}"
+                      th:classappend="${property.status.name() == 'ACTIVE'} ? 'bg-green-100 text-green-800' :
+                                     (${property.status.name() == 'IN_SERVICE'} ? 'bg-blue-100 text-blue-800' :
+                                     (${property.status.name() == 'STORED'} ? 'bg-yellow-100 text-yellow-800' :
+                                     'bg-gray-100 text-gray-800'))"
+                      class="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium">
+                </span>
+            </div>
+            <div class="p-6">
+                <p th:if="${property.description != null}" class="text-gray-600 mb-6" th:text="${property.description}"></p>
+
+                <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+
+                    <div th:if="${property.category != null}">
+                        <dt class="text-xs font-medium text-gray-500 uppercase tracking-wide">Category</dt>
+                        <dd class="mt-1 text-sm text-gray-900" th:text="${property.category}"></dd>
+                    </div>
+
+                    <div th:if="${property.location != null}">
+                        <dt class="text-xs font-medium text-gray-500 uppercase tracking-wide">Location</dt>
+                        <dd class="mt-1 text-sm text-gray-900" th:text="${property.location}"></dd>
+                    </div>
+
+                    <div th:if="${property.manufacturer != null}">
+                        <dt class="text-xs font-medium text-gray-500 uppercase tracking-wide">Manufacturer</dt>
+                        <dd class="mt-1 text-sm text-gray-900" th:text="${property.manufacturer}"></dd>
+                    </div>
+
+                    <div th:if="${property.modelNumber != null}">
+                        <dt class="text-xs font-medium text-gray-500 uppercase tracking-wide">Model Number</dt>
+                        <dd class="mt-1 text-sm text-gray-900" th:text="${property.modelNumber}"></dd>
+                    </div>
+
+                    <div th:if="${property.serialNumber != null}">
+                        <dt class="text-xs font-medium text-gray-500 uppercase tracking-wide">Serial Number</dt>
+                        <dd class="mt-1 text-sm text-gray-900" th:text="${property.serialNumber}"></dd>
+                    </div>
+
+                    <div th:if="${property.acquiredOn != null}">
+                        <dt class="text-xs font-medium text-gray-500 uppercase tracking-wide">Acquired On</dt>
+                        <dd class="mt-1 text-sm text-gray-900" th:text="${property.acquiredOn}"></dd>
+                    </div>
+
+                    <div th:if="${property.warrantyExpiresOn != null}">
+                        <dt class="text-xs font-medium text-gray-500 uppercase tracking-wide">Warranty Expires</dt>
+                        <dd class="mt-1 text-sm text-gray-900" th:text="${property.warrantyExpiresOn}"></dd>
+                    </div>
+
+                </div>
+
+                <!-- Parent property link -->
+                <div th:if="${parent != null}" class="mt-6 pt-6 border-t border-gray-100">
+                    <dt class="text-xs font-medium text-gray-500 uppercase tracking-wide mb-1">Parent Property</dt>
+                    <dd>
+                        <a th:href="@{/properties/{id}(id=${parent.id})}"
+                           th:text="${parent.name}"
+                           class="text-indigo-600 hover:text-indigo-800 text-sm font-medium transition">
+                        </a>
+                    </dd>
+                </div>
+
+                <!-- Child properties -->
+                <div th:if="${!#lists.isEmpty(children)}" class="mt-6 pt-6 border-t border-gray-100">
+                    <dt class="text-xs font-medium text-gray-500 uppercase tracking-wide mb-2">Child Properties</dt>
+                    <dd>
+                        <ul class="space-y-1">
+                            <li th:each="child : ${children}">
+                                <a th:href="@{/properties/{id}(id=${child.id})}"
+                                   th:text="${child.name}"
+                                   class="text-indigo-600 hover:text-indigo-800 text-sm font-medium transition">
+                                </a>
+                            </li>
+                        </ul>
+                    </dd>
+                </div>
+
+            </div>
+        </div>
+
+        <!-- Linked Contacts -->
+        <div class="bg-white rounded-lg shadow mb-6">
+            <div class="px-6 py-4 border-b border-gray-200">
+                <h2 class="text-lg font-semibold text-gray-900">Linked Contacts</h2>
+            </div>
+            <div class="p-6">
+                <p th:if="${#lists.isEmpty(contacts)}" class="text-gray-400 text-sm">No contacts linked to this property.</p>
+                <div th:unless="${#lists.isEmpty(contacts)}" class="overflow-x-auto">
+                    <table class="min-w-full divide-y divide-gray-200">
+                        <thead class="bg-gray-50">
+                            <tr>
+                                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Name</th>
+                                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Role</th>
+                                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Email</th>
+                                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Phone</th>
+                            </tr>
+                        </thead>
+                        <tbody class="bg-white divide-y divide-gray-200">
+                            <tr th:each="contact, iterStat : ${contacts}">
+                                <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900"
+                                    th:text="${contact.formattedName}">Contact Name</td>
+                                <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-600">
+                                    <span th:if="${propertyContacts[iterStat.index].role != null}"
+                                          th:text="${propertyContacts[iterStat.index].role}"></span>
+                                    <span th:unless="${propertyContacts[iterStat.index].role != null}" class="text-gray-400">—</span>
+                                </td>
+                                <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-600">
+                                    <span th:if="${!#lists.isEmpty(contact.emails)}" th:text="${contact.emails[0]}"></span>
+                                    <span th:if="${#lists.isEmpty(contact.emails)}" class="text-gray-400">—</span>
+                                </td>
+                                <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-600">
+                                    <span th:if="${!#lists.isEmpty(contact.telephones)}" th:text="${contact.telephones[0]}"></span>
+                                    <span th:if="${#lists.isEmpty(contact.telephones)}" class="text-gray-400">—</span>
+                                </td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+
+        <!-- Maintenance Schedules -->
+        <div class="bg-white rounded-lg shadow mb-6">
+            <div class="px-6 py-4 border-b border-gray-200">
+                <h2 class="text-lg font-semibold text-gray-900">Maintenance Schedules</h2>
+            </div>
+            <div class="p-6">
+                <p th:if="${#lists.isEmpty(schedules)}" class="text-gray-400 text-sm">No maintenance schedules for this property.</p>
+                <div th:unless="${#lists.isEmpty(schedules)}" class="overflow-x-auto">
+                    <table class="min-w-full divide-y divide-gray-200">
+                        <thead class="bg-gray-50">
+                            <tr>
+                                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Description</th>
+                                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Frequency</th>
+                                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Next Due</th>
+                            </tr>
+                        </thead>
+                        <tbody class="bg-white divide-y divide-gray-200">
+                            <tr th:each="schedule : ${schedules}">
+                                <td class="px-6 py-4 text-sm text-gray-900" th:text="${schedule.description}">Task</td>
+                                <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-600" th:text="${schedule.frequency}">Frequency</td>
+                                <td class="px-6 py-4 whitespace-nowrap text-sm"
+                                    th:classappend="${#temporals.createToday().isAfter(schedule.nextDue)} ? 'text-red-600 font-semibold' :
+                                                   (${#temporals.createToday().plusDays(7).isAfter(schedule.nextDue)} ? 'text-yellow-600 font-medium' : 'text-gray-700')"
+                                    th:text="${schedule.nextDue}">
+                                </td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+
+        <!-- Attachments -->
+        <div class="bg-white rounded-lg shadow mb-6">
+            <div class="px-6 py-4 border-b border-gray-200">
+                <h2 class="text-lg font-semibold text-gray-900">Attachments</h2>
+            </div>
+            <div class="p-6">
+                <p th:if="${#lists.isEmpty(attachments)}" class="text-gray-400 text-sm">No attachments for this property.</p>
+                <ul th:unless="${#lists.isEmpty(attachments)}" class="divide-y divide-gray-100">
+                    <li th:each="attachment : ${attachments}" class="flex items-center justify-between py-3">
+                        <div class="flex items-center space-x-3 min-w-0">
+                            <div class="min-w-0">
+                                <p class="text-sm font-medium text-gray-900 truncate" th:text="${attachment.filename}">filename.pdf</p>
+                                <p class="text-xs text-gray-500">
+                                    <span th:text="${attachment.contentType}">application/pdf</span>
+                                    &middot;
+                                    <span th:text="${#numbers.formatDecimal(attachment.sizeBytes / 1024.0, 1, 1)} + ' KB'">0 KB</span>
+                                </p>
+                            </div>
+                        </div>
+                        <a th:href="@{/api/attachments/{id}(id=${attachment.id})}"
+                           class="ml-4 text-sm text-indigo-600 hover:text-indigo-800 font-medium transition whitespace-nowrap">
+                            Download
+                        </a>
+                    </li>
+                </ul>
+            </div>
+        </div>
+
+    </main>
+
+</body>
+</html>

--- a/src/test/java/com/majordomo/adapter/in/web/steward/PropertyPageControllerTest.java
+++ b/src/test/java/com/majordomo/adapter/in/web/steward/PropertyPageControllerTest.java
@@ -1,0 +1,180 @@
+package com.majordomo.adapter.in.web.steward;
+
+import com.majordomo.domain.model.concierge.Contact;
+import com.majordomo.domain.model.identity.User;
+import com.majordomo.domain.model.steward.Property;
+import com.majordomo.domain.model.steward.PropertyContact;
+import com.majordomo.domain.model.steward.PropertyStatus;
+import com.majordomo.domain.port.in.ManageAttachmentUseCase;
+import com.majordomo.domain.port.in.concierge.ManageContactUseCase;
+import com.majordomo.domain.port.in.herald.ManageScheduleUseCase;
+import com.majordomo.domain.port.in.steward.ManagePropertyUseCase;
+import com.majordomo.domain.port.out.identity.MembershipRepository;
+import com.majordomo.domain.port.out.identity.UserRepository;
+import com.majordomo.domain.port.out.steward.PropertyContactRepository;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.model;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
+
+/**
+ * Tests for {@link PropertyPageController}.
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+class PropertyPageControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private ManagePropertyUseCase propertyUseCase;
+
+    @MockitoBean
+    private ManageScheduleUseCase scheduleUseCase;
+
+    @MockitoBean
+    private ManageContactUseCase contactUseCase;
+
+    @MockitoBean
+    private ManageAttachmentUseCase attachmentUseCase;
+
+    @MockitoBean
+    private PropertyContactRepository propertyContactRepository;
+
+    @MockitoBean
+    private UserRepository userRepository;
+
+    @MockitoBean
+    private MembershipRepository membershipRepository;
+
+    /** Authenticated user requesting an existing property receives 200 and the detail view. */
+    @Test
+    @WithMockUser(username = "testuser")
+    void detailReturns200ForAuthenticatedUser() throws Exception {
+        UUID propertyId = UUID.randomUUID();
+
+        Property property = new Property();
+        property.setId(propertyId);
+        property.setName("Test Property");
+        property.setStatus(PropertyStatus.ACTIVE);
+
+        User user = new User(UUID.randomUUID(), "testuser", "test@example.com");
+
+        when(propertyUseCase.findById(propertyId)).thenReturn(Optional.of(property));
+        when(propertyUseCase.findByParentId(propertyId)).thenReturn(List.of());
+        when(propertyContactRepository.findByPropertyId(propertyId)).thenReturn(List.of());
+        when(scheduleUseCase.findByPropertyId(propertyId)).thenReturn(List.of());
+        when(attachmentUseCase.list("property", propertyId)).thenReturn(List.of());
+        when(userRepository.findByUsername("testuser")).thenReturn(Optional.of(user));
+
+        mockMvc.perform(get("/properties/{id}", propertyId))
+                .andExpect(status().isOk())
+                .andExpect(view().name("property-detail"))
+                .andExpect(model().attributeExists("property"))
+                .andExpect(model().attributeExists("username"));
+    }
+
+    /** Unauthenticated access to the property detail page redirects to login. */
+    @Test
+    void detailRequiresAuthentication() throws Exception {
+        UUID propertyId = UUID.randomUUID();
+
+        mockMvc.perform(get("/properties/{id}", propertyId))
+                .andExpect(status().is3xxRedirection());
+    }
+
+    /** Requesting a non-existent property redirects to the dashboard. */
+    @Test
+    @WithMockUser(username = "testuser")
+    void detailRedirectsWhenPropertyNotFound() throws Exception {
+        UUID propertyId = UUID.randomUUID();
+
+        when(propertyUseCase.findById(propertyId)).thenReturn(Optional.empty());
+
+        mockMvc.perform(get("/properties/{id}", propertyId))
+                .andExpect(status().is3xxRedirection());
+    }
+
+    /** Property with a parent loads the parent and adds it to the model. */
+    @Test
+    @WithMockUser(username = "testuser")
+    void detailLoadsParentProperty() throws Exception {
+        UUID parentId = UUID.randomUUID();
+        UUID propertyId = UUID.randomUUID();
+
+        Property parent = new Property();
+        parent.setId(parentId);
+        parent.setName("Parent Property");
+
+        Property property = new Property();
+        property.setId(propertyId);
+        property.setName("Child Property");
+        property.setParentId(parentId);
+
+        User user = new User(UUID.randomUUID(), "testuser", "test@example.com");
+
+        when(propertyUseCase.findById(propertyId)).thenReturn(Optional.of(property));
+        when(propertyUseCase.findById(parentId)).thenReturn(Optional.of(parent));
+        when(propertyUseCase.findByParentId(propertyId)).thenReturn(List.of());
+        when(propertyContactRepository.findByPropertyId(propertyId)).thenReturn(List.of());
+        when(scheduleUseCase.findByPropertyId(propertyId)).thenReturn(List.of());
+        when(attachmentUseCase.list("property", propertyId)).thenReturn(List.of());
+        when(userRepository.findByUsername("testuser")).thenReturn(Optional.of(user));
+
+        mockMvc.perform(get("/properties/{id}", propertyId))
+                .andExpect(status().isOk())
+                .andExpect(view().name("property-detail"))
+                .andExpect(model().attributeExists("parent"));
+    }
+
+    /** Property with linked contacts adds contacts and propertyContacts to the model. */
+    @Test
+    @WithMockUser(username = "testuser")
+    void detailLoadsLinkedContacts() throws Exception {
+        UUID propertyId = UUID.randomUUID();
+        UUID contactId = UUID.randomUUID();
+
+        Property property = new Property();
+        property.setId(propertyId);
+        property.setName("Test Property");
+
+        PropertyContact pc = new PropertyContact();
+        pc.setId(UUID.randomUUID());
+        pc.setPropertyId(propertyId);
+        pc.setContactId(contactId);
+
+        Contact contact = new Contact();
+        contact.setId(contactId);
+        contact.setFormattedName("Acme Plumbing");
+
+        User user = new User(UUID.randomUUID(), "testuser", "test@example.com");
+
+        when(propertyUseCase.findById(propertyId)).thenReturn(Optional.of(property));
+        when(propertyUseCase.findByParentId(propertyId)).thenReturn(List.of());
+        when(propertyContactRepository.findByPropertyId(propertyId)).thenReturn(List.of(pc));
+        when(contactUseCase.findById(contactId)).thenReturn(Optional.of(contact));
+        when(scheduleUseCase.findByPropertyId(propertyId)).thenReturn(List.of());
+        when(attachmentUseCase.list("property", propertyId)).thenReturn(List.of());
+        when(userRepository.findByUsername("testuser")).thenReturn(Optional.of(user));
+
+        mockMvc.perform(get("/properties/{id}", propertyId))
+                .andExpect(status().isOk())
+                .andExpect(model().attributeExists("contacts"))
+                .andExpect(model().attributeExists("propertyContacts"));
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `PropertyPageController` (`GET /properties/{id}`) in the `steward` web adapter package; injects `ManagePropertyUseCase`, `ManageScheduleUseCase`, `ManageContactUseCase`, `ManageAttachmentUseCase`, `PropertyContactRepository`, `UserRepository`, and `MembershipRepository`
- Creates `property-detail.html` Thymeleaf template with Tailwind CSS (CDN): indigo header matching the dashboard, breadcrumb, property info card with status badge (green/blue/yellow/grey by status), optional parent link and child property list, linked contacts table, maintenance schedules table with red/yellow next-due colouring, and attachments list with download links
- Adds `PropertyPageControllerTest` with 5 tests covering: 200 for authenticated user, 3xx for unauthenticated, redirect when property not found, parent property loading, and linked contacts loading

## Test plan

- [ ] `./mvnw validate` passes (0 Checkstyle violations)
- [ ] `PropertyPageControllerTest` — 5 tests, 0 failures
- [ ] GET `/properties/{id}` returns 200 with `property-detail` view and all expected model attributes
- [ ] Unauthenticated request to `/properties/{id}` redirects to login
- [ ] Unknown property ID redirects to `/dashboard`

Closes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)