### PR TITLE
fix: add @ActiveProfiles("test") to MajordomoApplicationTests

### DIFF
--- a/src/test/java/com/majordomo/MajordomoApplicationTests.java
+++ b/src/test/java/com/majordomo/MajordomoApplicationTests.java
@@ -2,8 +2,10 @@ package com.majordomo;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@ActiveProfiles("test")
 class MajordomoApplicationTests {
 
     @Test


### PR DESCRIPTION
Closes #123.

## Summary
\`MajordomoApplicationTests\` had no \`@ActiveProfiles\` and relied on the test classpath ordering to override the prod \`application.yml\` datasource. That's fragile — a stale \`target/classes/application.properties\` (from an older build, no longer in \`src/\`) was silently overriding both yml files and pinning the URL to \`jdbc:postgresql://localhost:5432/majordomo\`, causing \`./mvnw test\` to fail without a running Postgres.

This PR:
- Adds \`@ActiveProfiles("test")\` so the test's intent is explicit (matches the \`@ActiveProfiles("integration")\` convention used by \`@IntegrationTest\`).

Note: \`./mvnw clean test\` would also have fixed it, since the \`application.properties\` isn't regenerated. Making the annotation explicit is still worth doing — it's stable against future config additions (e.g. \`application-prod.yml\`) and matches repo conventions.

## Test plan
- [x] \`./mvnw clean test\` → 212 tests, 0 failures, no Postgres running
- [x] \`./mvnw test\` → 212 tests, 0 failures (after clean)