### PR TITLE
build: bump ArchUnit to 1.4.1, fix violations exposed by re-enabled rules

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -165,7 +165,7 @@
         <dependency>
             <groupId>com.tngtech.archunit</groupId>
             <artifactId>archunit-junit5</artifactId>
-            <version>1.3.0</version>
+            <version>1.4.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/main/java/com/majordomo/adapter/out/ingest/ManualPasteSource.java
+++ b/src/main/java/com/majordomo/adapter/out/ingest/ManualPasteSource.java
@@ -2,6 +2,7 @@ package com.majordomo.adapter.out.ingest;
 
 import com.majordomo.domain.model.envoy.JobPosting;
 import com.majordomo.domain.model.envoy.JobSourceRequest;
+import com.majordomo.domain.port.out.envoy.JobSource;
 import org.springframework.stereotype.Component;
 
 import java.time.Instant;

--- a/src/main/java/com/majordomo/application/envoy/JobIngestionService.java
+++ b/src/main/java/com/majordomo/application/envoy/JobIngestionService.java
@@ -1,6 +1,6 @@
 package com.majordomo.application.envoy;
 
-import com.majordomo.adapter.out.ingest.JobSource;
+import com.majordomo.domain.port.out.envoy.JobSource;
 import com.majordomo.domain.model.UuidFactory;
 import com.majordomo.domain.model.envoy.JobPosting;
 import com.majordomo.domain.model.envoy.JobSourceRequest;

--- a/src/main/java/com/majordomo/application/envoy/JobScorerService.java
+++ b/src/main/java/com/majordomo/application/envoy/JobScorerService.java
@@ -22,7 +22,7 @@ import java.util.UUID;
  * interpretive choices.
  */
 @Service
-public class JobScorer implements ScoreJobPostingUseCase {
+public class JobScorerService implements ScoreJobPostingUseCase {
 
     private final RubricRepository rubrics;
     private final JobPostingRepository postings;
@@ -39,7 +39,7 @@ public class JobScorer implements ScoreJobPostingUseCase {
      * @param llm       outbound LLM scoring port
      * @param assembler deterministic LLM-response validator
      */
-    public JobScorer(RubricRepository rubrics,
+    public JobScorerService(RubricRepository rubrics,
                      JobPostingRepository postings,
                      ScoreReportRepository reports,
                      LlmScoringPort llm,

--- a/src/main/java/com/majordomo/domain/port/out/envoy/JobSource.java
+++ b/src/main/java/com/majordomo/domain/port/out/envoy/JobSource.java
@@ -1,4 +1,4 @@
-package com.majordomo.adapter.out.ingest;
+package com.majordomo.domain.port.out.envoy;
 
 import com.majordomo.domain.model.envoy.JobPosting;
 import com.majordomo.domain.model.envoy.JobSourceRequest;

--- a/src/test/java/com/majordomo/application/envoy/JobIngestionServiceTest.java
+++ b/src/test/java/com/majordomo/application/envoy/JobIngestionServiceTest.java
@@ -1,6 +1,6 @@
 package com.majordomo.application.envoy;
 
-import com.majordomo.adapter.out.ingest.JobSource;
+import com.majordomo.domain.port.out.envoy.JobSource;
 import com.majordomo.domain.model.UuidFactory;
 import com.majordomo.domain.model.envoy.JobPosting;
 import com.majordomo.domain.model.envoy.JobSourceRequest;

--- a/src/test/java/com/majordomo/application/envoy/JobScorerServiceTest.java
+++ b/src/test/java/com/majordomo/application/envoy/JobScorerServiceTest.java
@@ -31,14 +31,14 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
-class JobScorerTest {
+class JobScorerServiceTest {
 
     @Mock RubricRepository rubrics;
     @Mock JobPostingRepository postings;
     @Mock ScoreReportRepository reports;
     @Mock LlmScoringPort llm;
 
-    private JobScorer scorer;
+    private JobScorerService scorer;
     private final UUID orgId = UuidFactory.newId();
 
     private Rubric rubric;
@@ -46,7 +46,7 @@ class JobScorerTest {
 
     @BeforeEach
     void setUp() {
-        scorer = new JobScorer(rubrics, postings, reports, llm, new ScoreAssembler());
+        scorer = new JobScorerService(rubrics, postings, reports, llm, new ScoreAssembler());
         rubric = new Rubric(UuidFactory.newId(), Optional.empty(), 1, "default",
                 List.of(),
                 List.of(new Category("compensation", "pay", 20,

--- a/src/test/java/com/majordomo/architecture/HexagonalArchitectureTest.java
+++ b/src/test/java/com/majordomo/architecture/HexagonalArchitectureTest.java
@@ -1,8 +1,11 @@
 package com.majordomo.architecture;
 
-import com.tngtech.archunit.junit.AnalyzeClasses;
-import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import com.tngtech.archunit.core.importer.ImportOption;
 import com.tngtech.archunit.lang.ArchRule;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
 import static com.tngtech.archunit.library.dependencies.SlicesRuleDefinition.slices;
@@ -10,44 +13,74 @@ import static com.tngtech.archunit.library.dependencies.SlicesRuleDefinition.sli
 /**
  * ArchUnit tests enforcing hexagonal architecture boundaries.
  * Violations fail the build.
+ *
+ * <p>Uses plain JUnit Jupiter {@code @Test} methods rather than ArchUnit's
+ * {@code @ArchTest} static-field discovery, which Surefire was silently
+ * skipping (see issue #122).</p>
  */
-@AnalyzeClasses(packages = "com.majordomo")
 class HexagonalArchitectureTest {
 
+    private static JavaClasses classes;
+
+    @BeforeAll
+    static void importClasses() {
+        classes = new ClassFileImporter()
+                .withImportOption(new ImportOption.DoNotIncludeTests())
+                .importPackages("com.majordomo");
+    }
+
     /** Domain model must not depend on Spring framework. */
-    @ArchTest
-    static final ArchRule DOMAIN_MODEL_NO_SPRING = noClasses()
-            .that().resideInAPackage("..domain.model..")
-            .should().dependOnClassesThat().resideInAPackage("org.springframework..");
+    @Test
+    void domainModelHasNoSpringDependency() {
+        ArchRule rule = noClasses()
+                .that().resideInAPackage("..domain.model..")
+                .should().dependOnClassesThat().resideInAPackage("org.springframework..");
+        rule.check(classes);
+    }
 
     /** Domain model must not depend on JPA/Hibernate. */
-    @ArchTest
-    static final ArchRule DOMAIN_MODEL_NO_JPA = noClasses()
-            .that().resideInAPackage("..domain.model..")
-            .should().dependOnClassesThat().resideInAnyPackage(
-                    "jakarta.persistence..", "org.hibernate..");
+    @Test
+    void domainModelHasNoJpaDependency() {
+        ArchRule rule = noClasses()
+                .that().resideInAPackage("..domain.model..")
+                .should().dependOnClassesThat().resideInAnyPackage(
+                        "jakarta.persistence..", "org.hibernate..");
+        rule.check(classes);
+    }
 
     /** Domain ports must not depend on adapter packages. */
-    @ArchTest
-    static final ArchRule DOMAIN_PORTS_NO_ADAPTERS = noClasses()
-            .that().resideInAPackage("..domain.port..")
-            .should().dependOnClassesThat().resideInAPackage("..adapter..");
+    @Test
+    void domainPortsHaveNoAdapterDependency() {
+        ArchRule rule = noClasses()
+                .that().resideInAPackage("..domain.port..")
+                .should().dependOnClassesThat().resideInAPackage("..adapter..");
+        rule.check(classes);
+    }
 
     /** Application services must not depend on adapter packages. */
-    @ArchTest
-    static final ArchRule APPLICATION_NO_ADAPTERS = noClasses()
-            .that().resideInAPackage("..application..")
-            .should().dependOnClassesThat().resideInAPackage("..adapter..");
+    @Test
+    void applicationHasNoAdapterDependency() {
+        ArchRule rule = noClasses()
+                .that().resideInAPackage("..application..")
+                .should().dependOnClassesThat().resideInAPackage("..adapter..");
+        rule.check(classes);
+    }
 
     /** Persistence adapters must not depend on inbound adapters. */
-    @ArchTest
-    static final ArchRule ADAPTERS_NO_CROSS_REFERENCE = noClasses()
-            .that().resideInAPackage("..adapter.out..")
-            .should().dependOnClassesThat().resideInAPackage("..adapter.in..");
+    @Test
+    void outboundAdaptersHaveNoInboundDependency() {
+        ArchRule rule = noClasses()
+                .that().resideInAPackage("..adapter.out..")
+                .should().dependOnClassesThat().resideInAPackage("..adapter.in..");
+        rule.check(classes);
+    }
 
     /** No circular dependencies between top-level slices. */
-    @ArchTest
-    static final ArchRule NO_CYCLIC_DEPENDENCIES = slices()
-            .matching("com.majordomo.(*)..")
-            .should().beFreeOfCycles();
+    @Test
+    void slicesAreFreeOfCycles() {
+        ArchRule rule = slices()
+                .matching("com.majordomo.(*)..")
+                .should().beFreeOfCycles();
+        rule.check(classes);
+    }
 }

--- a/src/test/java/com/majordomo/architecture/NamingConventionTest.java
+++ b/src/test/java/com/majordomo/architecture/NamingConventionTest.java
@@ -1,20 +1,44 @@
 package com.majordomo.architecture;
 
-import com.tngtech.archunit.junit.AnalyzeClasses;
-import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import com.tngtech.archunit.core.importer.ImportOption;
 import com.tngtech.archunit.lang.ArchRule;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
 
 /**
  * ArchUnit tests enforcing naming conventions across the codebase.
+ *
+ * <p>Uses plain JUnit Jupiter {@code @Test} methods rather than ArchUnit's
+ * {@code @ArchTest} static-field discovery, which Surefire was silently
+ * skipping (see issue #122).</p>
  */
-@AnalyzeClasses(packages = "com.majordomo")
 class NamingConventionTest {
 
-    /** Application service classes should end with Service. */
-    @ArchTest
-    static final ArchRule APPLICATION_CLASSES_NAMED_SERVICE = classes()
-            .that().resideInAPackage("..application..")
-            .should().haveSimpleNameEndingWith("Service");
+    private static JavaClasses classes;
+
+    @BeforeAll
+    static void importClasses() {
+        classes = new ClassFileImporter()
+                .withImportOption(new ImportOption.DoNotIncludeTests())
+                .importPackages("com.majordomo");
+    }
+
+    /**
+     * Spring {@code @Service}-annotated classes in {@code ..application..}
+     * should end with {@code Service}. Helper classes (assemblers, builders,
+     * scorers), exceptions, value records, and tests don't carry the
+     * annotation and are correctly excluded.
+     */
+    @Test
+    void applicationServicesEndWithService() {
+        ArchRule rule = classes()
+                .that().resideInAPackage("..application..")
+                .and().areAnnotatedWith("org.springframework.stereotype.Service")
+                .should().haveSimpleNameEndingWith("Service");
+        rule.check(classes);
+    }
 }


### PR DESCRIPTION
Closes #122.

## Summary

ArchUnit 1.3.0 couldn't read Java 25 bytecode (\"Unsupported class file major version 69\"), so every \`HexagonalArchitectureTest\` and \`NamingConventionTest\` run quietly reported \`Tests run: 0\` — the architecture fitness functions weren't enforcing anything. Bumping to 1.4.1 fixes the bytecode read.

That uncovered a second issue: even on 1.4.1, Surefire's JUnit Platform integration silently skips ArchUnit's \`@ArchTest\` static-field discovery. Tried explicit \`<includeJUnit5Engines>archunit</includeJUnit5Engines>\` — no effect. Pivoted: rewrote the tests to use plain JUnit Jupiter \`@Test\` methods that import classes once in \`@BeforeAll\` and call \`rule.check(classes)\`. Same enforcement, no engine-discovery dependency.

Once the rules actually ran they caught **3 real violations**:

1. **\`JobSource\` interface lived in \`adapter.out.ingest\`** but is a true outbound port (the application service depends on it). Moved to \`domain.port.out.envoy.JobSource\`.
2. **Cycle adapter → application → adapter** — caused by #1; resolved by the move.
3. **\`NamingConventionTest\` was too broad** — required every class in \`..application..\` to end with \`Service\`, flagging 35 classes (every \`*Test\`, \`JobScorer\`, \`ScoreAssembler\`, \`PromptBuilder\`, \`ScoringPrompt\`, \`LlmScoringException\`, etc.). Tightened to only require \`@Service\`-annotated classes to end with \`Service\`. Fixed the one real violation: renamed \`JobScorer\` → \`JobScorerService\` for consistency with the rest of the application layer.

Also added \`new ImportOption.DoNotIncludeTests()\` to both arch tests so test-only \`@TestConfiguration\` helpers don't trigger production-code rules.

## Why \`@Test\` methods over \`@ArchTest\`

The \`@ArchTest\` field-style requires the \`archunit-junit5-engine\` to be picked up by JUnit Platform via Surefire. That handshake intermittently fails (still failing here on 1.4.1 + Surefire 3.5.3 on Java 25). Plain \`@Test\` methods skip that machinery entirely and produce identical enforcement. Trade-off: a couple extra lines per rule, but the rules actually run.

## Test plan

- [x] \`./mvnw test\` → 219 tests, 0 failures (was 212; 7 new arch tests now actually executing)
- [x] Both \`HexagonalArchitectureTest\` and \`NamingConventionTest\` report non-zero \`Tests run\` in surefire output
- [x] Deliberate violation: confirmed \`importing org.springframework.* into domain/model/\` fails the build (test removed before commit)