### PR TITLE
build: bump testcontainers to 1.21.3, pass Docker env to surefire

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
             <dependency>
                 <groupId>org.testcontainers</groupId>
                 <artifactId>testcontainers-bom</artifactId>
-                <version>1.20.4</version>
+                <version>1.21.3</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -236,7 +236,12 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration combine.self="override"/>
+                        <configuration combine.self="override">
+                            <environmentVariables>
+                                <DOCKER_HOST>${env.DOCKER_HOST}</DOCKER_HOST>
+                                <TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE>${env.TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE}</TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE>
+                            </environmentVariables>
+                        </configuration>
                     </plugin>
                 </plugins>
             </build>


### PR DESCRIPTION
Refs #124 — partial fix.

## Summary

- Bumped \`testcontainers-bom\` from 1.20.4 → 1.21.3 (pulls in docker-java 3.4.2)
- Wired \`DOCKER_HOST\` and \`TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE\` env passthrough into the \`integration-tests\` Surefire profile, so a developer who exports them in their shell actually has them reach the forked test JVM

## Honest caveat

The newer Testcontainers does **not** fully resolve the Docker Desktop 4.6x discovery issue described in #124. With Docker engine running and \`DOCKER_HOST=unix:///Users/.../.docker/run/docker.sock\` set, all three discovery strategies (\`EnvironmentAndSystemPropertyClientProviderStrategy\`, \`UnixSocketClientProviderStrategy\`, \`DockerDesktopClientProviderStrategy\`) still get back an empty \`/info\` body that docker-java rejects as 400 — even though \`curl --unix-socket\` against the same path returns a valid response. The body Testcontainers receives is essentially a Docker Desktop CLI-proxy redirect (\`Labels: ["com.docker.desktop.address=...docker-cli.sock"]\`), not the engine \`/info\` payload.

This is upstream behaviour in docker-java's response parsing combined with Docker Desktop 4.6x's socket layout, not something a Testcontainers minor bump fixes. Worth landing this PR anyway because:
1. Other Testcontainers fixes between 1.20.4 → 1.21.3 are useful
2. Without env passthrough, even a future fix wouldn't help — surefire forks weren't inheriting \`DOCKER_HOST\` reliably

## What still works
- \`./mvnw test\` (default profile, no integration tests) → 219/219 pass — unaffected
- \`./mvnw verify -P integration-tests\` on a host where docker-java's strategies actually succeed (Docker Desktop &lt; 4.6x, Colima, OrbStack, or a non-macOS Docker engine) — should pass

## Follow-up

Leaving #124 open for the upstream resolution. Possible next steps once docker-java ships a fix or Testcontainers adds a Docker-Desktop-4.6x-aware strategy: re-bump, then close.

## Test plan
- [x] \`./mvnw test\` — 219 tests, 0 failures
- [ ] \`./mvnw verify -P integration-tests\` on a working Docker setup (not validated locally — Docker Desktop 4.6x is broken on the dev machine)