### PR TITLE
fix: treat NoResourceFoundException as 404 + DEBUG, closes #127

### DIFF
--- a/src/main/java/com/majordomo/adapter/in/web/config/GlobalExceptionHandler.java
+++ b/src/main/java/com/majordomo/adapter/in/web/config/GlobalExceptionHandler.java
@@ -11,6 +11,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
 
 import org.springframework.security.access.AccessDeniedException;
 import java.time.Instant;
@@ -78,6 +79,22 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ErrorResponse> handleAccessDenied(
             AccessDeniedException ex, HttpServletRequest request) {
         return buildResponse(HttpStatus.FORBIDDEN, ex.getMessage(), request);
+    }
+
+    /**
+     * Handles missing static resources (e.g. browser-requested {@code /favicon.ico},
+     * mistyped URLs, bot probes). Returns 404 and logs at DEBUG so these don't
+     * fill the log with stack traces from the catch-all handler below.
+     *
+     * @param ex      the exception
+     * @param request the HTTP request
+     * @return 404 response with a generic message
+     */
+    @ExceptionHandler(NoResourceFoundException.class)
+    public ResponseEntity<ErrorResponse> handleResourceNotFound(
+            NoResourceFoundException ex, HttpServletRequest request) {
+        LOG.debug("Resource not found: {}", request.getRequestURI());
+        return buildResponse(HttpStatus.NOT_FOUND, "Resource not found", request);
     }
 
     /**

--- a/src/test/java/com/majordomo/adapter/in/web/config/GlobalExceptionHandlerTest.java
+++ b/src/test/java/com/majordomo/adapter/in/web/config/GlobalExceptionHandlerTest.java
@@ -84,4 +84,15 @@ class GlobalExceptionHandlerTest {
                 .andExpect(status().isInternalServerError())
                 .andExpect(jsonPath("$.message").value("An unexpected error occurred"));
     }
+
+    /** Missing static resource returns 404, not 500. Regression for #127. */
+    @Test
+    @WithMockUser
+    void missingResourceReturns404() throws Exception {
+        mockMvc.perform(get("/favicon.ico"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.status").value(404))
+                .andExpect(jsonPath("$.error").value("Not Found"))
+                .andExpect(jsonPath("$.message").value("Resource not found"));
+    }
 }


### PR DESCRIPTION
Closes #127.

## Summary

Add a dedicated \`@ExceptionHandler(NoResourceFoundException.class)\` to \`GlobalExceptionHandler\` so missing static resources (e.g. browser-requested \`/favicon.ico\`, mistyped URLs, bot probes) return **404** and log a single **DEBUG** line with just the URI — instead of falling through to the generic \`Exception\` handler that returned 500 with a multi-frame stack trace.

Before:
\`\`\`
ERROR c.m.a.i.w.c.GlobalExceptionHandler - Unhandled exception on /favicon.ico
org.springframework.web.servlet.resource.NoResourceFoundException: No static resource favicon.ico.
    …(150+ stack frames across Tomcat, Security filter chain)
\`\`\`

After:
\`\`\`
DEBUG c.m.a.i.w.c.GlobalExceptionHandler - Resource not found: /favicon.ico
\`\`\`

## Test plan
- [x] New test \`missingResourceReturns404\` confirms 404 status + correct error body
- [x] \`./mvnw test\` — 222 tests, 0 failures (was 221; +1 new test)
- [x] Existing \`Exception\` catch-all still produces 500 + stack trace for genuine bugs (verified by existing \`genericExceptionReturns500\` test)

Pairs with #126 (add favicon) — once that lands the path goes from 404 to 200 for \`/favicon.ico\`. This PR ensures any *other* missing-resource request also gets clean 404 handling.