### PR TITLE
feat(envoy): Phase 3 — URL + Greenhouse ingestion sources

### DIFF
--- a/src/main/java/com/majordomo/adapter/out/ingest/GreenhouseApiSource.java
+++ b/src/main/java/com/majordomo/adapter/out/ingest/GreenhouseApiSource.java
@@ -1,0 +1,114 @@
+package com.majordomo.adapter.out.ingest;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.majordomo.domain.model.envoy.JobPosting;
+import com.majordomo.domain.model.envoy.JobSourceRequest;
+import com.majordomo.domain.port.out.envoy.JobSource;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Ingests a posting from the public Greenhouse job board API. Requires
+ * {@code hints["board"]} (the board slug) and {@code payload} (the job id).
+ */
+@Component
+public class GreenhouseApiSource implements JobSource {
+
+    private final RestClient http;
+    private final String baseUrl;
+
+    /**
+     * Constructs the source.
+     *
+     * @param http    shared HTTP client (qualifier {@code ingestRestClient})
+     * @param baseUrl Greenhouse API base URL
+     *                ({@code envoy.greenhouse.base-url}, default
+     *                {@code https://boards-api.greenhouse.io})
+     */
+    public GreenhouseApiSource(@Qualifier("ingestRestClient") RestClient http,
+                               @Value("${envoy.greenhouse.base-url:https://boards-api.greenhouse.io}")
+                               String baseUrl) {
+        this.http = http;
+        this.baseUrl = baseUrl;
+    }
+
+    @Override
+    public String name() {
+        return "greenhouse";
+    }
+
+    @Override
+    public boolean supports(JobSourceRequest request) {
+        return "greenhouse".equals(request.type());
+    }
+
+    @Override
+    public JobPosting fetch(JobSourceRequest request) {
+        String board = request.hints() == null ? null : request.hints().get("board");
+        if (board == null || request.payload() == null) {
+            throw new IllegalArgumentException(
+                    "greenhouse requires hints[\"board\"] and payload (job id)");
+        }
+        GhJob job = http.get()
+                .uri(baseUrl + "/v1/boards/{board}/jobs/{id}", board, request.payload())
+                .retrieve()
+                .body(GhJob.class);
+        if (job == null) {
+            throw new IllegalStateException(
+                    "Greenhouse returned empty body for " + request.payload());
+        }
+
+        var p = new JobPosting();
+        p.setSource("greenhouse");
+        p.setExternalId(String.valueOf(job.id()));
+        p.setTitle(job.title());
+        p.setLocation(job.location() == null ? null : job.location().name());
+        p.setCompany(job.companyName());
+        p.setRawText(stripHtml(job.content()));
+        p.setExtracted(new HashMap<>(Map.of("board", board)));
+        p.setFetchedAt(Instant.now());
+        return p;
+    }
+
+    private String stripHtml(String html) {
+        if (html == null) {
+            return "";
+        }
+        return html.replace("&lt;", "<")
+                .replace("&gt;", ">")
+                .replace("&amp;", "&")
+                .replaceAll("<[^>]+>", " ")
+                .replaceAll("\\s+", " ")
+                .trim();
+    }
+
+    /**
+     * Partial shape of Greenhouse's job-detail response.
+     *
+     * @param id          numeric job id
+     * @param title       job title
+     * @param content     HTML body
+     * @param location    nested location object
+     * @param companyName company name from {@code company_name}
+     */
+    private record GhJob(
+            long id,
+            String title,
+            String content,
+            GhLocation location,
+            @JsonProperty("company_name") String companyName
+    ) { }
+
+    /**
+     * Greenhouse nested location.
+     *
+     * @param name location display name
+     */
+    private record GhLocation(String name) { }
+}

--- a/src/main/java/com/majordomo/adapter/out/ingest/IngestHttpConfiguration.java
+++ b/src/main/java/com/majordomo/adapter/out/ingest/IngestHttpConfiguration.java
@@ -1,0 +1,34 @@
+package com.majordomo.adapter.out.ingest;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.web.client.RestClient;
+
+import java.time.Duration;
+
+/**
+ * Shared {@link RestClient} used by all HTTP-based {@code JobSource} implementations.
+ * Conservative timeouts — job boards can be slow, but we never want a single
+ * posting fetch to block a thread for minutes.
+ */
+@Configuration
+public class IngestHttpConfiguration {
+
+    /**
+     * Builds the shared HTTP client (qualifier {@code ingestRestClient}) for use
+     * in job sources.
+     *
+     * @return the configured {@link RestClient}
+     */
+    @Bean("ingestRestClient")
+    public RestClient ingestRestClient() {
+        var factory = new SimpleClientHttpRequestFactory();
+        factory.setConnectTimeout((int) Duration.ofSeconds(10).toMillis());
+        factory.setReadTimeout((int) Duration.ofSeconds(30).toMillis());
+        return RestClient.builder()
+                .requestFactory(factory)
+                .defaultHeader("User-Agent", "majordomo-envoy/1.0")
+                .build();
+    }
+}

--- a/src/main/java/com/majordomo/adapter/out/ingest/UrlFetchSource.java
+++ b/src/main/java/com/majordomo/adapter/out/ingest/UrlFetchSource.java
@@ -1,0 +1,66 @@
+package com.majordomo.adapter.out.ingest;
+
+import com.majordomo.domain.model.envoy.JobPosting;
+import com.majordomo.domain.model.envoy.JobSourceRequest;
+import com.majordomo.domain.port.out.envoy.JobSource;
+import com.majordomo.domain.port.out.envoy.LlmExtractionPort;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Ingests a job posting from an arbitrary URL by fetching the HTML and handing
+ * it to {@link LlmExtractionPort} for structured-field extraction. The raw HTML
+ * is preserved on the posting's {@code rawText} so the scorer can still read the
+ * full body.
+ */
+@Component
+public class UrlFetchSource implements JobSource {
+
+    private final RestClient http;
+    private final LlmExtractionPort extractor;
+
+    /**
+     * Constructs the source.
+     *
+     * @param http      shared HTTP client (qualifier {@code ingestRestClient})
+     * @param extractor LLM-backed extraction port
+     */
+    public UrlFetchSource(@Qualifier("ingestRestClient") RestClient http,
+                          LlmExtractionPort extractor) {
+        this.http = http;
+        this.extractor = extractor;
+    }
+
+    @Override
+    public String name() {
+        return "url";
+    }
+
+    @Override
+    public boolean supports(JobSourceRequest request) {
+        return "url".equals(request.type());
+    }
+
+    @Override
+    public JobPosting fetch(JobSourceRequest request) {
+        String url = request.payload();
+        String body = http.get().uri(url).retrieve().body(String.class);
+        Map<String, String> extracted = extractor.extract(body == null ? "" : body);
+
+        var p = new JobPosting();
+        p.setSource("url");
+        p.setExternalId(url);
+        p.setRawText(body == null ? "" : body);
+        p.setCompany(extracted.get("company"));
+        p.setTitle(extracted.get("title"));
+        p.setLocation(extracted.get("location"));
+        p.setExtracted(new HashMap<>(extracted));
+        p.setFetchedAt(Instant.now());
+        return p;
+    }
+}

--- a/src/main/java/com/majordomo/adapter/out/llm/AnthropicLlmExtractionAdapter.java
+++ b/src/main/java/com/majordomo/adapter/out/llm/AnthropicLlmExtractionAdapter.java
@@ -1,0 +1,46 @@
+package com.majordomo.adapter.out.llm;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.majordomo.application.envoy.LlmScoringException;
+import com.majordomo.domain.port.out.envoy.LlmExtractionPort;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+
+/**
+ * Uses the shared {@link AnthropicMessageClient} to ask the LLM to pull structured
+ * fields out of raw job-posting HTML or text.
+ */
+@Component
+public class AnthropicLlmExtractionAdapter implements LlmExtractionPort {
+
+    private static final String SYSTEM_PROMPT = """
+            You will be given the raw body of a job posting (HTML or plain text).
+            Return a JSON object with best-effort values for any of these keys you
+            can determine: company, title, location, salary, equity, team, tech.
+            Omit keys you cannot determine. Return JSON only, no prose, no fences.
+            """;
+
+    private final AnthropicMessageClient client;
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    /**
+     * Constructs the adapter.
+     *
+     * @param client wrapper over the Anthropic SDK client
+     */
+    public AnthropicLlmExtractionAdapter(AnthropicMessageClient client) {
+        this.client = client;
+    }
+
+    @Override
+    public Map<String, String> extract(String rawText) {
+        String json = client.send(SYSTEM_PROMPT, rawText);
+        try {
+            return mapper.readValue(json, new TypeReference<Map<String, String>>() { });
+        } catch (Exception e) {
+            throw new LlmScoringException("Extraction LLM returned unparseable JSON: " + json, e);
+        }
+    }
+}

--- a/src/main/java/com/majordomo/domain/port/out/envoy/LlmExtractionPort.java
+++ b/src/main/java/com/majordomo/domain/port/out/envoy/LlmExtractionPort.java
@@ -1,0 +1,21 @@
+package com.majordomo.domain.port.out.envoy;
+
+import java.util.Map;
+
+/**
+ * Outbound port for LLM-driven structured extraction from free text (typically HTML).
+ * Callers pass raw posting text; the port returns a flat map of labelled fields
+ * (company, title, location, salary, etc.).
+ */
+public interface LlmExtractionPort {
+
+    /**
+     * Extracts structured fields from a posting's raw body. Keys in the returned map
+     * are a best-effort subset of: {@code company}, {@code title}, {@code location},
+     * {@code salary}, {@code equity}, {@code team}, {@code tech}.
+     *
+     * @param rawText raw body of a job posting (HTML or plain text)
+     * @return a flat map of extracted fields
+     */
+    Map<String, String> extract(String rawText);
+}

--- a/src/test/java/com/majordomo/adapter/out/ingest/GreenhouseApiSourceTest.java
+++ b/src/test/java/com/majordomo/adapter/out/ingest/GreenhouseApiSourceTest.java
@@ -1,0 +1,65 @@
+package com.majordomo.adapter.out.ingest;
+
+import com.majordomo.domain.model.envoy.JobPosting;
+import com.majordomo.domain.model.envoy.JobSourceRequest;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.client.RestClient;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class GreenhouseApiSourceTest {
+
+    private MockWebServer web;
+    private GreenhouseApiSource source;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        web = new MockWebServer();
+        web.start();
+        var client = RestClient.builder().build();
+        // strip trailing slash so URI template "/v1/boards/..." doesn't double up
+        String base = web.url("/").toString().replaceAll("/$", "");
+        source = new GreenhouseApiSource(client, base);
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        web.shutdown();
+    }
+
+    @Test
+    void supportsGreenhouseType() {
+        assertThat(source.supports(new JobSourceRequest("greenhouse", "1", Map.of()))).isTrue();
+    }
+
+    @Test
+    void mapsGreenhousePayloadToJobPosting() {
+        web.enqueue(new MockResponse()
+                .setHeader("Content-Type", "application/json")
+                .setBody("""
+                        {
+                          "id": 12345,
+                          "title": "Senior Backend Engineer",
+                          "location": {"name": "Remote - US"},
+                          "content": "&lt;p&gt;We are hiring&lt;/p&gt;",
+                          "company_name": "Acme"
+                        }
+                        """));
+
+        var req = new JobSourceRequest("greenhouse", "12345", Map.of("board", "acme"));
+        JobPosting p = source.fetch(req);
+
+        assertThat(p.getSource()).isEqualTo("greenhouse");
+        assertThat(p.getExternalId()).isEqualTo("12345");
+        assertThat(p.getTitle()).isEqualTo("Senior Backend Engineer");
+        assertThat(p.getLocation()).isEqualTo("Remote - US");
+        assertThat(p.getCompany()).isEqualTo("Acme");
+        assertThat(p.getRawText()).contains("We are hiring");
+    }
+}

--- a/src/test/java/com/majordomo/adapter/out/ingest/UrlFetchSourceTest.java
+++ b/src/test/java/com/majordomo/adapter/out/ingest/UrlFetchSourceTest.java
@@ -1,0 +1,61 @@
+package com.majordomo.adapter.out.ingest;
+
+import com.majordomo.domain.model.envoy.JobPosting;
+import com.majordomo.domain.model.envoy.JobSourceRequest;
+import com.majordomo.domain.port.out.envoy.LlmExtractionPort;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.client.RestClient;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class UrlFetchSourceTest {
+
+    private MockWebServer web;
+    private UrlFetchSource source;
+    private LlmExtractionPort extractor;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        web = new MockWebServer();
+        web.start();
+        extractor = mock(LlmExtractionPort.class);
+        source = new UrlFetchSource(RestClient.create(), extractor);
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        web.shutdown();
+    }
+
+    @Test
+    void supportsUrlType() {
+        assertThat(source.supports(new JobSourceRequest("url", "x", Map.of()))).isTrue();
+        assertThat(source.supports(new JobSourceRequest("manual", "x", Map.of()))).isFalse();
+    }
+
+    @Test
+    void fetchesAndDelegatesExtractionToLlm() {
+        web.enqueue(new MockResponse()
+                .setHeader("Content-Type", "text/html")
+                .setBody("<html><body>We pay well</body></html>"));
+        when(extractor.extract(any())).thenReturn(Map.of(
+                "company", "Acme", "title", "Senior", "salary", "$220k"));
+
+        var req = new JobSourceRequest("url", web.url("/job/1").toString(), Map.of());
+        JobPosting p = source.fetch(req);
+
+        assertThat(p.getRawText()).contains("We pay well");
+        assertThat(p.getExtracted()).containsEntry("company", "Acme");
+        assertThat(p.getSource()).isEqualTo("url");
+        assertThat(p.getExternalId()).isEqualTo(web.url("/job/1").toString());
+    }
+}


### PR DESCRIPTION
Refs #119, Phase 3 of the Envoy plan.

## Summary

Adds two new \`JobSource\` implementations alongside the Phase 1 \`ManualPasteSource\`:

- **\`UrlFetchSource\`** — fetches arbitrary URLs and hands the body to a new \`LlmExtractionPort\` for structured-field extraction (company, title, location, salary, equity, team, tech). Raw HTML is preserved on \`rawText\` so the scorer still sees the full body.
- **\`GreenhouseApiSource\`** — calls Greenhouse's public board API (\`/v1/boards/{board}/jobs/{id}\`), maps the JSON response (id, title, location.name, content, company_name) onto a \`JobPosting\`, and strips entity-encoded HTML out of the content. \`hints["board"]\` carries the board slug; \`payload\` carries the job id. Base URL is configurable via \`envoy.greenhouse.base-url\`.

Supporting bits:
- \`LlmExtractionPort\` — outbound port; \`extract(String) → Map<String,String>\`
- \`AnthropicLlmExtractionAdapter\` — implements the port via the existing \`AnthropicMessageClient\` with a system prompt asking for a flat JSON object
- \`IngestHttpConfiguration\` — shared \`RestClient\` bean (\`@Qualifier("ingestRestClient")\`) with conservative 10s connect / 30s read timeouts and a \`majordomo-envoy/1.0\` UA, used by both new sources

\`JobIngestionService\` already routes by \`JobSource.supports(...)\` so no orchestration changes were needed — both sources are picked up automatically as \`@Component\` beans.

## Test plan
- [x] \`UrlFetchSourceTest\` — verifies \`supports("url")\`, fetches mock HTML via \`MockWebServer\`, asserts the LLM extraction map is applied to the posting
- [x] \`GreenhouseApiSourceTest\` — verifies \`supports("greenhouse")\` and the JSON-to-\`JobPosting\` mapping (title, nested location.name, company_name, HTML-stripped content)
- [x] \`./mvnw test\` — 226 tests, 0 failures (was 222; +4 new)
- [ ] Smoke against the real Greenhouse API: \`curl https://boards-api.greenhouse.io/v1/boards/anthropic/jobs/{id}\` to confirm shape, then ingest via \`POST /api/envoy/postings?type=greenhouse&board=anthropic&payload={id}\`

## Follow-up (still in #119)
Phase 4: \`ReportController\` (paginated GET /api/envoy/reports), \`RubricController\` (PUT /api/envoy/rubrics/{name}), domain events (\`JobPostingIngested\`, \`JobPostingScored\`) + audit listener wiring, end-to-end HTTP integration test.