### PR TITLE
feat(envoy): Phase 4 — report query, rubric authoring, domain events

### DIFF
--- a/src/main/java/com/majordomo/adapter/in/event/AuditEventListener.java
+++ b/src/main/java/com/majordomo/adapter/in/event/AuditEventListener.java
@@ -4,6 +4,8 @@ import com.majordomo.domain.model.AuditAction;
 import com.majordomo.domain.model.AuditLogEntry;
 import com.majordomo.domain.model.EntityType;
 import com.majordomo.domain.model.UuidFactory;
+import com.majordomo.domain.model.event.JobPostingIngested;
+import com.majordomo.domain.model.event.JobPostingScored;
 import com.majordomo.domain.model.event.PropertyArchived;
 import com.majordomo.domain.model.event.ServiceRecordCreated;
 import com.majordomo.domain.model.event.UserCreated;
@@ -66,6 +68,28 @@ public class AuditEventListener {
     @EventListener
     public void onUserCreated(UserCreated event) {
         log(EntityType.USER.name(), event.userId(),
+                AuditAction.CREATE.name(), event.occurredAt());
+    }
+
+    /**
+     * Records an audit entry when a job posting is ingested.
+     *
+     * @param event the posting ingestion event
+     */
+    @EventListener
+    public void onJobPostingIngested(JobPostingIngested event) {
+        log(EntityType.JOB_POSTING.name(), event.postingId(),
+                AuditAction.CREATE.name(), event.occurredAt());
+    }
+
+    /**
+     * Records an audit entry when a job posting is scored.
+     *
+     * @param event the scoring event
+     */
+    @EventListener
+    public void onJobPostingScored(JobPostingScored event) {
+        log(EntityType.SCORE_REPORT.name(), event.reportId(),
                 AuditAction.CREATE.name(), event.occurredAt());
     }
 

--- a/src/main/java/com/majordomo/adapter/in/web/envoy/ReportController.java
+++ b/src/main/java/com/majordomo/adapter/in/web/envoy/ReportController.java
@@ -1,0 +1,75 @@
+package com.majordomo.adapter.in.web.envoy;
+
+import com.majordomo.application.identity.OrganizationAccessService;
+import com.majordomo.domain.model.Page;
+import com.majordomo.domain.model.envoy.Recommendation;
+import com.majordomo.domain.model.envoy.ScoreReport;
+import com.majordomo.domain.port.in.envoy.QueryScoreReportsUseCase;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.UUID;
+
+/** REST controller for querying persisted score reports. */
+@RestController
+@RequestMapping("/api/envoy/reports")
+@Tag(name = "Envoy", description = "Score report query")
+public class ReportController {
+
+    private final QueryScoreReportsUseCase query;
+    private final OrganizationAccessService organizationAccessService;
+
+    /**
+     * Constructs the controller.
+     *
+     * @param query                     inbound port for report queries
+     * @param organizationAccessService enforces per-org access control
+     */
+    public ReportController(QueryScoreReportsUseCase query,
+                            OrganizationAccessService organizationAccessService) {
+        this.query = query;
+        this.organizationAccessService = organizationAccessService;
+    }
+
+    /**
+     * Lists score reports for an org, cursor-paginated with optional filters.
+     *
+     * @param organizationId required org scope
+     * @param minFinalScore  optional min score filter
+     * @param recommendation optional recommendation filter
+     * @param cursor         optional cursor for pagination
+     * @param limit          row cap (default 20, clamped to [1, 100])
+     * @return page of reports
+     */
+    @GetMapping
+    public Page<ScoreReport> list(
+            @RequestParam UUID organizationId,
+            @RequestParam(required = false) Integer minFinalScore,
+            @RequestParam(required = false) Recommendation recommendation,
+            @RequestParam(required = false) UUID cursor,
+            @RequestParam(defaultValue = "20") int limit) {
+        organizationAccessService.verifyAccess(organizationId);
+        return query.query(organizationId, minFinalScore, recommendation, cursor, limit);
+    }
+
+    /**
+     * Fetches a single report by id within an org.
+     *
+     * @param id             report id
+     * @param organizationId required org scope
+     * @return 200 with the report or 404 if not found in this org
+     */
+    @GetMapping("/{id}")
+    public ResponseEntity<ScoreReport> getById(@PathVariable UUID id,
+                                               @RequestParam UUID organizationId) {
+        organizationAccessService.verifyAccess(organizationId);
+        return query.findById(id, organizationId)
+                .map(ResponseEntity::ok)
+                .orElse(ResponseEntity.notFound().build());
+    }
+}

--- a/src/main/java/com/majordomo/adapter/in/web/envoy/RubricController.java
+++ b/src/main/java/com/majordomo/adapter/in/web/envoy/RubricController.java
@@ -1,0 +1,52 @@
+package com.majordomo.adapter.in.web.envoy;
+
+import com.majordomo.application.identity.OrganizationAccessService;
+import com.majordomo.domain.model.envoy.Rubric;
+import com.majordomo.domain.port.in.envoy.ManageRubricUseCase;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.UUID;
+
+/** REST controller for rubric authoring. */
+@RestController
+@RequestMapping("/api/envoy/rubrics")
+@Tag(name = "Envoy", description = "Rubric management")
+public class RubricController {
+
+    private final ManageRubricUseCase rubrics;
+    private final OrganizationAccessService organizationAccessService;
+
+    /**
+     * Constructs the controller.
+     *
+     * @param rubrics                   inbound port for rubric authoring
+     * @param organizationAccessService enforces per-org access control
+     */
+    public RubricController(ManageRubricUseCase rubrics,
+                            OrganizationAccessService organizationAccessService) {
+        this.rubrics = rubrics;
+        this.organizationAccessService = organizationAccessService;
+    }
+
+    /**
+     * Appends a new org-specific version of the named rubric.
+     *
+     * @param name           rubric name (path)
+     * @param organizationId required org scope
+     * @param rubric         submitted rubric body (id/version/effectiveFrom assigned by service)
+     * @return the persisted rubric with its new id, version, and effectiveFrom
+     */
+    @PutMapping("/{name}")
+    public Rubric putRubric(@PathVariable String name,
+                            @RequestParam UUID organizationId,
+                            @RequestBody Rubric rubric) {
+        organizationAccessService.verifyAccess(organizationId);
+        return rubrics.saveNewVersion(name, rubric, organizationId);
+    }
+}

--- a/src/main/java/com/majordomo/application/envoy/JobIngestionService.java
+++ b/src/main/java/com/majordomo/application/envoy/JobIngestionService.java
@@ -4,7 +4,9 @@ import com.majordomo.domain.port.out.envoy.JobSource;
 import com.majordomo.domain.model.UuidFactory;
 import com.majordomo.domain.model.envoy.JobPosting;
 import com.majordomo.domain.model.envoy.JobSourceRequest;
+import com.majordomo.domain.model.event.JobPostingIngested;
 import com.majordomo.domain.port.in.envoy.IngestJobPostingUseCase;
+import com.majordomo.domain.port.out.EventPublisher;
 import com.majordomo.domain.port.out.envoy.JobPostingRepository;
 import org.springframework.stereotype.Service;
 
@@ -23,17 +25,22 @@ public class JobIngestionService implements IngestJobPostingUseCase {
 
     private final List<JobSource> sources;
     private final JobPostingRepository postings;
+    private final EventPublisher eventPublisher;
 
     /**
      * Constructs the service. Spring injects all {@link JobSource} beans into
      * {@code sources}.
      *
-     * @param sources  the discovered ingestion sources
-     * @param postings outbound port for posting persistence
+     * @param sources        the discovered ingestion sources
+     * @param postings       outbound port for posting persistence
+     * @param eventPublisher domain event publisher
      */
-    public JobIngestionService(List<JobSource> sources, JobPostingRepository postings) {
+    public JobIngestionService(List<JobSource> sources,
+                               JobPostingRepository postings,
+                               EventPublisher eventPublisher) {
         this.sources = sources;
         this.postings = postings;
+        this.eventPublisher = eventPublisher;
     }
 
     @Override
@@ -59,6 +66,9 @@ public class JobIngestionService implements IngestJobPostingUseCase {
         if (fetched.getId() == null) {
             fetched.setId(UuidFactory.newId());
         }
-        return postings.save(fetched);
+        JobPosting saved = postings.save(fetched);
+        eventPublisher.publish(new JobPostingIngested(
+                saved.getId(), organizationId, saved.getSource(), Instant.now()));
+        return saved;
     }
 }

--- a/src/main/java/com/majordomo/application/envoy/JobScorerService.java
+++ b/src/main/java/com/majordomo/application/envoy/JobScorerService.java
@@ -6,13 +6,16 @@ import com.majordomo.domain.model.envoy.JobPosting;
 import com.majordomo.domain.model.envoy.LlmScoreResponse;
 import com.majordomo.domain.model.envoy.Rubric;
 import com.majordomo.domain.model.envoy.ScoreReport;
+import com.majordomo.domain.model.event.JobPostingScored;
 import com.majordomo.domain.port.in.envoy.ScoreJobPostingUseCase;
+import com.majordomo.domain.port.out.EventPublisher;
 import com.majordomo.domain.port.out.envoy.JobPostingRepository;
 import com.majordomo.domain.port.out.envoy.LlmScoringPort;
 import com.majordomo.domain.port.out.envoy.RubricRepository;
 import com.majordomo.domain.port.out.envoy.ScoreReportRepository;
 import org.springframework.stereotype.Service;
 
+import java.time.Instant;
 import java.util.UUID;
 
 /**
@@ -29,26 +32,30 @@ public class JobScorerService implements ScoreJobPostingUseCase {
     private final ScoreReportRepository reports;
     private final LlmScoringPort llm;
     private final ScoreAssembler assembler;
+    private final EventPublisher eventPublisher;
 
     /**
      * Constructs the scorer with all required collaborators.
      *
-     * @param rubrics   outbound port for rubrics
-     * @param postings  outbound port for postings
-     * @param reports   outbound port for score reports
-     * @param llm       outbound LLM scoring port
-     * @param assembler deterministic LLM-response validator
+     * @param rubrics        outbound port for rubrics
+     * @param postings       outbound port for postings
+     * @param reports        outbound port for score reports
+     * @param llm            outbound LLM scoring port
+     * @param assembler      deterministic LLM-response validator
+     * @param eventPublisher domain event publisher
      */
     public JobScorerService(RubricRepository rubrics,
-                     JobPostingRepository postings,
-                     ScoreReportRepository reports,
-                     LlmScoringPort llm,
-                     ScoreAssembler assembler) {
+                            JobPostingRepository postings,
+                            ScoreReportRepository reports,
+                            LlmScoringPort llm,
+                            ScoreAssembler assembler,
+                            EventPublisher eventPublisher) {
         this.rubrics = rubrics;
         this.postings = postings;
         this.reports = reports;
         this.llm = llm;
         this.assembler = assembler;
+        this.eventPublisher = eventPublisher;
     }
 
     @Override
@@ -61,6 +68,10 @@ public class JobScorerService implements ScoreJobPostingUseCase {
 
         LlmScoreResponse resp = llm.score(posting, rubric);
         ScoreReport report = assembler.assemble(posting, rubric, resp, llm.modelId());
-        return reports.save(report);
+        ScoreReport saved = reports.save(report);
+        eventPublisher.publish(new JobPostingScored(
+                saved.id(), saved.organizationId(), saved.postingId(),
+                saved.finalScore(), saved.recommendation(), Instant.now()));
+        return saved;
     }
 }

--- a/src/main/java/com/majordomo/application/envoy/RubricService.java
+++ b/src/main/java/com/majordomo/application/envoy/RubricService.java
@@ -1,0 +1,48 @@
+package com.majordomo.application.envoy;
+
+import com.majordomo.domain.model.UuidFactory;
+import com.majordomo.domain.model.envoy.Rubric;
+import com.majordomo.domain.port.in.envoy.ManageRubricUseCase;
+import com.majordomo.domain.port.out.envoy.RubricRepository;
+import org.springframework.stereotype.Service;
+
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+
+/** Rubric authoring — every save produces a new monotonically-increasing version. */
+@Service
+public class RubricService implements ManageRubricUseCase {
+
+    private final RubricRepository repo;
+
+    /**
+     * Constructs the service.
+     *
+     * @param repo outbound rubric repository
+     */
+    public RubricService(RubricRepository repo) {
+        this.repo = repo;
+    }
+
+    @Override
+    public Rubric saveNewVersion(String name, Rubric submitted, UUID organizationId) {
+        // Only an existing org-specific version increments — system-default
+        // ({@code organizationId IS NULL}) is the seed and stays at v1.
+        int nextVersion = repo.findActiveByName(name, organizationId)
+                .filter(r -> r.organizationId().isPresent())
+                .map(r -> r.version() + 1)
+                .orElse(1);
+        Rubric toSave = new Rubric(
+                UuidFactory.newId(),
+                Optional.of(organizationId),
+                nextVersion,
+                name,
+                submitted.disqualifiers(),
+                submitted.categories(),
+                submitted.flags(),
+                submitted.thresholds(),
+                Instant.now());
+        return repo.save(toSave);
+    }
+}

--- a/src/main/java/com/majordomo/application/envoy/ScoreReportQueryService.java
+++ b/src/main/java/com/majordomo/application/envoy/ScoreReportQueryService.java
@@ -1,0 +1,39 @@
+package com.majordomo.application.envoy;
+
+import com.majordomo.domain.model.Page;
+import com.majordomo.domain.model.envoy.Recommendation;
+import com.majordomo.domain.model.envoy.ScoreReport;
+import com.majordomo.domain.port.in.envoy.QueryScoreReportsUseCase;
+import com.majordomo.domain.port.out.envoy.ScoreReportRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+import java.util.UUID;
+
+/** Read-only service for score reports. */
+@Service
+public class ScoreReportQueryService implements QueryScoreReportsUseCase {
+
+    private final ScoreReportRepository repo;
+
+    /**
+     * Constructs the service.
+     *
+     * @param repo outbound report repository
+     */
+    public ScoreReportQueryService(ScoreReportRepository repo) {
+        this.repo = repo;
+    }
+
+    @Override
+    public Optional<ScoreReport> findById(UUID id, UUID organizationId) {
+        return repo.findById(id, organizationId);
+    }
+
+    @Override
+    public Page<ScoreReport> query(UUID organizationId, Integer minFinalScore,
+                                   Recommendation recommendation, UUID cursor, int limit) {
+        int clamped = Math.max(1, Math.min(limit, 100));
+        return repo.query(organizationId, minFinalScore, recommendation, cursor, clamped);
+    }
+}

--- a/src/main/java/com/majordomo/domain/model/EntityType.java
+++ b/src/main/java/com/majordomo/domain/model/EntityType.java
@@ -11,5 +11,6 @@ public enum EntityType {
     MAINTENANCE_SCHEDULE,
     ATTACHMENT,
     API_KEY,
-    JOB_POSTING
+    JOB_POSTING,
+    SCORE_REPORT
 }

--- a/src/main/java/com/majordomo/domain/model/event/JobPostingIngested.java
+++ b/src/main/java/com/majordomo/domain/model/event/JobPostingIngested.java
@@ -1,0 +1,18 @@
+package com.majordomo.domain.model.event;
+
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * Published after a new job posting is persisted by the ingestion service.
+ *
+ * @param postingId      the newly-persisted posting's id
+ * @param organizationId the owning organization
+ * @param source         the {@code JobSource.name()} that produced it
+ * @param occurredAt     when the event occurred
+ */
+public record JobPostingIngested(
+        UUID postingId,
+        UUID organizationId,
+        String source,
+        Instant occurredAt) { }

--- a/src/main/java/com/majordomo/domain/model/event/JobPostingScored.java
+++ b/src/main/java/com/majordomo/domain/model/event/JobPostingScored.java
@@ -1,0 +1,24 @@
+package com.majordomo.domain.model.event;
+
+import com.majordomo.domain.model.envoy.Recommendation;
+
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * Published after a score report is persisted by the scoring service.
+ *
+ * @param reportId       the persisted report id
+ * @param organizationId the owning organization
+ * @param postingId      the posting that was scored
+ * @param finalScore     the final score
+ * @param recommendation the derived recommendation
+ * @param occurredAt     when the event occurred
+ */
+public record JobPostingScored(
+        UUID reportId,
+        UUID organizationId,
+        UUID postingId,
+        int finalScore,
+        Recommendation recommendation,
+        Instant occurredAt) { }

--- a/src/main/java/com/majordomo/domain/port/in/envoy/ManageRubricUseCase.java
+++ b/src/main/java/com/majordomo/domain/port/in/envoy/ManageRubricUseCase.java
@@ -1,0 +1,21 @@
+package com.majordomo.domain.port.in.envoy;
+
+import com.majordomo.domain.model.envoy.Rubric;
+
+import java.util.UUID;
+
+/** Inbound port for rubric authoring. */
+public interface ManageRubricUseCase {
+
+    /**
+     * Appends a new org-specific version of the named rubric. The caller's
+     * {@code id}, {@code organizationId}, {@code version}, and {@code effectiveFrom}
+     * on {@code rubric} are ignored — the service assigns them.
+     *
+     * @param name           the rubric name whose next version is being created
+     * @param rubric         body for the new version (categories, flags, disqualifiers, thresholds)
+     * @param organizationId the owning org
+     * @return the saved rubric with its new id, organizationId, version, and effectiveFrom
+     */
+    Rubric saveNewVersion(String name, Rubric rubric, UUID organizationId);
+}

--- a/src/main/java/com/majordomo/domain/port/in/envoy/QueryScoreReportsUseCase.java
+++ b/src/main/java/com/majordomo/domain/port/in/envoy/QueryScoreReportsUseCase.java
@@ -1,0 +1,34 @@
+package com.majordomo.domain.port.in.envoy;
+
+import com.majordomo.domain.model.Page;
+import com.majordomo.domain.model.envoy.Recommendation;
+import com.majordomo.domain.model.envoy.ScoreReport;
+
+import java.util.Optional;
+import java.util.UUID;
+
+/** Inbound port for reading score reports. All operations are org-scoped. */
+public interface QueryScoreReportsUseCase {
+
+    /**
+     * Finds a report by id within an org.
+     *
+     * @param id             report id
+     * @param organizationId owning org
+     * @return matching report, or empty
+     */
+    Optional<ScoreReport> findById(UUID id, UUID organizationId);
+
+    /**
+     * Cursor-paginated, filterable report query within an org.
+     *
+     * @param organizationId required org scope
+     * @param minFinalScore  optional min score (null = no lower bound)
+     * @param recommendation optional recommendation filter (null = any)
+     * @param cursor         optional cursor (null = first page)
+     * @param limit          row cap (clamped to [1, 100])
+     * @return page of reports
+     */
+    Page<ScoreReport> query(UUID organizationId, Integer minFinalScore,
+                            Recommendation recommendation, UUID cursor, int limit);
+}

--- a/src/test/java/com/majordomo/adapter/in/web/envoy/ReportControllerTest.java
+++ b/src/test/java/com/majordomo/adapter/in/web/envoy/ReportControllerTest.java
@@ -1,0 +1,94 @@
+package com.majordomo.adapter.in.web.envoy;
+
+import com.majordomo.adapter.in.web.config.OAuth2UserService;
+import com.majordomo.adapter.in.web.config.SecurityConfig;
+import com.majordomo.application.identity.OrganizationAccessService;
+import com.majordomo.domain.model.Page;
+import com.majordomo.domain.model.UuidFactory;
+import com.majordomo.domain.model.envoy.Recommendation;
+import com.majordomo.domain.model.envoy.ScoreReport;
+import com.majordomo.domain.port.in.envoy.QueryScoreReportsUseCase;
+import com.majordomo.domain.port.out.identity.ApiKeyRepository;
+import com.majordomo.domain.port.out.identity.MembershipRepository;
+import com.majordomo.domain.port.out.identity.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(ReportController.class)
+@Import(SecurityConfig.class)
+class ReportControllerTest {
+
+    @Autowired MockMvc mvc;
+
+    @MockitoBean QueryScoreReportsUseCase query;
+    @MockitoBean OrganizationAccessService organizationAccessService;
+    @MockitoBean UserRepository userRepository;
+    @MockitoBean MembershipRepository membershipRepository;
+    @MockitoBean ApiKeyRepository apiKeyRepository;
+    @MockitoBean OAuth2UserService oAuth2UserService;
+
+    private static final UUID ORG_ID = UUID.randomUUID();
+
+    @Test
+    @WithMockUser
+    void listPassesFiltersThrough() throws Exception {
+        doNothing().when(organizationAccessService).verifyAccess(any());
+        when(query.query(eq(ORG_ID), any(), any(), any(), any(Integer.class)))
+                .thenReturn(new Page<>(List.of(), null, false));
+
+        mvc.perform(get("/api/envoy/reports")
+                        .param("organizationId", ORG_ID.toString())
+                        .param("minFinalScore", "70")
+                        .param("recommendation", "APPLY_NOW")
+                        .param("limit", "25"))
+                .andExpect(status().isOk());
+
+        verify(query).query(eq(ORG_ID), eq(70), eq(Recommendation.APPLY_NOW), eq(null), eq(25));
+    }
+
+    @Test
+    @WithMockUser
+    void getByIdReturns200() throws Exception {
+        var id = UuidFactory.newId();
+        var report = new ScoreReport(id, ORG_ID, UuidFactory.newId(), UuidFactory.newId(), 1,
+                Optional.empty(), List.of(), List.of(), 10, 10,
+                Recommendation.CONSIDER, "m", Instant.now());
+        doNothing().when(organizationAccessService).verifyAccess(any());
+        when(query.findById(id, ORG_ID)).thenReturn(Optional.of(report));
+
+        mvc.perform(get("/api/envoy/reports/" + id)
+                        .param("organizationId", ORG_ID.toString()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(id.toString()));
+    }
+
+    @Test
+    @WithMockUser
+    void getByIdReturns404WhenMissing() throws Exception {
+        doNothing().when(organizationAccessService).verifyAccess(any());
+        when(query.findById(any(), any())).thenReturn(Optional.empty());
+
+        mvc.perform(get("/api/envoy/reports/" + UuidFactory.newId())
+                        .param("organizationId", ORG_ID.toString()))
+                .andExpect(status().isNotFound());
+    }
+}

--- a/src/test/java/com/majordomo/adapter/in/web/envoy/RubricControllerTest.java
+++ b/src/test/java/com/majordomo/adapter/in/web/envoy/RubricControllerTest.java
@@ -1,0 +1,71 @@
+package com.majordomo.adapter.in.web.envoy;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.majordomo.adapter.in.web.config.OAuth2UserService;
+import com.majordomo.adapter.in.web.config.SecurityConfig;
+import com.majordomo.application.identity.OrganizationAccessService;
+import com.majordomo.domain.model.UuidFactory;
+import com.majordomo.domain.model.envoy.Category;
+import com.majordomo.domain.model.envoy.Rubric;
+import com.majordomo.domain.model.envoy.Thresholds;
+import com.majordomo.domain.model.envoy.Tier;
+import com.majordomo.domain.port.in.envoy.ManageRubricUseCase;
+import com.majordomo.domain.port.out.identity.ApiKeyRepository;
+import com.majordomo.domain.port.out.identity.MembershipRepository;
+import com.majordomo.domain.port.out.identity.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(RubricController.class)
+@Import(SecurityConfig.class)
+class RubricControllerTest {
+
+    @Autowired MockMvc mvc;
+    @Autowired ObjectMapper json;
+
+    @MockitoBean ManageRubricUseCase rubrics;
+    @MockitoBean OrganizationAccessService organizationAccessService;
+    @MockitoBean UserRepository userRepository;
+    @MockitoBean MembershipRepository membershipRepository;
+    @MockitoBean ApiKeyRepository apiKeyRepository;
+    @MockitoBean OAuth2UserService oAuth2UserService;
+
+    private static final UUID ORG_ID = UUID.randomUUID();
+
+    @Test
+    @WithMockUser
+    void putRubric_createsNewVersion() throws Exception {
+        var saved = new Rubric(UuidFactory.newId(), Optional.of(ORG_ID), 4, "default",
+                List.of(),
+                List.of(new Category("c", "x", 10, List.of(new Tier("Only", 5, "x")))),
+                List.of(), new Thresholds(20, 15, 5), Instant.now());
+        doNothing().when(organizationAccessService).verifyAccess(any());
+        when(rubrics.saveNewVersion(eq("default"), any(), eq(ORG_ID))).thenReturn(saved);
+
+        mvc.perform(put("/api/envoy/rubrics/default")
+                        .param("organizationId", ORG_ID.toString())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(json.writeValueAsString(saved)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.version").value(4));
+    }
+}

--- a/src/test/java/com/majordomo/application/envoy/JobIngestionServiceTest.java
+++ b/src/test/java/com/majordomo/application/envoy/JobIngestionServiceTest.java
@@ -4,6 +4,8 @@ import com.majordomo.domain.port.out.envoy.JobSource;
 import com.majordomo.domain.model.UuidFactory;
 import com.majordomo.domain.model.envoy.JobPosting;
 import com.majordomo.domain.model.envoy.JobSourceRequest;
+import com.majordomo.domain.model.event.JobPostingIngested;
+import com.majordomo.domain.port.out.EventPublisher;
 import com.majordomo.domain.port.out.envoy.JobPostingRepository;
 import org.junit.jupiter.api.Test;
 
@@ -44,20 +46,25 @@ class JobIngestionServiceTest {
             return p;
         });
 
-        var service = new JobIngestionService(List.of(nonMatching, matching), repo);
+        var publisher = mock(EventPublisher.class);
+        var service = new JobIngestionService(List.of(nonMatching, matching), repo, publisher);
         JobPosting saved = service.ingest(new JobSourceRequest("manual", "body", Map.of()), orgId);
 
         assertThat(saved.getId()).isNotNull();
         assertThat(saved.getOrganizationId()).isEqualTo(orgId);
         verify(matching).fetch(any());
         verify(nonMatching, never()).fetch(any());
+        verify(publisher).publish(any(JobPostingIngested.class));
     }
 
     @Test
     void throwsWhenNoSourceSupportsTheRequest() {
         var source = mock(JobSource.class);
         when(source.supports(any())).thenReturn(false);
-        var service = new JobIngestionService(List.of(source), mock(JobPostingRepository.class));
+        var service = new JobIngestionService(
+                List.of(source),
+                mock(JobPostingRepository.class),
+                mock(EventPublisher.class));
 
         assertThatThrownBy(() -> service.ingest(
                 new JobSourceRequest("mystery", "", Map.of()), orgId))
@@ -85,11 +92,13 @@ class JobIngestionServiceTest {
         when(repo.findBySourceAndExternalId("greenhouse", "abc", orgId))
                 .thenReturn(Optional.of(existing));
 
-        var service = new JobIngestionService(List.of(source), repo);
+        var publisher = mock(EventPublisher.class);
+        var service = new JobIngestionService(List.of(source), repo, publisher);
         JobPosting result = service.ingest(
                 new JobSourceRequest("greenhouse", "abc", Map.of()), orgId);
 
         assertThat(result.getId()).isEqualTo(existing.getId());
         verify(repo, never()).save(any());
+        verify(publisher, never()).publish(any());
     }
 }

--- a/src/test/java/com/majordomo/application/envoy/JobScorerServiceTest.java
+++ b/src/test/java/com/majordomo/application/envoy/JobScorerServiceTest.java
@@ -10,6 +10,8 @@ import com.majordomo.domain.model.envoy.Rubric;
 import com.majordomo.domain.model.envoy.ScoreReport;
 import com.majordomo.domain.model.envoy.Thresholds;
 import com.majordomo.domain.model.envoy.Tier;
+import com.majordomo.domain.model.event.JobPostingScored;
+import com.majordomo.domain.port.out.EventPublisher;
 import com.majordomo.domain.port.out.envoy.JobPostingRepository;
 import com.majordomo.domain.port.out.envoy.LlmScoringPort;
 import com.majordomo.domain.port.out.envoy.RubricRepository;
@@ -28,6 +30,7 @@ import java.util.UUID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -37,6 +40,7 @@ class JobScorerServiceTest {
     @Mock JobPostingRepository postings;
     @Mock ScoreReportRepository reports;
     @Mock LlmScoringPort llm;
+    @Mock EventPublisher eventPublisher;
 
     private JobScorerService scorer;
     private final UUID orgId = UuidFactory.newId();
@@ -46,7 +50,8 @@ class JobScorerServiceTest {
 
     @BeforeEach
     void setUp() {
-        scorer = new JobScorerService(rubrics, postings, reports, llm, new ScoreAssembler());
+        scorer = new JobScorerService(
+                rubrics, postings, reports, llm, new ScoreAssembler(), eventPublisher);
         rubric = new Rubric(UuidFactory.newId(), Optional.empty(), 1, "default",
                 List.of(),
                 List.of(new Category("compensation", "pay", 20,
@@ -73,6 +78,7 @@ class JobScorerServiceTest {
         assertThat(r.finalScore()).isEqualTo(15);
         assertThat(r.recommendation()).isEqualTo(Recommendation.APPLY);
         assertThat(r.llmModel()).isEqualTo("claude-sonnet-4-6");
+        verify(eventPublisher).publish(any(JobPostingScored.class));
     }
 
     @Test

--- a/src/test/java/com/majordomo/application/envoy/RubricServiceTest.java
+++ b/src/test/java/com/majordomo/application/envoy/RubricServiceTest.java
@@ -1,0 +1,84 @@
+package com.majordomo.application.envoy;
+
+import com.majordomo.domain.model.UuidFactory;
+import com.majordomo.domain.model.envoy.Category;
+import com.majordomo.domain.model.envoy.Rubric;
+import com.majordomo.domain.model.envoy.Thresholds;
+import com.majordomo.domain.model.envoy.Tier;
+import com.majordomo.domain.port.out.envoy.RubricRepository;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class RubricServiceTest {
+
+    private final UUID orgId = UuidFactory.newId();
+
+    @Test
+    void saveNewVersion_incrementsVersionAndStampsFields() {
+        var repo = mock(RubricRepository.class);
+        var existing = new Rubric(UuidFactory.newId(), Optional.of(orgId), 3, "default",
+                List.of(), List.of(cat()), List.of(),
+                new Thresholds(20, 15, 5), Instant.now().minusSeconds(3600));
+        when(repo.findActiveByName("default", orgId)).thenReturn(Optional.of(existing));
+        when(repo.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        var submitted = new Rubric(null, Optional.empty(), 0, "default", List.of(),
+                List.of(cat()), List.of(), new Thresholds(30, 20, 10), null);
+
+        var service = new RubricService(repo);
+        Rubric saved = service.saveNewVersion("default", submitted, orgId);
+
+        assertThat(saved.version()).isEqualTo(4);
+        assertThat(saved.id()).isNotNull();
+        assertThat(saved.effectiveFrom()).isNotNull();
+        assertThat(saved.organizationId()).contains(orgId);
+        assertThat(saved.thresholds().applyImmediately()).isEqualTo(30);
+    }
+
+    @Test
+    void saveNewVersion_startsAtV1WhenNoOrgSpecificExists() {
+        var repo = mock(RubricRepository.class);
+        when(repo.findActiveByName("brand-new", orgId)).thenReturn(Optional.empty());
+        when(repo.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        var submitted = new Rubric(null, Optional.empty(), 0, "brand-new", List.of(),
+                List.of(cat()), List.of(), new Thresholds(30, 20, 10), null);
+
+        var saved = new RubricService(repo).saveNewVersion("brand-new", submitted, orgId);
+
+        assertThat(saved.version()).isEqualTo(1);
+        assertThat(saved.organizationId()).contains(orgId);
+    }
+
+    @Test
+    void saveNewVersion_systemDefaultDoesNotIncrement() {
+        // org has no override yet — findActiveByName falls back to the seeded
+        // system-default (organizationId.isEmpty()). The new version starts at 1.
+        var repo = mock(RubricRepository.class);
+        var systemDefault = new Rubric(UuidFactory.newId(), Optional.empty(), 1, "default",
+                List.of(), List.of(cat()), List.of(),
+                new Thresholds(20, 15, 5), Instant.now());
+        when(repo.findActiveByName("default", orgId)).thenReturn(Optional.of(systemDefault));
+        when(repo.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        var submitted = new Rubric(null, Optional.empty(), 0, "default", List.of(),
+                List.of(cat()), List.of(), new Thresholds(30, 20, 10), null);
+
+        var saved = new RubricService(repo).saveNewVersion("default", submitted, orgId);
+
+        assertThat(saved.version()).isEqualTo(1);
+    }
+
+    private Category cat() {
+        return new Category("c", "x", 10, List.of(new Tier("Only", 5, "x")));
+    }
+}

--- a/src/test/java/com/majordomo/application/envoy/ScoreReportQueryServiceTest.java
+++ b/src/test/java/com/majordomo/application/envoy/ScoreReportQueryServiceTest.java
@@ -1,0 +1,52 @@
+package com.majordomo.application.envoy;
+
+import com.majordomo.domain.model.Page;
+import com.majordomo.domain.model.UuidFactory;
+import com.majordomo.domain.model.envoy.Recommendation;
+import com.majordomo.domain.model.envoy.ScoreReport;
+import com.majordomo.domain.port.out.envoy.ScoreReportRepository;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class ScoreReportQueryServiceTest {
+
+    private final UUID orgId = UuidFactory.newId();
+
+    @Test
+    void clampsLimitAndDelegatesToRepository() {
+        var repo = mock(ScoreReportRepository.class);
+        var service = new ScoreReportQueryService(repo);
+        when(repo.query(eq(orgId), any(), any(), any(), eq(100)))
+                .thenReturn(new Page<>(List.of(), null, false));
+
+        service.query(orgId, 60, Recommendation.APPLY_NOW, null, 500);
+
+        verify(repo).query(orgId, 60, Recommendation.APPLY_NOW, null, 100);
+    }
+
+    @Test
+    void findByIdDelegates() {
+        var repo = mock(ScoreReportRepository.class);
+        var expected = new ScoreReport(UuidFactory.newId(), orgId,
+                UuidFactory.newId(), UuidFactory.newId(), 1, Optional.empty(),
+                List.of(), List.of(),
+                10, 10, Recommendation.CONSIDER, "m", Instant.now());
+        when(repo.findById(expected.id(), orgId)).thenReturn(Optional.of(expected));
+
+        var service = new ScoreReportQueryService(repo);
+        var found = service.findById(expected.id(), orgId).orElseThrow();
+
+        assertThat(found.id()).isEqualTo(expected.id());
+    }
+}


### PR DESCRIPTION
Closes #119.

## Summary

Final phase of the Envoy plan. Adds the remaining REST surface, the rubric-authoring write path, and audit-log wiring for envoy domain events.

### Querying (Task 24)
- \`QueryScoreReportsUseCase\` inbound port
- \`ScoreReportQueryService\` — clamps \`limit\` to [1, 100] and delegates to the existing \`ScoreReportRepository.query(...)\`

### Reports REST (Task 26)
- \`GET /api/envoy/reports?organizationId=…&minFinalScore=…&recommendation=…&cursor=…&limit=…\` — paginated, filterable list
- \`GET /api/envoy/reports/{id}?organizationId=…\` — single report or 404
- Both verify org access via \`OrganizationAccessService\` first

### Rubric authoring REST (Task 27)
- \`ManageRubricUseCase\` inbound port + \`RubricService\` impl
- \`PUT /api/envoy/rubrics/{name}?organizationId=…\` — appends a new org-specific version. Submitted \`id\`/\`version\`/\`effectiveFrom\` on the body are ignored; the service assigns them
- Versioning: walks back from the active rubric for \`(name, organizationId)\` only when it's already org-specific (system-default never increments — first org override starts at v1)

### Domain events + audit (Task 28)
- \`JobPostingIngested\` (record) — published by \`JobIngestionService\` after persist
- \`JobPostingScored\` (record) — published by \`JobScorerService\` after persist
- \`AuditEventListener\` gains two new \`@EventListener\` methods that map the events onto \`AuditAction.CREATE\` log entries
- \`EntityType\` gains \`SCORE_REPORT\`

### Skipped
- **Task 29** (end-to-end \`@SpringBootTest\` over real HTTP) — would need a working Testcontainers Postgres setup, which is broken on this dev machine via #124 (Docker Desktop 4.6x). The five existing controller \`@WebMvcTest\` slices cover each endpoint's HTTP contract; revisit once #124 closes.

## Test plan
- [x] \`./mvnw test\` — 235 tests, 0 failures (was 226; +9 new)
- [x] \`ScoreReportQueryServiceTest\` — limit clamp + delegation (2 tests)
- [x] \`ReportControllerTest\` — list filter passthrough + 200/404 by id (3 tests)
- [x] \`RubricServiceTest\` — increments per-org version, starts at v1 when no org override exists, system-default doesn't bump the version counter (3 tests)
- [x] \`RubricControllerTest\` — \`PUT /api/envoy/rubrics/{name}\` returns the saved rubric (1 test)
- [x] Existing \`JobScorerServiceTest\` and \`JobIngestionServiceTest\` updated to verify the new \`EventPublisher\` calls
- [ ] Manual: \`docker compose up -d db redis && ANTHROPIC_API_KEY=… ./mvnw spring-boot:run\`, then \`POST /api/envoy/postings\`, \`POST /api/envoy/postings/{id}/score\`, \`GET /api/envoy/reports\`, \`PUT /api/envoy/rubrics/default\` from Swagger