### PR TITLE
docs: add envoy end-to-end smoke test script

### DIFF
--- a/docs/smoke-test/README.md
+++ b/docs/smoke-test/README.md
@@ -1,0 +1,66 @@
+# Envoy smoke test
+
+End-to-end check that the envoy job-scoring service works against a real
+Postgres + Redis + Anthropic stack. Useful as a manual QA after merges that
+touch envoy or its dependencies (Spring Boot bumps, Anthropic SDK bumps,
+Flyway migrations, security config changes).
+
+The unit and `@WebMvcTest` slices in `src/test/` already cover the contract
+of each piece. This script verifies they're correctly wired together when
+the app boots against real infrastructure.
+
+## Prereqs
+
+```bash
+docker compose up -d db redis             # Postgres on :3946, Redis on :6379
+export ANTHROPIC_API_KEY=sk-ant-...       # required: scoring calls Anthropic
+ANTHROPIC_API_KEY=$ANTHROPIC_API_KEY ./mvnw spring-boot:run
+```
+
+The `ANTHROPIC_API_KEY` must be exported in the same shell that runs
+`spring-boot:run` — Maven inherits the parent shell's environment.
+
+## Run
+
+In a third terminal:
+
+```bash
+./docs/smoke-test/envoy-smoke.sh
+```
+
+The script:
+
+1. Verifies `/actuator/health` returns 200
+2. Logs in via `POST /login` (form, `robsartin` / `xyzzyPLAN9`), saves the session cookie
+3. `POST /api/envoy/postings` with a manual paste of a synthetic job posting
+4. `POST /api/envoy/postings/{id}/score` — this calls Anthropic for real
+5. `GET /api/envoy/reports` — verifies the persisted report shows up
+
+Exits 0 with a green PASSED line on success, non-zero on any failure.
+
+## Cost
+
+One scoring call is roughly 4–6k input tokens (rubric + posting body) and a
+few hundred output tokens. At Sonnet 4.6 prices that's well under a cent
+per run.
+
+## Overrides
+
+Environment variables (defaults in parens):
+
+- `BASE_URL` (`http://localhost:8080`)
+- `USERNAME` (`robsartin`)
+- `PASSWORD` (`xyzzyPLAN9`)
+- `ORGANIZATION_ID` (`019606a0-0000-7000-8000-000000000003` — the seed org from `V2__seed_default_user.sql`)
+
+## When this should be expanded
+
+Items currently out of scope but worth adding when the surface grows:
+
+- `PUT /api/envoy/rubrics/{name}` round-trip (author a custom rubric, score
+  against it, verify the report references the new version)
+- `UrlFetchSource` / `GreenhouseApiSource` paths — both need real network
+  egress and a stable target URL/board, so they're better as separate
+  opt-in scripts
+- Audit log assertion — verify `JobPostingIngested` and `JobPostingScored`
+  produced `audit_log_entries` rows

--- a/docs/smoke-test/envoy-smoke.sh
+++ b/docs/smoke-test/envoy-smoke.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# End-to-end smoke test for the envoy job-scoring service.
+#
+# Walks the full POST /api/envoy/postings → POST .../{id}/score → GET
+# /api/envoy/reports flow against a locally-running app, using form login
+# to obtain a Spring Security session cookie. Exits non-zero on any HTTP
+# error or unexpected response shape.
+#
+# Prereqs:
+#   - docker compose up -d db redis      # Postgres on :3946, Redis on :6379
+#   - export ANTHROPIC_API_KEY=sk-ant-... # required: scoring calls Anthropic
+#   - ./mvnw spring-boot:run              # in another terminal
+#
+# Usage:
+#   ./docs/smoke-test/envoy-smoke.sh
+#
+# Optional env overrides:
+#   BASE_URL      (default http://localhost:8080)
+#   USERNAME      (default robsartin)
+#   PASSWORD      (default xyzzyPLAN9)
+#   ORGANIZATION_ID  (default 019606a0-0000-7000-8000-000000000003 — seed org)
+
+set -euo pipefail
+
+BASE_URL="${BASE_URL:-http://localhost:8080}"
+USERNAME="${USERNAME:-robsartin}"
+PASSWORD="${PASSWORD:-xyzzyPLAN9}"
+ORGANIZATION_ID="${ORGANIZATION_ID:-019606a0-0000-7000-8000-000000000003}"
+
+COOKIES="$(mktemp -t envoy-smoke-cookies.XXXXXX)"
+trap 'rm -f "$COOKIES"' EXIT
+
+step() { printf "\n\033[1;36m▸ %s\033[0m\n" "$*"; }
+ok()   { printf "  \033[1;32m✓\033[0m %s\n" "$*"; }
+fail() { printf "  \033[1;31m✗ %s\033[0m\n" "$*" >&2; exit 1; }
+
+require() {
+    command -v "$1" >/dev/null 2>&1 || fail "missing required command: $1"
+}
+require curl
+require jq
+
+step "1/5 health check"
+status=$(curl -s -o /dev/null -w '%{http_code}' "$BASE_URL/actuator/health")
+[[ "$status" == "200" ]] || fail "actuator/health returned $status (is the app running on $BASE_URL?)"
+ok "app is up at $BASE_URL"
+
+step "2/5 form login as $USERNAME"
+login_status=$(curl -s -o /dev/null -w '%{http_code}' \
+    -c "$COOKIES" -b "$COOKIES" \
+    -X POST "$BASE_URL/login" \
+    -H 'Content-Type: application/x-www-form-urlencoded' \
+    --data-urlencode "username=$USERNAME" \
+    --data-urlencode "password=$PASSWORD")
+# Spring Security form login returns 302 on success
+[[ "$login_status" =~ ^30[0-9]$ ]] \
+    || fail "login returned $login_status, expected 3xx (wrong creds? user not seeded?)"
+ok "session cookie acquired"
+
+step "3/5 ingest a job posting"
+ingest_response=$(curl -fsS -c "$COOKIES" -b "$COOKIES" \
+    -X POST "$BASE_URL/api/envoy/postings?organizationId=$ORGANIZATION_ID" \
+    -H 'Content-Type: application/json' \
+    -d @- <<'EOF'
+{
+  "type": "manual",
+  "payload": "Senior Backend Engineer at Acme Corp. We're hiring a Staff/Senior backend engineer for our platform team. Stack: Java 21, Spring Boot 3, Postgres 17, AWS. Fully remote across the US. Compensation: $230k base, target $300k OTE, equity. Series C, $200M ARR, profitable. We don't expect 60-hour weeks; we work hard and we go home. Reports to a named EM with a clear quarterly roadmap.",
+  "hints": {
+    "company": "Acme Corp",
+    "title": "Senior Backend Engineer",
+    "location": "Remote (US)"
+  }
+}
+EOF
+)
+posting_id=$(echo "$ingest_response" | jq -r '.id')
+[[ -n "$posting_id" && "$posting_id" != "null" ]] || fail "ingest response had no .id: $ingest_response"
+ok "posting ingested, id=$posting_id"
+
+step "4/5 score the posting (calls Anthropic — costs a few cents)"
+[[ -n "${ANTHROPIC_API_KEY:-}" ]] \
+    || fail "ANTHROPIC_API_KEY not set in the app's environment — restart spring-boot:run with it exported"
+score_response=$(curl -fsS -c "$COOKIES" -b "$COOKIES" \
+    -X POST "$BASE_URL/api/envoy/postings/$posting_id/score?organizationId=$ORGANIZATION_ID")
+final_score=$(echo "$score_response" | jq -r '.finalScore')
+recommendation=$(echo "$score_response" | jq -r '.recommendation')
+[[ -n "$final_score" && "$final_score" != "null" ]] \
+    || fail "score response missing .finalScore: $score_response"
+ok "scored: finalScore=$final_score, recommendation=$recommendation"
+
+step "5/5 list reports for this org"
+list_response=$(curl -fsS -c "$COOKIES" -b "$COOKIES" \
+    "$BASE_URL/api/envoy/reports?organizationId=$ORGANIZATION_ID&limit=10")
+count=$(echo "$list_response" | jq -r '.items | length')
+[[ "$count" -ge 1 ]] || fail "report list was empty: $list_response"
+ok "reports list returned $count item(s)"
+
+printf "\n\033[1;32mSmoke test PASSED.\033[0m Posting %s scored at %s (%s).\n" \
+    "$posting_id" "$final_score" "$recommendation"


### PR DESCRIPTION
Adds a small bash script that exercises the full envoy ingest → score → list flow against a locally-running app. Useful as manual QA after envoy / Spring Boot / Anthropic-SDK changes; the slice tests already cover each piece in isolation but nothing currently verifies they boot and talk to real Postgres + Redis + Anthropic together.

## What it does

\`docs/smoke-test/envoy-smoke.sh\`:

1. Pings \`/actuator/health\` (200)
2. Form-logs in as \`robsartin\` and saves the session cookie
3. \`POST /api/envoy/postings\` with a synthetic posting body
4. \`POST /api/envoy/postings/{id}/score\` — calls Anthropic for real (~ a fraction of a cent)
5. \`GET /api/envoy/reports\` — confirms the persisted report shows up

Org-id default is the seed org from \`V2__seed_default_user.sql\` (\`019606a0-…-000000000003\`); override via \`ORGANIZATION_ID\` env if testing against a different org.

## How to run

Documented in \`docs/smoke-test/README.md\`. TL;DR:

\`\`\`bash
docker compose up -d db redis
ANTHROPIC_API_KEY=sk-ant-... ./mvnw spring-boot:run
# in another terminal:
./docs/smoke-test/envoy-smoke.sh
\`\`\`

## Out of scope

Listed in the README. Notable: rubric authoring round-trip, \`UrlFetchSource\` / \`GreenhouseApiSource\` paths (need real network egress to a stable target), and audit-log assertions. Worth adding once the surface grows or when we need a CI-grade integration test (which would belong as an \`@IntegrationTest\` against Testcontainers, not a shell script).

## Test plan

- [x] \`bash -n\` clean
- [ ] User runs it locally and reports back