### PR TITLE
fix: disable Flyway placeholder replacement (broke V15 envoy seed)

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -15,6 +15,10 @@ spring:
   flyway:
     enabled: true
     locations: classpath:db/migration
+    # Disabled because V15 inlines a JSONB literal containing ${…} sequences
+    # that Flyway would otherwise treat as placeholders. No migration uses
+    # Flyway placeholders today — re-enable per-migration if that changes.
+    placeholder-replacement: false
 
   data:
     redis:

--- a/src/test/resources/application-integration.yml
+++ b/src/test/resources/application-integration.yml
@@ -10,6 +10,7 @@ spring:
   flyway:
     enabled: true
     locations: classpath:db/migration
+    placeholder-replacement: false
 
 springdoc:
   api-docs:


### PR DESCRIPTION
## Problem

Discovered during local smoke test of envoy. Boot fails with:

\`\`\`
FlywayException: No value provided for placeholder: \${
  \"id\": \"01910000-0000-7000-8000-000000000001\",
  \"version\": 1,
  ...
\`\`\`

Flyway scans every migration for \`\${name}\` placeholders. \`V15__envoy_seed_default_rubric.sql\` uses a Postgres dollar-quoted JSONB literal (\`\$JSON\$ {...} \$JSON\$\`); the literal sequence \`\$JSON\${\` happens to match Flyway's placeholder prefix, so it tries to substitute and fails.

## Fix

Set \`spring.flyway.placeholder-replacement: false\` in both the main and integration profiles. No existing migration uses Flyway placeholders (grep'd — only V15 has \`\${\` and that's the JSON literal), so disabling it globally is safe and simpler than the per-script directive.

Comment in the yml flags this as a single-bug-driven decision so a future migration that *does* want placeholders gets a chance to opt back in (per-migration via \`script\` config, or by re-enabling globally and quoting V15 differently).

## Test plan
- [x] \`./mvnw test\` — 237 tests, 0 failures (no regression)
- [ ] Manual: \`docker compose up -d db redis && ANTHROPIC_API_KEY=… ./mvnw spring-boot:run\` — Flyway should now apply V14 + V15 cleanly and the app should start. Then run \`./docs/smoke-test/envoy-smoke.sh\`.