### PR TITLE
fix: smoke test — capture XSRF-TOKEN before POST /login

### DIFF
--- a/docs/smoke-test/envoy-smoke.sh
+++ b/docs/smoke-test/envoy-smoke.sh
@@ -46,16 +46,29 @@ status=$(curl -s -o /dev/null -w '%{http_code}' "$BASE_URL/actuator/health")
 ok "app is up at $BASE_URL"
 
 step "2/5 form login as $USERNAME"
-login_status=$(curl -s -o /dev/null -w '%{http_code}' \
+# GET /login first to receive the XSRF-TOKEN cookie that Spring Security's
+# CsrfFilter will require on the POST. CookieCsrfTokenRepository writes it
+# with HttpOnly=false so curl can read and re-send it.
+curl -s -o /dev/null -c "$COOKIES" "$BASE_URL/login"
+csrf=$(awk '$6 == "XSRF-TOKEN" { print $7 }' "$COOKIES")
+[[ -n "$csrf" ]] || fail "no XSRF-TOKEN cookie returned by GET /login (is CSRF still enabled?)"
+
+login_response=$(curl -s -o /dev/null -w '%{http_code}|%{redirect_url}' \
     -c "$COOKIES" -b "$COOKIES" \
     -X POST "$BASE_URL/login" \
     -H 'Content-Type: application/x-www-form-urlencoded' \
+    -H "X-XSRF-TOKEN: $csrf" \
     --data-urlencode "username=$USERNAME" \
     --data-urlencode "password=$PASSWORD")
-# Spring Security form login returns 302 on success
+login_status="${login_response%%|*}"
+login_target="${login_response##*|}"
+# Spring Security form login: 302 → defaultSuccessUrl on success,
+# 302 → /login?error on failure.
 [[ "$login_status" =~ ^30[0-9]$ ]] \
-    || fail "login returned $login_status, expected 3xx (wrong creds? user not seeded?)"
-ok "session cookie acquired"
+    || fail "login returned $login_status, expected 3xx (csrf failure? endpoint changed?)"
+[[ "$login_target" != *"/login?error"* ]] \
+    || fail "login redirected to /login?error — wrong creds or user not seeded"
+ok "session cookie acquired (redirect → $login_target)"
 
 step "3/5 ingest a job posting"
 ingest_response=$(curl -fsS -c "$COOKIES" -b "$COOKIES" \


### PR DESCRIPTION
## Problem

Discovered while running \`./docs/smoke-test/envoy-smoke.sh\` against a running app: the form login \`POST /login\` was rejected by Spring Security's \`CsrfFilter\` (302 → \`/login\` instead of the expected 302 → \`/\`), and every subsequent \`/api/envoy/*\` call also redirected to \`/login\` because the session was never authenticated.

\`SecurityConfig\` disables CSRF only for \`/api/**\` — the form login endpoint still requires the token. The original smoke script went straight to \`POST /login\` without one.

## Fix

\`GET /login\` first, capture the \`XSRF-TOKEN\` cookie that \`CookieCsrfTokenRepository.withHttpOnlyFalse()\` writes, then \`POST /login\` with both the cookie and an \`X-XSRF-TOKEN\` header.

Also tightened the success check: previously any 3xx was treated as success, but Spring's failure path is \`302 → /login?error\`, which we now detect explicitly. Output now includes the redirect target so failures are obvious in the log.

## Test plan
- [ ] User runs \`./docs/smoke-test/envoy-smoke.sh\` against the local stack and the login step succeeds (then ingest → score → list)