### PR TITLE
fix: use non-Xor CSRF handler so non-browser clients can authenticate

### DIFF
--- a/src/main/java/com/majordomo/adapter/in/web/config/SecurityConfig.java
+++ b/src/main/java/com/majordomo/adapter/in/web/config/SecurityConfig.java
@@ -12,6 +12,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
+import org.springframework.security.web.csrf.CsrfTokenRequestAttributeHandler;
 
 /**
  * Spring Security configuration for Majordomo.
@@ -83,6 +84,16 @@ public class SecurityConfig {
             .csrf(csrf -> csrf
                 .ignoringRequestMatchers("/api/**")
                 .csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse())
+                // Use the plain handler instead of the BREACH-mitigating
+                // XorCsrfTokenRequestAttributeHandler so the value sent back
+                // in the X-XSRF-TOKEN header / _csrf form param matches the
+                // raw value stored in the XSRF-TOKEN cookie. Required for
+                // curl-based scripts (smoke test, ad-hoc API probing) and
+                // any non-browser client. The browser flow still works via
+                // Thymeleaf-rendered _csrf inputs. Trade-off: no BREACH
+                // protection on CSRF token transport — acceptable for a
+                // localhost-by-default personal-management app.
+                .csrfTokenRequestHandler(new CsrfTokenRequestAttributeHandler())
             );
 
         return http.build();


### PR DESCRIPTION
## Problem

Discovered while running \`./docs/smoke-test/envoy-smoke.sh\`. The smoke script and any other non-browser HTTP client cannot authenticate via form login: \`POST /login\` redirects back to \`/login\` (not \`/\`, not \`/login?error\`), all subsequent \`/api/**\` requests redirect to \`/login\`, dashboard probes also redirect — i.e. the session never authenticates.

Root cause: Spring Security 6's default CSRF handler is \`XorCsrfTokenRequestAttributeHandler\`. It writes a *raw* token to the \`XSRF-TOKEN\` cookie but expects the *masked* (XOR'd) token in the request (header or form param). Browsers send the masked value because Thymeleaf renders \`<input name=\"_csrf\" value=\"\${_csrf.token}\">\` with the masked token. curl scripts that echo back the cookie value get a CSRF rejection, which falls through to a generic redirect to \`/login\` — silently anonymous.

## Fix

Configure the plain \`CsrfTokenRequestAttributeHandler\` so the cookie value and the expected request value are the same raw token. One-line change in \`SecurityConfig\` plus an inline comment explaining the trade-off.

## Trade-off

Removes BREACH protection on CSRF token transport. For a localhost-by-default personal-management app this is fine — BREACH requires a network-attacker scenario over compressed HTTPS on the public internet, which isn't this app's threat model. Browser login behavior is unchanged.

## Why not seed an API key

Considered but rejected as the smoke-test fix:
- Requires a Flyway migration plus a place to ship the plaintext key
- API keys hash via SHA-256 in this codebase, but a *seeded* key would have to ship its plaintext somewhere or get printed at boot — both ugly
- Doesn't help any other curl-based debugging the user might want to do

## Test plan
- [x] \`./mvnw test\` — 237 tests, 0 failures (no regression)
- [ ] User runs \`./docs/smoke-test/envoy-smoke.sh\` after this merges and confirms full pass through ingest → score → list