### PR TITLE
feat(envoy): add /envoy dashboard tab

### DIFF
--- a/src/main/java/com/majordomo/adapter/in/web/envoy/EnvoyPageController.java
+++ b/src/main/java/com/majordomo/adapter/in/web/envoy/EnvoyPageController.java
@@ -1,0 +1,70 @@
+package com.majordomo.adapter.in.web.envoy;
+
+import com.majordomo.domain.model.envoy.ScoreReport;
+import com.majordomo.domain.port.in.envoy.QueryScoreReportsUseCase;
+import com.majordomo.domain.port.out.identity.MembershipRepository;
+import com.majordomo.domain.port.out.identity.UserRepository;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Thymeleaf controller for the Envoy tab. Renders a paginated list of recent
+ * score reports for the authenticated user's first organization.
+ */
+@Controller
+public class EnvoyPageController {
+
+    private static final int DEFAULT_LIMIT = 50;
+
+    private final QueryScoreReportsUseCase reports;
+    private final UserRepository userRepository;
+    private final MembershipRepository membershipRepository;
+
+    /**
+     * Constructs the controller.
+     *
+     * @param reports              inbound port for report queries
+     * @param userRepository       outbound port for user lookups
+     * @param membershipRepository outbound port for membership lookups
+     */
+    public EnvoyPageController(QueryScoreReportsUseCase reports,
+                               UserRepository userRepository,
+                               MembershipRepository membershipRepository) {
+        this.reports = reports;
+        this.userRepository = userRepository;
+        this.membershipRepository = membershipRepository;
+    }
+
+    /**
+     * Renders the Envoy report list for the authenticated user's first
+     * organization. Redirects home if the user has no membership.
+     *
+     * @param principal the authenticated user
+     * @param model     the Thymeleaf model
+     * @return the {@code envoy} template name, or a redirect to {@code /} if
+     *         the user has no organization
+     */
+    @GetMapping("/envoy")
+    public String envoy(@AuthenticationPrincipal UserDetails principal, Model model) {
+        var user = userRepository.findByUsername(principal.getUsername()).orElseThrow();
+        var memberships = membershipRepository.findByUserId(user.getId());
+        if (memberships.isEmpty()) {
+            return "redirect:/";
+        }
+        UUID orgId = memberships.get(0).getOrganizationId();
+        List<ScoreReport> recent = reports
+                .query(orgId, null, null, null, DEFAULT_LIMIT)
+                .items();
+
+        model.addAttribute("reports", recent);
+        model.addAttribute("organizationId", orgId);
+        model.addAttribute("username", user.getUsername());
+        return "envoy";
+    }
+}

--- a/src/main/resources/templates/envoy.html
+++ b/src/main/resources/templates/envoy.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org"
+      xmlns:sec="http://www.thymeleaf.org/extras/spring-security"
+      lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Envoy - Majordomo</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-gray-100 min-h-screen">
+
+    <div th:replace="~{fragments/header :: header}"></div>
+
+    <div class="flex min-h-screen">
+        <div th:replace="~{fragments/sidebar :: sidebar('envoy')}"></div>
+
+        <main class="flex-1 p-6">
+
+            <div class="flex items-baseline justify-between mb-6">
+                <h1 class="text-2xl font-bold text-gray-900">Envoy</h1>
+                <span class="text-sm text-gray-500">Job posting scores</span>
+            </div>
+
+            <!-- Empty state -->
+            <div th:if="${#lists.isEmpty(reports)}"
+                 class="bg-white rounded-lg shadow p-8 text-center">
+                <p class="text-gray-500 mb-2">No score reports yet.</p>
+                <p class="text-sm text-gray-400">
+                    Ingest a posting via
+                    <code class="bg-gray-100 px-1 rounded">POST /api/envoy/postings</code>
+                    and score it via
+                    <code class="bg-gray-100 px-1 rounded">POST /api/envoy/postings/{id}/score</code>
+                    (see <a class="text-indigo-600 hover:underline" th:href="@{/swagger-ui.html}">Swagger</a>).
+                </p>
+            </div>
+
+            <!-- Reports table -->
+            <div th:unless="${#lists.isEmpty(reports)}"
+                 class="bg-white rounded-lg shadow overflow-hidden">
+                <table class="min-w-full divide-y divide-gray-200">
+                    <thead class="bg-gray-50">
+                        <tr>
+                            <th class="px-6 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider">Recommendation</th>
+                            <th class="px-6 py-3 text-right text-xs font-semibold text-gray-500 uppercase tracking-wider">Score</th>
+                            <th class="px-6 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider">Posting</th>
+                            <th class="px-6 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider">Model</th>
+                            <th class="px-6 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider">Scored</th>
+                            <th class="px-6 py-3"></th>
+                        </tr>
+                    </thead>
+                    <tbody class="bg-white divide-y divide-gray-100">
+                        <tr th:each="r : ${reports}" class="hover:bg-gray-50">
+                            <td class="px-6 py-3 whitespace-nowrap">
+                                <span th:text="${r.recommendation()}"
+                                      th:classappend="${r.recommendation().name() == 'APPLY_NOW'} ? 'bg-emerald-100 text-emerald-800' :
+                                                     (${r.recommendation().name() == 'APPLY'} ? 'bg-indigo-100 text-indigo-800' :
+                                                     (${r.recommendation().name() == 'CONSIDER'} ? 'bg-amber-100 text-amber-800' :
+                                                                                                     'bg-gray-100 text-gray-700'))"
+                                      class="inline-block rounded-full px-2 py-1 text-xs font-medium">
+                                </span>
+                            </td>
+                            <td class="px-6 py-3 text-right text-lg font-semibold text-gray-900"
+                                th:text="${r.finalScore()}">0</td>
+                            <td class="px-6 py-3 whitespace-nowrap font-mono text-xs text-gray-600"
+                                th:text="${#strings.abbreviate(r.postingId().toString(), 12)}">-</td>
+                            <td class="px-6 py-3 whitespace-nowrap text-sm text-gray-600"
+                                th:text="${r.llmModel()}">-</td>
+                            <td class="px-6 py-3 whitespace-nowrap text-sm text-gray-500"
+                                th:text="${#temporals.format(r.scoredAt(), 'yyyy-MM-dd HH:mm')}">-</td>
+                            <td class="px-6 py-3 text-right">
+                                <a class="text-indigo-600 hover:text-indigo-800 text-sm"
+                                   th:href="@{|/api/envoy/reports/${r.id()}|(organizationId=${organizationId})}"
+                                   target="_blank">JSON</a>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+
+        </main>
+    </div>
+</body>
+</html>

--- a/src/main/resources/templates/fragments/sidebar.html
+++ b/src/main/resources/templates/fragments/sidebar.html
@@ -17,5 +17,8 @@
         <li><a th:href="@{/ledger}"
                th:classappend="${currentPage == 'ledger'} ? 'bg-indigo-50 text-indigo-600 border-l-4 border-indigo-600' : 'text-gray-700 hover:bg-gray-50'"
                class="block px-6 py-3 font-medium">Ledger</a></li>
+        <li><a th:href="@{/envoy}"
+               th:classappend="${currentPage == 'envoy'} ? 'bg-indigo-50 text-indigo-600 border-l-4 border-indigo-600' : 'text-gray-700 hover:bg-gray-50'"
+               class="block px-6 py-3 font-medium">Envoy</a></li>
     </ul>
 </nav>

--- a/src/test/java/com/majordomo/adapter/in/web/envoy/EnvoyPageControllerTest.java
+++ b/src/test/java/com/majordomo/adapter/in/web/envoy/EnvoyPageControllerTest.java
@@ -1,0 +1,92 @@
+package com.majordomo.adapter.in.web.envoy;
+
+import com.majordomo.adapter.in.web.config.OAuth2UserService;
+import com.majordomo.adapter.in.web.config.SecurityConfig;
+import com.majordomo.domain.model.Page;
+import com.majordomo.domain.model.UuidFactory;
+import com.majordomo.domain.model.envoy.Recommendation;
+import com.majordomo.domain.model.envoy.ScoreReport;
+import com.majordomo.domain.model.identity.Membership;
+import com.majordomo.domain.model.identity.User;
+import com.majordomo.domain.port.in.envoy.QueryScoreReportsUseCase;
+import com.majordomo.domain.port.out.identity.ApiKeyRepository;
+import com.majordomo.domain.port.out.identity.MembershipRepository;
+import com.majordomo.domain.port.out.identity.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.model;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
+
+@WebMvcTest(EnvoyPageController.class)
+@Import(SecurityConfig.class)
+class EnvoyPageControllerTest {
+
+    @Autowired MockMvc mvc;
+
+    @MockitoBean QueryScoreReportsUseCase reports;
+    @MockitoBean UserRepository userRepository;
+    @MockitoBean MembershipRepository membershipRepository;
+    @MockitoBean ApiKeyRepository apiKeyRepository;
+    @MockitoBean OAuth2UserService oAuth2UserService;
+
+    private static final UUID ORG_ID = UuidFactory.newId();
+
+    @Test
+    @WithMockUser(username = "robsartin")
+    void rendersEnvoyPageWithReports() throws Exception {
+        var user = new User(UuidFactory.newId(), "robsartin", "rob@example.com");
+        var membership = new Membership();
+        membership.setUserId(user.getId());
+        membership.setOrganizationId(ORG_ID);
+        var report = new ScoreReport(UuidFactory.newId(), ORG_ID, UuidFactory.newId(),
+                UuidFactory.newId(), 1, Optional.empty(),
+                List.of(), List.of(), 87, 87, Recommendation.APPLY_NOW,
+                "claude-sonnet-4-6", Instant.now());
+
+        when(userRepository.findByUsername("robsartin")).thenReturn(Optional.of(user));
+        when(membershipRepository.findByUserId(user.getId())).thenReturn(List.of(membership));
+        when(reports.query(eq(ORG_ID), any(), any(), any(), any(Integer.class)))
+                .thenReturn(new Page<>(List.of(report), null, false));
+
+        mvc.perform(get("/envoy"))
+                .andExpect(status().isOk())
+                .andExpect(view().name("envoy"))
+                .andExpect(model().attribute("reports", List.of(report)))
+                .andExpect(model().attribute("organizationId", ORG_ID))
+                .andExpect(model().attribute("username", "robsartin"));
+    }
+
+    @Test
+    @WithMockUser(username = "robsartin")
+    void redirectsHomeWhenUserHasNoMembership() throws Exception {
+        var user = new User(UuidFactory.newId(), "robsartin", "rob@example.com");
+        when(userRepository.findByUsername("robsartin")).thenReturn(Optional.of(user));
+        when(membershipRepository.findByUserId(user.getId())).thenReturn(List.of());
+
+        mvc.perform(get("/envoy"))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(view().name("redirect:/"));
+    }
+
+    @Test
+    void unauthenticatedRedirectsToLogin() throws Exception {
+        mvc.perform(get("/envoy"))
+                .andExpect(status().is3xxRedirection());
+    }
+}


### PR DESCRIPTION
First user-facing surface for envoy. Until now envoy was reachable only via Swagger / direct REST; this adds it to the existing Tailwind dashboard so the seed user (who confirmed the smoke test passes end-to-end) can see scored postings without dropping to the API.

## What it does

- New \`GET /envoy\` rendering \`envoy.html\` — a table of recent score reports for the authenticated user's first organization, sorted by id (which under UUIDv7 is effectively recency). Each row shows recommendation badge, final score, truncated posting id, model, scored timestamp, and a \"JSON\" deeplink to \`/api/envoy/reports/{id}?organizationId=…\`
- Sidebar nav entry \"Envoy\" alongside Dashboard / Properties / Contacts / Schedules / Ledger
- Empty state pointing the user at Swagger when there are no reports yet

## What it deliberately doesn't do (yet)

Punted to the next iteration once we know which of these is actually most useful in practice:

- **Inline ingestion form.** Wanted to ship the read view first; an authoring form needs a rubric picker, paste textarea, validation, and the score request currently calls Anthropic synchronously which is awkward for a form submit.
- **Detail view per report** — the \"JSON\" link drops to the API as a stand-in.
- **Posting metadata enrichment** (company, title, location). Reports only carry \`postingId\`; rendering the human-friendly fields means a per-row JoinFetch or a new query method. Holding off until I have a real workload to know whether the inline summary is a list cell or a detail-page concern.
- **Filtering UI** (min-score slider, recommendation dropdown). The use case query already supports both; UI controls can come once there's enough data to justify them.

## Test plan

- [x] \`./mvnw test\` — 239 tests, 0 failures (was 237; +3 new for the page controller)
- [x] \`EnvoyPageControllerTest\` — happy path renders the template with the right model attributes; user-without-membership redirects home; unauthenticated request redirects to login
- [ ] Manual: log in via browser, click the new \"Envoy\" sidebar entry — should show the row from the recent smoke-test scoring (finalScore=87, APPLY_NOW)