### PR TITLE
fix: form login lands at /dashboard, closes #142

### DIFF
--- a/src/main/java/com/majordomo/adapter/in/web/config/SecurityConfig.java
+++ b/src/main/java/com/majordomo/adapter/in/web/config/SecurityConfig.java
@@ -61,7 +61,7 @@ public class SecurityConfig {
             )
             .formLogin(form -> form
                 .loginPage("/login")
-                .defaultSuccessUrl("/", true)
+                .defaultSuccessUrl("/dashboard", true)
                 .permitAll()
             )
             .oauth2Login(oauth -> oauth

--- a/src/test/java/com/majordomo/adapter/in/web/config/SecurityConfigTest.java
+++ b/src/test/java/com/majordomo/adapter/in/web/config/SecurityConfigTest.java
@@ -10,19 +10,47 @@ import com.majordomo.domain.port.out.identity.ApiKeyRepository;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.crypto.argon2.Argon2PasswordEncoder;
+import org.springframework.security.provisioning.InMemoryUserDetailsManager;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestBuilders.formLogin;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 /**
  * Tests for {@link SecurityConfig} verifying public and protected endpoint access.
  */
 @WebMvcTest(controllers = {HomeController.class, LoginController.class, ContactController.class})
-@Import(SecurityConfig.class)
+@Import({SecurityConfig.class, SecurityConfigTest.TestUserDetailsConfig.class})
 class SecurityConfigTest {
+
+    /**
+     * Provides an in-memory user details service so the {@code formLogin}
+     * request builder can authenticate against a known principal without
+     * needing the production {@code AuthenticationService} (which requires
+     * the full domain wiring).
+     */
+    @TestConfiguration
+    static class TestUserDetailsConfig {
+        @Bean
+        UserDetailsService userDetailsService() {
+            String hash = Argon2PasswordEncoder.defaultsForSpringSecurity_v5_8()
+                    .encode("secret");
+            return new InMemoryUserDetailsManager(
+                    User.withUsername("alice")
+                            .password(hash)
+                            .authorities("ROLE_USER")
+                            .build());
+        }
+    }
 
     @Autowired
     private MockMvc mockMvc;
@@ -65,5 +93,29 @@ class SecurityConfigTest {
     void faviconIsAccessibleWithoutAuth() throws Exception {
         mockMvc.perform(get("/favicon.ico"))
                 .andExpect(status().isOk());
+    }
+
+    /**
+     * Successful form login should land the user on /dashboard, not /.
+     * Closes #142 — the home page is the unauthenticated marketing surface;
+     * authenticated users belong on the app shell at /dashboard.
+     */
+    @Test
+    void successfulFormLoginRedirectsToDashboard() throws Exception {
+        mockMvc.perform(formLogin("/login").user("alice").password("secret"))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/dashboard"));
+    }
+
+    /**
+     * Confirms the security wall on /dashboard: an unauthenticated GET is
+     * redirected to the login page. Pairs with the success-URL change so
+     * we know the path we now redirect to is itself protected.
+     */
+    @Test
+    void dashboardRequiresAuthentication() throws Exception {
+        mockMvc.perform(get("/dashboard"))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("http://localhost/login"));
     }
 }


### PR DESCRIPTION
## Summary

- After successful form login, redirect to `/dashboard` (the app shell) instead of `/` (the unauthenticated marketing page). Closes #142.
- One-line change in `SecurityConfig`: `.defaultSuccessUrl("/", true)` → `.defaultSuccessUrl("/dashboard", true)`.

## Tests (strict TDD)

- Added `SecurityConfigTest.successfulFormLoginRedirectsToDashboard`, which uses `SecurityMockMvcRequestBuilders.formLogin()` and asserts the 302 `Location` is `/dashboard`. Verified failing first against the unchanged code (`expected:</dashboard> but was:</>`), then passing after the one-line fix.
- Added `SecurityConfigTest.dashboardRequiresAuthentication` to confirm the security wall on `/dashboard`: an unauthenticated GET still redirects to `/login`.
- Wired an in-memory `UserDetailsService` via a nested `@TestConfiguration` so the form-login flow can authenticate without the full domain wiring; password is hashed with the same `Argon2PasswordEncoder.defaultsForSpringSecurity_v5_8()` used in production.

## Verification

- `./mvnw verify` green locally — 241 tests, 0 failures, 0 errors. Matches CI.

## Test plan

- [x] `SecurityConfigTest` — POST `/login` with valid creds returns 302 with `Location: /dashboard`
- [x] `SecurityConfigTest` — GET `/dashboard` without auth redirects to `/login`
- [x] `./mvnw verify` passes (Checkstyle + ArchUnit + all unit/slice tests)
- [ ] Manual: log out, log back in, confirm landing on the dashboard with the sidebar visible