### PR TITLE
feat(envoy): LLM confidence per category, closes #150

### DIFF
--- a/src/main/java/com/majordomo/application/envoy/PromptBuilder.java
+++ b/src/main/java/com/majordomo/application/envoy/PromptBuilder.java
@@ -36,7 +36,8 @@ public class PromptBuilder {
                   {
                     "disqualifierKey": string | null,
                     "categoryVerdicts": [
-                      {"categoryKey": string, "tierLabel": string, "rationale": string}
+                      {"categoryKey": string, "tierLabel": string,
+                       "rationale": string, "confidence": "HIGH" | "MEDIUM" | "LOW"}
                     ],
                     "flagHits": [
                       {"flagKey": string, "rationale": string}
@@ -45,7 +46,16 @@ public class PromptBuilder {
                   """)
           .append("\nReturn exactly one categoryVerdict per category below.\n")
           .append("If any disqualifier applies, set disqualifierKey to its key and ")
-          .append("return empty categoryVerdicts and flagHits.\n\n");
+          .append("return empty categoryVerdicts and flagHits.\n\n")
+          .append("For each categoryVerdict, set `confidence` to reflect how strongly ")
+          .append("the posting supports your tier choice:\n")
+          .append("- \"HIGH\": the posting contains explicit, unambiguous evidence ")
+          .append("(e.g. a stated salary range, a named tech stack).\n")
+          .append("- \"MEDIUM\": some evidence is present but partial, indirect, ")
+          .append("or open to interpretation.\n")
+          .append("- \"LOW\": signals are sparse or absent and the verdict is ")
+          .append("essentially a guess (e.g. \"competitive salary\" with no numbers).\n")
+          .append("Use only the literal strings HIGH, MEDIUM, or LOW.\n\n");
 
         sb.append("## Disqualifiers (hard fails)\n");
         if (rubric.disqualifiers().isEmpty()) {

--- a/src/main/java/com/majordomo/application/envoy/ScoreAssembler.java
+++ b/src/main/java/com/majordomo/application/envoy/ScoreAssembler.java
@@ -62,7 +62,11 @@ public class ScoreAssembler {
         for (var verdict : resp.categoryVerdicts()) {
             Tier tier = lookupTier(rubric, verdict.categoryKey(), verdict.tierLabel());
             categoryScores.add(new CategoryScore(
-                    verdict.categoryKey(), tier.points(), tier.label(), verdict.rationale()));
+                    verdict.categoryKey(),
+                    tier.points(),
+                    tier.label(),
+                    verdict.rationale(),
+                    verdict.confidence()));
             rawScore += tier.points();
         }
 

--- a/src/main/java/com/majordomo/domain/model/envoy/CategoryScore.java
+++ b/src/main/java/com/majordomo/domain/model/envoy/CategoryScore.java
@@ -1,12 +1,64 @@
 package com.majordomo.domain.model.envoy;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Optional;
+
 /**
  * The LLM's verdict for a single category. The rationale is preserved verbatim
  * for audit so surprising scores can be explained after the fact.
+ *
+ * <p>{@code confidence} is optional on the wire: legacy reports written before
+ * issue #150 lack the field, and {@link ScoreReport ScoreReport} bodies are
+ * loaded via Jackson from the JSONB column on every read.
  *
  * @param categoryKey the {@link Category#key()} this score applies to
  * @param points      points awarded (matches the selected tier's points)
  * @param tierLabel   label of the {@link Tier} the LLM selected
  * @param rationale   LLM's free-text reasoning for the tier selection
+ * @param confidence  the LLM's self-reported certainty; empty for legacy rows
  */
-public record CategoryScore(String categoryKey, int points, String tierLabel, String rationale) { }
+public record CategoryScore(
+        String categoryKey,
+        int points,
+        String tierLabel,
+        String rationale,
+        Optional<Confidence> confidence) {
+
+    /**
+     * Convenience constructor for callers that did not capture confidence
+     * (e.g. older test fixtures). Equivalent to {@link Optional#empty()}.
+     *
+     * @param categoryKey the {@link Category#key()} this score applies to
+     * @param points      points awarded (matches the selected tier's points)
+     * @param tierLabel   label of the {@link Tier} the LLM selected
+     * @param rationale   LLM's free-text reasoning for the tier selection
+     */
+    public CategoryScore(String categoryKey, int points, String tierLabel, String rationale) {
+        this(categoryKey, points, tierLabel, rationale, Optional.empty());
+    }
+
+    /**
+     * Jackson creator so a missing or null {@code confidence} field
+     * deserialises to {@link Optional#empty()} — required for backward
+     * compatibility with score-report JSONB rows written prior to #150.
+     *
+     * @param categoryKey raw category key from JSON
+     * @param points      raw point value from JSON
+     * @param tierLabel   raw tier label from JSON
+     * @param rationale   raw rationale from JSON
+     * @param confidence  raw confidence enum (possibly null) from JSON
+     * @return a normalised {@code CategoryScore}
+     */
+    @JsonCreator
+    public static CategoryScore of(
+            @JsonProperty("categoryKey") String categoryKey,
+            @JsonProperty("points") int points,
+            @JsonProperty("tierLabel") String tierLabel,
+            @JsonProperty("rationale") String rationale,
+            @JsonProperty("confidence") Confidence confidence) {
+        return new CategoryScore(
+                categoryKey, points, tierLabel, rationale, Optional.ofNullable(confidence));
+    }
+}

--- a/src/main/java/com/majordomo/domain/model/envoy/Confidence.java
+++ b/src/main/java/com/majordomo/domain/model/envoy/Confidence.java
@@ -1,0 +1,19 @@
+package com.majordomo.domain.model.envoy;
+
+/**
+ * The LLM's self-reported certainty for a single {@link CategoryScore}.
+ * Surfaced on score-report views so users can tell a confident verdict
+ * (explicit signals in the posting) from a guess (sparse or ambiguous text).
+ *
+ * <p>Three buckets keep the LLM contract simple — finer gradations would
+ * invite false precision from a model that has no grounded notion of
+ * probability. Mapped to JSON by name (Jackson default for enums).
+ */
+public enum Confidence {
+    /** The posting contains explicit, unambiguous evidence for the chosen tier. */
+    HIGH,
+    /** Some evidence is present but partial, indirect, or open to interpretation. */
+    MEDIUM,
+    /** Sparse or absent signals; the verdict is essentially a guess. */
+    LOW
+}

--- a/src/main/java/com/majordomo/domain/model/envoy/LlmScoreResponse.java
+++ b/src/main/java/com/majordomo/domain/model/envoy/LlmScoreResponse.java
@@ -24,11 +24,55 @@ public record LlmScoreResponse(
     /**
      * A single category verdict returned by the LLM.
      *
+     * <p>{@code confidence} is optional on the wire so older score reports
+     * (written before issue #150) still deserialise cleanly. Jackson maps the
+     * {@link Confidence} enum to/from its name (HIGH/MEDIUM/LOW).
+     *
      * @param categoryKey matches {@link Category#key()} in the rubric
      * @param tierLabel   matches a {@link Tier#label()} within that category
      * @param rationale   free text explaining the selection
+     * @param confidence  the LLM's self-reported certainty for this verdict;
+     *                    empty when absent on the wire
      */
-    public record CategoryVerdict(String categoryKey, String tierLabel, String rationale) { }
+    public record CategoryVerdict(
+            String categoryKey,
+            String tierLabel,
+            String rationale,
+            Optional<Confidence> confidence) {
+
+        /**
+         * Convenience constructor for callers that have not yet adopted the
+         * confidence field (older tests, generated payloads). Equivalent to
+         * supplying {@link Optional#empty()} for {@code confidence}.
+         *
+         * @param categoryKey matches {@link Category#key()} in the rubric
+         * @param tierLabel   matches a {@link Tier#label()} within that category
+         * @param rationale   free text explaining the selection
+         */
+        public CategoryVerdict(String categoryKey, String tierLabel, String rationale) {
+            this(categoryKey, tierLabel, rationale, Optional.empty());
+        }
+
+        /**
+         * Jackson creator so a missing or null {@code confidence} field
+         * deserialises to {@link Optional#empty()} instead of failing.
+         *
+         * @param categoryKey raw category key from JSON
+         * @param tierLabel   raw tier label from JSON
+         * @param rationale   raw rationale from JSON
+         * @param confidence  raw confidence enum (possibly null) from JSON
+         * @return a normalised {@code CategoryVerdict}
+         */
+        @JsonCreator
+        public static CategoryVerdict of(
+                @JsonProperty("categoryKey") String categoryKey,
+                @JsonProperty("tierLabel") String tierLabel,
+                @JsonProperty("rationale") String rationale,
+                @JsonProperty("confidence") Confidence confidence) {
+            return new CategoryVerdict(
+                    categoryKey, tierLabel, rationale, Optional.ofNullable(confidence));
+        }
+    }
 
     /**
      * A single flag finding returned by the LLM.

--- a/src/test/java/com/majordomo/adapter/out/persistence/envoy/ScoreReportMapperBackwardCompatTest.java
+++ b/src/test/java/com/majordomo/adapter/out/persistence/envoy/ScoreReportMapperBackwardCompatTest.java
@@ -1,0 +1,129 @@
+package com.majordomo.adapter.out.persistence.envoy;
+
+import com.majordomo.domain.model.UuidFactory;
+import com.majordomo.domain.model.envoy.Confidence;
+import com.majordomo.domain.model.envoy.ScoreReport;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies that older score-report JSON payloads, which do not include the
+ * {@code confidence} field on each category score, still deserialise cleanly
+ * through the same Jackson configuration used by {@link ScoreReportMapper}
+ * and {@link RubricMapper}. The {@code body} JSONB column already holds rows
+ * written before the confidence-per-category feature shipped — those rows
+ * must continue to load.
+ */
+class ScoreReportMapperBackwardCompatTest {
+
+    @Test
+    void oldShapedScoreReportDeserialisesWithoutConfidenceField() {
+        UUID id = UuidFactory.newId();
+        UUID orgId = UuidFactory.newId();
+        UUID postingId = UuidFactory.newId();
+        UUID rubricId = UuidFactory.newId();
+        Instant scoredAt = Instant.parse("2026-01-15T10:00:00Z");
+
+        // Body shape predates issue #150 — no `confidence` key on any category.
+        String legacyBody = """
+                {
+                  "id": "%s",
+                  "organizationId": "%s",
+                  "postingId": "%s",
+                  "rubricId": "%s",
+                  "rubricVersion": 1,
+                  "disqualifiedBy": null,
+                  "categoryScores": [
+                    {"categoryKey": "compensation", "points": 15,
+                     "tierLabel": "Good", "rationale": "salary listed"}
+                  ],
+                  "flagHits": [],
+                  "rawScore": 15,
+                  "finalScore": 15,
+                  "recommendation": "APPLY",
+                  "llmModel": "claude-sonnet-4-6",
+                  "scoredAt": "2026-01-15T10:00:00Z"
+                }
+                """.formatted(id, orgId, postingId, rubricId);
+
+        var entity = new ScoreReportEntity();
+        entity.setId(id);
+        entity.setOrganizationId(orgId);
+        entity.setPostingId(postingId);
+        entity.setRubricId(rubricId);
+        entity.setRubricVersion(1);
+        entity.setBody(legacyBody);
+        entity.setFinalScore(15);
+        entity.setRecommendation("APPLY");
+        entity.setScoredAt(scoredAt);
+
+        ScoreReport report = ScoreReportMapper.toDomain(entity);
+
+        assertThat(report.id()).isEqualTo(id);
+        assertThat(report.categoryScores()).hasSize(1);
+        assertThat(report.categoryScores().get(0).categoryKey()).isEqualTo("compensation");
+        assertThat(report.categoryScores().get(0).confidence()).isEmpty();
+    }
+
+    @Test
+    void newShapedScoreReportRoundTripsThroughMapper() {
+        UUID id = UuidFactory.newId();
+        UUID orgId = UuidFactory.newId();
+        UUID postingId = UuidFactory.newId();
+        UUID rubricId = UuidFactory.newId();
+        Instant scoredAt = Instant.parse("2026-04-23T10:00:00Z");
+
+        String newBody = """
+                {
+                  "id": "%s",
+                  "organizationId": "%s",
+                  "postingId": "%s",
+                  "rubricId": "%s",
+                  "rubricVersion": 1,
+                  "disqualifiedBy": null,
+                  "categoryScores": [
+                    {"categoryKey": "compensation", "points": 15,
+                     "tierLabel": "Good", "rationale": "salary listed",
+                     "confidence": "HIGH"},
+                    {"categoryKey": "remote", "points": 5,
+                     "tierLabel": "Hybrid", "rationale": "ambiguous",
+                     "confidence": "LOW"}
+                  ],
+                  "flagHits": [],
+                  "rawScore": 20,
+                  "finalScore": 20,
+                  "recommendation": "APPLY",
+                  "llmModel": "claude-sonnet-4-6",
+                  "scoredAt": "2026-04-23T10:00:00Z"
+                }
+                """.formatted(id, orgId, postingId, rubricId);
+
+        var entity = new ScoreReportEntity();
+        entity.setId(id);
+        entity.setOrganizationId(orgId);
+        entity.setPostingId(postingId);
+        entity.setRubricId(rubricId);
+        entity.setRubricVersion(1);
+        entity.setBody(newBody);
+        entity.setFinalScore(20);
+        entity.setRecommendation("APPLY");
+        entity.setScoredAt(scoredAt);
+
+        ScoreReport report = ScoreReportMapper.toDomain(entity);
+
+        assertThat(report.categoryScores()).hasSize(2);
+        assertThat(report.categoryScores().get(0).confidence()).contains(Confidence.HIGH);
+        assertThat(report.categoryScores().get(1).confidence()).contains(Confidence.LOW);
+
+        // And round-trip back to JSON — the serialised form must still be
+        // deserialisable by the same mapper.
+        var roundTripEntity = ScoreReportMapper.toEntity(report);
+        ScoreReport again = ScoreReportMapper.toDomain(roundTripEntity);
+        assertThat(again.categoryScores().get(0).confidence()).contains(Confidence.HIGH);
+        assertThat(again.categoryScores().get(1).confidence()).contains(Confidence.LOW);
+    }
+}

--- a/src/test/java/com/majordomo/application/envoy/PromptBuilderTest.java
+++ b/src/test/java/com/majordomo/application/envoy/PromptBuilderTest.java
@@ -42,4 +42,25 @@ class PromptBuilderTest {
         assertThat(p.systemPrompt()).doesNotContain("\"points\"");
         assertThat(p.userPrompt()).contains("Acme").contains("Senior Engineer").contains("We offer");
     }
+
+    @Test
+    void systemPromptInstructsLlmAboutConfidenceField() {
+        var rubric = new Rubric(UuidFactory.newId(), Optional.empty(), 1, "default",
+                List.of(),
+                List.of(new Category("compensation", "pay", 20, List.of(
+                        new Tier("Good", 15, "$200-250k")))),
+                List.of(),
+                new Thresholds(20, 15, 5), Instant.now());
+
+        var posting = new JobPosting();
+        posting.setRawText("body");
+
+        ScoringPrompt p = new PromptBuilder().build(posting, rubric);
+
+        assertThat(p.systemPrompt())
+                .contains("confidence")
+                .contains("HIGH")
+                .contains("MEDIUM")
+                .contains("LOW");
+    }
 }

--- a/src/test/java/com/majordomo/application/envoy/ScoreAssemblerTest.java
+++ b/src/test/java/com/majordomo/application/envoy/ScoreAssemblerTest.java
@@ -2,6 +2,7 @@ package com.majordomo.application.envoy;
 
 import com.majordomo.domain.model.UuidFactory;
 import com.majordomo.domain.model.envoy.Category;
+import com.majordomo.domain.model.envoy.Confidence;
 import com.majordomo.domain.model.envoy.Disqualifier;
 import com.majordomo.domain.model.envoy.Flag;
 import com.majordomo.domain.model.envoy.JobPosting;
@@ -146,5 +147,56 @@ class ScoreAssemblerTest {
         assertThatThrownBy(() -> assembler().assemble(posting, rubric, resp, "m"))
                 .isInstanceOf(LlmScoringException.class)
                 .hasMessageContaining("remote");
+    }
+
+    @Test
+    void confidenceFlowsFromVerdictToCategoryScore() {
+        var resp = LlmScoreResponse.of(null,
+                List.of(
+                        new LlmScoreResponse.CategoryVerdict(
+                                "compensation", "Good", "salary listed", Optional.of(Confidence.HIGH)),
+                        new LlmScoreResponse.CategoryVerdict(
+                                "remote", "Hybrid", "ambiguous wording", Optional.of(Confidence.LOW))),
+                List.of());
+
+        ScoreReport report = assembler().assemble(posting, rubric, resp, "m");
+
+        assertThat(report.categoryScores())
+                .extracting("categoryKey", "confidence")
+                .containsExactly(
+                        org.assertj.core.api.Assertions.tuple("compensation", Optional.of(Confidence.HIGH)),
+                        org.assertj.core.api.Assertions.tuple("remote", Optional.of(Confidence.LOW)));
+    }
+
+    @Test
+    void missingConfidenceProducesEmptyOptional() {
+        var resp = LlmScoreResponse.of(null,
+                List.of(
+                        new LlmScoreResponse.CategoryVerdict("compensation", "Good", "salary listed"),
+                        new LlmScoreResponse.CategoryVerdict("remote", "Hybrid", "some days required")),
+                List.of());
+
+        ScoreReport report = assembler().assemble(posting, rubric, resp, "m");
+
+        assertThat(report.categoryScores()).allSatisfy(cs ->
+                assertThat(cs.confidence()).isEmpty());
+    }
+
+    @Test
+    void allConfidenceLevelsAccepted() {
+        for (Confidence c : Confidence.values()) {
+            var resp = LlmScoreResponse.of(null,
+                    List.of(
+                            new LlmScoreResponse.CategoryVerdict(
+                                    "compensation", "Good", "r", Optional.of(c)),
+                            new LlmScoreResponse.CategoryVerdict(
+                                    "remote", "Hybrid", "r", Optional.of(c))),
+                    List.of());
+
+            ScoreReport report = assembler().assemble(posting, rubric, resp, "m");
+
+            assertThat(report.categoryScores())
+                    .allSatisfy(cs -> assertThat(cs.confidence()).contains(c));
+        }
     }
 }

--- a/src/test/java/com/majordomo/domain/model/envoy/LlmScoreResponseTest.java
+++ b/src/test/java/com/majordomo/domain/model/envoy/LlmScoreResponseTest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class LlmScoreResponseTest {
 
@@ -41,5 +42,78 @@ class LlmScoreResponseTest {
                 """;
         var resp = new ObjectMapper().readValue(json, LlmScoreResponse.class);
         assertThat(resp.disqualifierKey()).contains("ON_SITE_ONLY");
+    }
+
+    @Test
+    void deserialisesConfidenceFromCategoryVerdict() throws Exception {
+        String json = """
+                {
+                  "disqualifierKey": null,
+                  "categoryVerdicts": [
+                    {"categoryKey": "compensation", "tierLabel": "Good",
+                     "rationale": "Posting lists $200-250k base.",
+                     "confidence": "HIGH"}
+                  ],
+                  "flagHits": []
+                }
+                """;
+        var resp = new ObjectMapper().readValue(json, LlmScoreResponse.class);
+
+        assertThat(resp.categoryVerdicts()).hasSize(1);
+        assertThat(resp.categoryVerdicts().get(0).confidence())
+                .contains(Confidence.HIGH);
+    }
+
+    @Test
+    void categoryVerdictWithoutConfidenceDeserialisesAsEmpty() throws Exception {
+        String json = """
+                {
+                  "disqualifierKey": null,
+                  "categoryVerdicts": [
+                    {"categoryKey": "compensation", "tierLabel": "Good",
+                     "rationale": "old payload, no confidence field"}
+                  ],
+                  "flagHits": []
+                }
+                """;
+        var resp = new ObjectMapper().readValue(json, LlmScoreResponse.class);
+
+        assertThat(resp.categoryVerdicts()).hasSize(1);
+        assertThat(resp.categoryVerdicts().get(0).confidence()).isEmpty();
+    }
+
+    @Test
+    void invalidConfidenceStringIsRejected() {
+        String json = """
+                {
+                  "disqualifierKey": null,
+                  "categoryVerdicts": [
+                    {"categoryKey": "compensation", "tierLabel": "Good",
+                     "rationale": "r", "confidence": "VERY_HIGH"}
+                  ],
+                  "flagHits": []
+                }
+                """;
+        assertThatThrownBy(() -> new ObjectMapper().readValue(json, LlmScoreResponse.class))
+                .isInstanceOf(com.fasterxml.jackson.databind.exc.InvalidFormatException.class);
+    }
+
+    @Test
+    void allConfidenceValuesRoundTripThroughJackson() throws Exception {
+        var mapper = new ObjectMapper();
+        for (Confidence value : Confidence.values()) {
+            String json = """
+                    {
+                      "disqualifierKey": null,
+                      "categoryVerdicts": [
+                        {"categoryKey": "compensation", "tierLabel": "Good",
+                         "rationale": "r", "confidence": "%s"}
+                      ],
+                      "flagHits": []
+                    }
+                    """.formatted(value.name());
+            var resp = mapper.readValue(json, LlmScoreResponse.class);
+            assertThat(resp.categoryVerdicts().get(0).confidence()).contains(value);
+        }
     }
 }


### PR DESCRIPTION
## Summary

Adds a per-category `confidence` (HIGH / MEDIUM / LOW) so the score-report UI can distinguish an evidence-backed verdict from a guess. The change rides through the existing layers without a Flyway migration:

- **LLM contract** — `LlmScoreResponse.CategoryVerdict` gains `Optional<Confidence> confidence`. A `@JsonCreator` accepts a missing/null wire value and produces `Optional.empty()`. Jackson serializes the new `Confidence` enum by name, so unknown strings (`"VERY_HIGH"`) are rejected by the deserializer.
- **Domain** — `CategoryScore` gains the same `Optional<Confidence> confidence`. A 4-arg convenience constructor preserves existing call sites and a `@JsonCreator` keeps backward compatibility on read.
- **Assembler** — `ScoreAssembler` reads `verdict.confidence()` and pipes it into the constructed `CategoryScore`. No new validation is needed: the enum constraint is enforced at the JSON boundary, and `Optional.empty()` is the explicit "absent" path.
- **Prompt** — `PromptBuilder.renderSystemPrompt` updates the JSON schema block to include `confidence` and adds a paragraph defining the three values (with the "competitive salary" vs "$220k base" example baked in as guidance).

## Backward compatibility

The `envoy_score_report.body` JSONB column already holds rows without `confidence`. `ScoreReportMapperBackwardCompatTest` round-trips an older-shaped report through the same Jackson configuration `ScoreReportMapper`/`RubricMapper` use, asserting that `confidence` deserializes to `Optional.empty()` and that a new-shape report with `HIGH`/`LOW` round-trips through `toEntity` → `toDomain`. No Flyway migration is needed; no behaviour is changed for legacy rows.

## Tests added / modified

- `LlmScoreResponseTest` — new tests for confidence deserialization (present, absent, all three values, invalid string rejected).
- `ScoreAssemblerTest` — new tests for confidence propagation, missing-confidence as empty Optional, and acceptance of all three enum levels.
- `PromptBuilderTest` — new test asserting the system prompt mentions `confidence` and lists the valid values.
- `ScoreReportMapperBackwardCompatTest` (new file) — verifies the JSONB round-trip for legacy and new shapes through the existing mapper chain.

Full `./mvnw verify` passes locally (249 tests, 0 failures).

## Test plan

- [x] `./mvnw verify` green locally
- [ ] CI green on PR
- [ ] Manual sanity: re-score an existing posting and confirm new reports carry `confidence`, while the older report on the dashboard still loads

Closes #150

🤖 Generated with [Claude Code](https://claude.com/claude-code)