### PR TITLE
feat(envoy): notify on APPLY_NOW postings, closes #148

### DIFF
--- a/src/main/java/com/majordomo/adapter/in/event/HighScorePostingNotificationListener.java
+++ b/src/main/java/com/majordomo/adapter/in/event/HighScorePostingNotificationListener.java
@@ -1,0 +1,101 @@
+package com.majordomo.adapter.in.event;
+
+import com.majordomo.domain.model.envoy.Recommendation;
+import com.majordomo.domain.model.event.JobPostingScored;
+import com.majordomo.domain.model.identity.NotificationCategory;
+import com.majordomo.domain.port.out.envoy.JobPostingRepository;
+import com.majordomo.domain.port.out.herald.NotificationPort;
+import com.majordomo.domain.port.out.identity.MembershipRepository;
+import com.majordomo.domain.port.out.identity.UserPreferencesRepository;
+import com.majordomo.domain.port.out.identity.UserRepository;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+/**
+ * Listens for {@link JobPostingScored} events and dispatches a notification to
+ * each member of the owning organization when the recommendation is
+ * {@link Recommendation#APPLY_NOW}. Mirrors the maintenance/warranty
+ * notification pattern: looks up the org's members, honors each member's
+ * {@link NotificationCategory#HIGH_SCORE_POSTING} opt-out via
+ * {@code UserPreferences}, and dispatches via the existing
+ * {@link NotificationPort}.
+ */
+@Component
+public class HighScorePostingNotificationListener {
+
+    private static final Logger LOG = LoggerFactory.getLogger(
+            HighScorePostingNotificationListener.class);
+
+    private final JobPostingRepository jobPostingRepository;
+    private final MembershipRepository membershipRepository;
+    private final UserRepository userRepository;
+    private final UserPreferencesRepository preferencesRepository;
+    private final NotificationPort notificationPort;
+
+    /**
+     * Constructs the listener with required dependencies.
+     *
+     * @param jobPostingRepository  outbound port for job postings
+     * @param membershipRepository  outbound port for organization memberships
+     * @param userRepository        outbound port for users
+     * @param preferencesRepository outbound port for user notification preferences
+     * @param notificationPort      outbound port for sending notifications
+     */
+    public HighScorePostingNotificationListener(JobPostingRepository jobPostingRepository,
+                                                MembershipRepository membershipRepository,
+                                                UserRepository userRepository,
+                                                UserPreferencesRepository preferencesRepository,
+                                                NotificationPort notificationPort) {
+        this.jobPostingRepository = jobPostingRepository;
+        this.membershipRepository = membershipRepository;
+        this.userRepository = userRepository;
+        this.preferencesRepository = preferencesRepository;
+        this.notificationPort = notificationPort;
+    }
+
+    /**
+     * Dispatches a notification for {@code APPLY_NOW} score events to each
+     * member of the org who has not disabled the {@code HIGH_SCORE_POSTING}
+     * category. Other recommendations are ignored.
+     *
+     * @param event the score event
+     */
+    @EventListener
+    public void onJobPostingScored(JobPostingScored event) {
+        if (event.recommendation() != Recommendation.APPLY_NOW) {
+            return;
+        }
+
+        var posting = jobPostingRepository.findById(event.postingId(), event.organizationId());
+        if (posting.isEmpty()) {
+            LOG.warn("APPLY_NOW event for unknown posting {} in org {}",
+                    event.postingId(), event.organizationId());
+            return;
+        }
+
+        String company = posting.get().getCompany();
+        String title = posting.get().getTitle();
+        String subject = "High-scoring posting: " + company + " - " + title;
+        String body = company + " - " + title
+                + " scored " + event.finalScore() + "/100 - APPLY_NOW - "
+                + "/envoy/reports/" + event.reportId();
+
+        var memberships = membershipRepository.findByOrganizationId(event.organizationId());
+        for (var membership : memberships) {
+            var user = userRepository.findById(membership.getUserId());
+            user.ifPresent(u -> {
+                var prefs = preferencesRepository.findByUserId(u.getId());
+                if (prefs.isPresent()
+                        && !prefs.get().isCategoryEnabled(NotificationCategory.HIGH_SCORE_POSTING)) {
+                    return;
+                }
+                notificationPort.send(u.getEmail(), subject, body);
+            });
+        }
+        LOG.info("APPLY_NOW notification dispatched for posting {} (report {})",
+                event.postingId(), event.reportId());
+    }
+}

--- a/src/main/java/com/majordomo/domain/model/identity/NotificationCategory.java
+++ b/src/main/java/com/majordomo/domain/model/identity/NotificationCategory.java
@@ -4,10 +4,12 @@ package com.majordomo.domain.model.identity;
  * Categories of notifications that can be individually disabled per user.
  */
 public enum NotificationCategory {
+    /** High-scoring job posting alerts (envoy APPLY_NOW). */
+    HIGH_SCORE_POSTING,
     /** Upcoming maintenance reminders. */
     MAINTENANCE_DUE,
-    /** Property warranty expiration alerts. */
-    WARRANTY_EXPIRING,
     /** System announcements and new features. */
-    SITE_UPDATES
+    SITE_UPDATES,
+    /** Property warranty expiration alerts. */
+    WARRANTY_EXPIRING
 }

--- a/src/test/java/com/majordomo/adapter/in/event/HighScorePostingNotificationListenerTest.java
+++ b/src/test/java/com/majordomo/adapter/in/event/HighScorePostingNotificationListenerTest.java
@@ -1,0 +1,238 @@
+package com.majordomo.adapter.in.event;
+
+import com.majordomo.domain.model.envoy.JobPosting;
+import com.majordomo.domain.model.envoy.Recommendation;
+import com.majordomo.domain.model.event.JobPostingScored;
+import com.majordomo.domain.model.identity.MemberRole;
+import com.majordomo.domain.model.identity.Membership;
+import com.majordomo.domain.model.identity.User;
+import com.majordomo.domain.model.identity.UserPreferences;
+import com.majordomo.domain.port.out.envoy.JobPostingRepository;
+import com.majordomo.domain.port.out.herald.NotificationPort;
+import com.majordomo.domain.port.out.identity.MembershipRepository;
+import com.majordomo.domain.port.out.identity.UserPreferencesRepository;
+import com.majordomo.domain.port.out.identity.UserRepository;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for {@link HighScorePostingNotificationListener}.
+ */
+@ExtendWith(MockitoExtension.class)
+class HighScorePostingNotificationListenerTest {
+
+    @Mock
+    private JobPostingRepository jobPostingRepository;
+
+    @Mock
+    private MembershipRepository membershipRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private UserPreferencesRepository preferencesRepository;
+
+    @Mock
+    private NotificationPort notificationPort;
+
+    private HighScorePostingNotificationListener listener;
+
+    @BeforeEach
+    void setUp() {
+        listener = new HighScorePostingNotificationListener(
+                jobPostingRepository, membershipRepository, userRepository,
+                preferencesRepository, notificationPort);
+    }
+
+    @Test
+    void applyNowDispatchesNotification() {
+        UUID reportId = UUID.randomUUID();
+        UUID orgId = UUID.randomUUID();
+        UUID postingId = UUID.randomUUID();
+        UUID userId = UUID.randomUUID();
+
+        var posting = new JobPosting();
+        posting.setId(postingId);
+        posting.setOrganizationId(orgId);
+        posting.setCompany("Acme Inc");
+        posting.setTitle("Staff Engineer");
+
+        var membership = new Membership(UUID.randomUUID(), userId, orgId, MemberRole.OWNER);
+        var user = new User(userId, "owner", "owner@example.com");
+
+        when(jobPostingRepository.findById(postingId, orgId))
+                .thenReturn(Optional.of(posting));
+        when(membershipRepository.findByOrganizationId(orgId))
+                .thenReturn(List.of(membership));
+        when(userRepository.findById(userId))
+                .thenReturn(Optional.of(user));
+        when(preferencesRepository.findByUserId(userId))
+                .thenReturn(Optional.empty());
+
+        listener.onJobPostingScored(new JobPostingScored(
+                reportId, orgId, postingId, 92, Recommendation.APPLY_NOW, Instant.now()));
+
+        verify(notificationPort).send(
+                eq("owner@example.com"),
+                contains("Acme Inc"),
+                contains("APPLY_NOW"));
+    }
+
+    @Test
+    void applyNowBodyIncludesScoreCompanyTitleAndDeeplink() {
+        UUID reportId = UUID.randomUUID();
+        UUID orgId = UUID.randomUUID();
+        UUID postingId = UUID.randomUUID();
+        UUID userId = UUID.randomUUID();
+
+        var posting = new JobPosting();
+        posting.setId(postingId);
+        posting.setOrganizationId(orgId);
+        posting.setCompany("Acme Inc");
+        posting.setTitle("Staff Engineer");
+
+        var membership = new Membership(UUID.randomUUID(), userId, orgId, MemberRole.OWNER);
+        var user = new User(userId, "owner", "owner@example.com");
+
+        when(jobPostingRepository.findById(postingId, orgId))
+                .thenReturn(Optional.of(posting));
+        when(membershipRepository.findByOrganizationId(orgId))
+                .thenReturn(List.of(membership));
+        when(userRepository.findById(userId))
+                .thenReturn(Optional.of(user));
+        when(preferencesRepository.findByUserId(userId))
+                .thenReturn(Optional.empty());
+
+        listener.onJobPostingScored(new JobPostingScored(
+                reportId, orgId, postingId, 92, Recommendation.APPLY_NOW, Instant.now()));
+
+        verify(notificationPort).send(
+                eq("owner@example.com"),
+                anyString(),
+                contains("Staff Engineer"));
+        verify(notificationPort).send(
+                eq("owner@example.com"),
+                anyString(),
+                contains("92/100"));
+        verify(notificationPort).send(
+                eq("owner@example.com"),
+                anyString(),
+                contains("/envoy/reports/" + reportId));
+    }
+
+    @Test
+    void applyDoesNotDispatchNotification() {
+        UUID reportId = UUID.randomUUID();
+        UUID orgId = UUID.randomUUID();
+        UUID postingId = UUID.randomUUID();
+
+        listener.onJobPostingScored(new JobPostingScored(
+                reportId, orgId, postingId, 80, Recommendation.APPLY, Instant.now()));
+
+        verify(notificationPort, never()).send(anyString(), anyString(), anyString());
+    }
+
+    @Test
+    void considerDoesNotDispatchNotification() {
+        UUID reportId = UUID.randomUUID();
+        UUID orgId = UUID.randomUUID();
+        UUID postingId = UUID.randomUUID();
+
+        listener.onJobPostingScored(new JobPostingScored(
+                reportId, orgId, postingId, 60, Recommendation.CONSIDER, Instant.now()));
+
+        verify(notificationPort, never()).send(anyString(), anyString(), anyString());
+    }
+
+    @Test
+    void skipDoesNotDispatchNotification() {
+        UUID reportId = UUID.randomUUID();
+        UUID orgId = UUID.randomUUID();
+        UUID postingId = UUID.randomUUID();
+
+        listener.onJobPostingScored(new JobPostingScored(
+                reportId, orgId, postingId, 30, Recommendation.SKIP, Instant.now()));
+
+        verify(notificationPort, never()).send(anyString(), anyString(), anyString());
+    }
+
+    @Test
+    void memberWithHighScorePostingDisabledIsSkipped() {
+        UUID reportId = UUID.randomUUID();
+        UUID orgId = UUID.randomUUID();
+        UUID postingId = UUID.randomUUID();
+        UUID enabledUserId = UUID.randomUUID();
+        UUID disabledUserId = UUID.randomUUID();
+
+        var posting = new JobPosting();
+        posting.setId(postingId);
+        posting.setOrganizationId(orgId);
+        posting.setCompany("Acme Inc");
+        posting.setTitle("Staff Engineer");
+
+        var enabledMembership = new Membership(
+                UUID.randomUUID(), enabledUserId, orgId, MemberRole.OWNER);
+        var disabledMembership = new Membership(
+                UUID.randomUUID(), disabledUserId, orgId, MemberRole.OWNER);
+
+        var enabledUser = new User(enabledUserId, "enabled", "enabled@example.com");
+        var disabledUser = new User(disabledUserId, "disabled", "disabled@example.com");
+
+        var disabledPrefs = new UserPreferences();
+        disabledPrefs.setNotificationsEnabled(true);
+        disabledPrefs.setNotificationCategoriesDisabled(List.of("HIGH_SCORE_POSTING"));
+
+        when(jobPostingRepository.findById(postingId, orgId))
+                .thenReturn(Optional.of(posting));
+        when(membershipRepository.findByOrganizationId(orgId))
+                .thenReturn(List.of(enabledMembership, disabledMembership));
+        when(userRepository.findById(enabledUserId))
+                .thenReturn(Optional.of(enabledUser));
+        when(userRepository.findById(disabledUserId))
+                .thenReturn(Optional.of(disabledUser));
+        when(preferencesRepository.findByUserId(enabledUserId))
+                .thenReturn(Optional.empty());
+        when(preferencesRepository.findByUserId(disabledUserId))
+                .thenReturn(Optional.of(disabledPrefs));
+
+        listener.onJobPostingScored(new JobPostingScored(
+                reportId, orgId, postingId, 92, Recommendation.APPLY_NOW, Instant.now()));
+
+        verify(notificationPort).send(
+                eq("enabled@example.com"), anyString(), anyString());
+        verify(notificationPort, never()).send(
+                eq("disabled@example.com"), anyString(), anyString());
+    }
+
+    @Test
+    void postingNotFoundDoesNotDispatchNotification() {
+        UUID reportId = UUID.randomUUID();
+        UUID orgId = UUID.randomUUID();
+        UUID postingId = UUID.randomUUID();
+
+        when(jobPostingRepository.findById(postingId, orgId))
+                .thenReturn(Optional.empty());
+
+        listener.onJobPostingScored(new JobPostingScored(
+                reportId, orgId, postingId, 92, Recommendation.APPLY_NOW, Instant.now()));
+
+        verify(notificationPort, never()).send(anyString(), anyString(), anyString());
+    }
+}


### PR DESCRIPTION
## Summary

Closes #148. When the envoy `JobScorerService` publishes a `JobPostingScored` event with `recommendation == APPLY_NOW`, send a notification to each member of the owning organization, mirroring the existing maintenance/warranty notification pipeline.

## Changes

- `NotificationCategory.HIGH_SCORE_POSTING` — new enum value (alphabetized alongside `MAINTENANCE_DUE`, `SITE_UPDATES`, `WARRANTY_EXPIRING`).
- `adapter/in/event/HighScorePostingNotificationListener` — new `@EventListener` on `JobPostingScored`. Filters to `APPLY_NOW`, looks up the posting (for company + title via `JobPostingRepository`), iterates org memberships, and dispatches via `NotificationPort`. Skips any user whose `UserPreferences` has `HIGH_SCORE_POSTING` in `notificationCategoriesDisabled` — same gate `MaintenanceNotificationService` and `WarrantyAlertService` use.
- Notification body format: `"<company> - <title> scored <finalScore>/100 - APPLY_NOW - /envoy/reports/{reportId}"`.

## Test plan

- [x] Unit test: `APPLY_NOW` -> notification dispatched (subject + body asserted via mocks).
- [x] Unit test: body contains company, title, `<score>/100`, and the `/envoy/reports/{reportId}` deeplink.
- [x] Unit tests: `APPLY` / `CONSIDER` / `SKIP` -> no notification dispatched (separate assertion per recommendation).
- [x] Unit test: member with `HIGH_SCORE_POSTING` in disabled list is skipped while another org member without that opt-out still receives the notification.
- [x] Unit test: posting not found in repository -> no notification, warn-level log.
- [x] `./mvnw verify` passes locally (246 tests, BUILD SUCCESS) -- includes Checkstyle, all unit tests, and the `HexagonalArchitectureTest` / `NamingConventionTest` ArchUnit fitness functions.

## Out of scope (per issue)

- Threshold tuning beyond `APPLY_NOW`.
- Digest-mode batching of multiple high-score postings.