### PR TITLE
feat(envoy): multi-rubric scoring, closes #149

### DIFF
--- a/src/main/java/com/majordomo/adapter/in/web/config/GlobalExceptionHandler.java
+++ b/src/main/java/com/majordomo/adapter/in/web/config/GlobalExceptionHandler.java
@@ -9,6 +9,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.servlet.resource.NoResourceFoundException;
@@ -66,6 +67,20 @@ public class GlobalExceptionHandler {
                 .map(e -> e.getField() + ": " + e.getDefaultMessage())
                 .collect(Collectors.joining(", "));
         return buildResponse(HttpStatus.BAD_REQUEST, message, request);
+    }
+
+    /**
+     * Handles missing required request parameters (e.g. omitted
+     * {@code @RequestParam}).
+     *
+     * @param ex      the exception
+     * @param request the HTTP request
+     * @return 400 response with error details
+     */
+    @ExceptionHandler(MissingServletRequestParameterException.class)
+    public ResponseEntity<ErrorResponse> handleMissingParameter(
+            MissingServletRequestParameterException ex, HttpServletRequest request) {
+        return buildResponse(HttpStatus.BAD_REQUEST, ex.getMessage(), request);
     }
 
     /**

--- a/src/main/java/com/majordomo/adapter/in/web/envoy/PostingController.java
+++ b/src/main/java/com/majordomo/adapter/in/web/envoy/PostingController.java
@@ -18,6 +18,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.net.URI;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
@@ -81,5 +82,26 @@ public class PostingController {
             @RequestParam(defaultValue = "default") String rubricName) {
         organizationAccessService.verifyAccess(organizationId);
         return ResponseEntity.ok(scoreUseCase.score(id, rubricName, organizationId));
+    }
+
+    /**
+     * Scores an existing posting against multiple rubrics. Each rubric produces
+     * a separate persisted {@code ScoreReport} and a separate
+     * {@code JobPostingScored} domain event. Fails fast: if any rubric cannot
+     * be resolved the call returns 404 and no reports are persisted.
+     *
+     * @param id             posting id
+     * @param organizationId owning org (caller must be a member)
+     * @param rubricNames    rubric names to score against (repeat the param
+     *                       or use a comma-separated value); must be non-empty
+     * @return the persisted score reports, in the same order as {@code rubricNames}
+     */
+    @PostMapping("/{id}/score-all")
+    public ResponseEntity<List<ScoreReport>> scoreAll(
+            @PathVariable UUID id,
+            @RequestParam UUID organizationId,
+            @RequestParam List<String> rubricNames) {
+        organizationAccessService.verifyAccess(organizationId);
+        return ResponseEntity.ok(scoreUseCase.scoreAll(id, rubricNames, organizationId));
     }
 }

--- a/src/main/java/com/majordomo/application/envoy/JobScorerService.java
+++ b/src/main/java/com/majordomo/application/envoy/JobScorerService.java
@@ -16,6 +16,8 @@ import com.majordomo.domain.port.out.envoy.ScoreReportRepository;
 import org.springframework.stereotype.Service;
 
 import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 
 /**
@@ -65,7 +67,32 @@ public class JobScorerService implements ScoreJobPostingUseCase {
                         EntityType.JOB_POSTING.name(), postingId));
         Rubric rubric = rubrics.findActiveByName(rubricName, organizationId)
                 .orElseThrow(() -> new EntityNotFoundException("RUBRIC", rubricName));
+        return runOne(posting, rubric);
+    }
 
+    @Override
+    public List<ScoreReport> scoreAll(
+            UUID postingId, List<String> rubricNames, UUID organizationId) {
+        if (rubricNames == null || rubricNames.isEmpty()) {
+            throw new IllegalArgumentException("rubricNames must be non-empty");
+        }
+        JobPosting posting = postings.findById(postingId, organizationId)
+                .orElseThrow(() -> new EntityNotFoundException(
+                        EntityType.JOB_POSTING.name(), postingId));
+        // Resolve all rubrics first so we fail fast without persisting partial state.
+        List<Rubric> resolved = new ArrayList<>(rubricNames.size());
+        for (String name : rubricNames) {
+            resolved.add(rubrics.findActiveByName(name, organizationId)
+                    .orElseThrow(() -> new EntityNotFoundException("RUBRIC", name)));
+        }
+        List<ScoreReport> saved = new ArrayList<>(resolved.size());
+        for (Rubric rubric : resolved) {
+            saved.add(runOne(posting, rubric));
+        }
+        return saved;
+    }
+
+    private ScoreReport runOne(JobPosting posting, Rubric rubric) {
         LlmScoreResponse resp = llm.score(posting, rubric);
         ScoreReport report = assembler.assemble(posting, rubric, resp, llm.modelId());
         ScoreReport saved = reports.save(report);

--- a/src/main/java/com/majordomo/domain/port/in/envoy/ScoreJobPostingUseCase.java
+++ b/src/main/java/com/majordomo/domain/port/in/envoy/ScoreJobPostingUseCase.java
@@ -2,9 +2,10 @@ package com.majordomo.domain.port.in.envoy;
 
 import com.majordomo.domain.model.envoy.ScoreReport;
 
+import java.util.List;
 import java.util.UUID;
 
-/** Inbound port for scoring a previously-ingested posting against an active rubric. */
+/** Inbound port for scoring a previously-ingested posting against active rubrics. */
 public interface ScoreJobPostingUseCase {
 
     /**
@@ -16,4 +17,19 @@ public interface ScoreJobPostingUseCase {
      * @return the persisted score report
      */
     ScoreReport score(UUID postingId, String rubricName, UUID organizationId);
+
+    /**
+     * Scores a posting against multiple rubrics in one operation. Each rubric
+     * produces a separate persisted {@link ScoreReport} and a separate
+     * {@code JobPostingScored} domain event. Fails fast: if any rubric (or the
+     * posting itself) cannot be resolved, the call throws and no reports are
+     * persisted and no events are published.
+     *
+     * @param postingId      the posting to score
+     * @param rubricNames    rubric names to score against (must be non-empty)
+     * @param organizationId the requesting org (must own the posting)
+     * @return the persisted score reports, in the same order as {@code rubricNames}
+     * @throws IllegalArgumentException if {@code rubricNames} is empty
+     */
+    List<ScoreReport> scoreAll(UUID postingId, List<String> rubricNames, UUID organizationId);
 }

--- a/src/test/java/com/majordomo/adapter/in/web/envoy/PostingControllerTest.java
+++ b/src/test/java/com/majordomo/adapter/in/web/envoy/PostingControllerTest.java
@@ -95,4 +95,46 @@ class PostingControllerTest {
                 .andExpect(jsonPath("$.finalScore").value(60))
                 .andExpect(jsonPath("$.recommendation").value("APPLY"));
     }
+
+    @Test
+    @WithMockUser
+    void scoreAllReturnsListOfReports() throws Exception {
+        var postingId = UuidFactory.newId();
+        var rubricBackendId = UuidFactory.newId();
+        var rubricStaffPlusId = UuidFactory.newId();
+        var reportBackend = new ScoreReport(UuidFactory.newId(), ORG_ID, postingId,
+                rubricBackendId, 1, Optional.empty(),
+                List.of(), List.of(), 60, 60, Recommendation.APPLY,
+                "claude-sonnet-4-6", Instant.now());
+        var reportStaffPlus = new ScoreReport(UuidFactory.newId(), ORG_ID, postingId,
+                rubricStaffPlusId, 1, Optional.empty(),
+                List.of(), List.of(), 40, 40, Recommendation.SKIP,
+                "claude-sonnet-4-6", Instant.now());
+        doNothing().when(organizationAccessService).verifyAccess(any());
+        when(scoreUseCase.scoreAll(eq(postingId),
+                eq(List.of("backend", "staff-plus")), eq(ORG_ID)))
+                .thenReturn(List.of(reportBackend, reportStaffPlus));
+
+        mvc.perform(post("/api/envoy/postings/" + postingId + "/score-all")
+                        .param("organizationId", ORG_ID.toString())
+                        .param("rubricNames", "backend", "staff-plus"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(2))
+                .andExpect(jsonPath("$[0].finalScore").value(60))
+                .andExpect(jsonPath("$[0].recommendation").value("APPLY"))
+                .andExpect(jsonPath("$[1].finalScore").value(40))
+                .andExpect(jsonPath("$[1].recommendation").value("SKIP"));
+    }
+
+    @Test
+    @WithMockUser
+    void scoreAllRejectsEmptyRubricListAsBadRequest() throws Exception {
+        var postingId = UuidFactory.newId();
+        doNothing().when(organizationAccessService).verifyAccess(any());
+
+        // No rubricNames param at all -> Spring binding fails with 400.
+        mvc.perform(post("/api/envoy/postings/" + postingId + "/score-all")
+                        .param("organizationId", ORG_ID.toString()))
+                .andExpect(status().isBadRequest());
+    }
 }

--- a/src/test/java/com/majordomo/application/envoy/JobScorerServiceTest.java
+++ b/src/test/java/com/majordomo/application/envoy/JobScorerServiceTest.java
@@ -19,6 +19,7 @@ import com.majordomo.domain.port.out.envoy.ScoreReportRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -30,6 +31,8 @@ import java.util.UUID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -95,5 +98,87 @@ class JobScorerServiceTest {
         when(rubrics.findActiveByName("default", orgId)).thenReturn(Optional.empty());
         assertThatThrownBy(() -> scorer.score(posting.getId(), "default", orgId))
                 .isInstanceOf(EntityNotFoundException.class);
+    }
+
+    @Test
+    void scoreAllPersistsOneReportPerRubricAndPublishesOneEventEach() {
+        Rubric rubricBackend = new Rubric(UuidFactory.newId(), Optional.empty(), 1, "backend",
+                List.of(),
+                List.of(new Category("compensation", "pay", 20,
+                        List.of(new Tier("Good", 15, "$200-250k")))),
+                List.of(), new Thresholds(20, 15, 5), Instant.now());
+        Rubric rubricStaffPlus = new Rubric(UuidFactory.newId(), Optional.empty(), 2, "staff-plus",
+                List.of(),
+                List.of(new Category("compensation", "pay", 20,
+                        List.of(new Tier("Good", 15, "$200-250k")))),
+                List.of(), new Thresholds(20, 15, 5), Instant.now());
+        when(postings.findById(posting.getId(), orgId)).thenReturn(Optional.of(posting));
+        when(rubrics.findActiveByName("backend", orgId)).thenReturn(Optional.of(rubricBackend));
+        when(rubrics.findActiveByName("staff-plus", orgId)).thenReturn(Optional.of(rubricStaffPlus));
+        when(llm.score(any(), any())).thenReturn(LlmScoreResponse.of(null,
+                List.of(new LlmScoreResponse.CategoryVerdict("compensation", "Good", "listed")),
+                List.of()));
+        when(llm.modelId()).thenReturn("claude-sonnet-4-6");
+        when(reports.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        List<ScoreReport> saved = scorer.scoreAll(
+                posting.getId(), List.of("backend", "staff-plus"), orgId);
+
+        assertThat(saved).hasSize(2);
+        assertThat(saved).allSatisfy(r -> assertThat(r.postingId()).isEqualTo(posting.getId()));
+        assertThat(saved).extracting(ScoreReport::rubricId)
+                .containsExactly(rubricBackend.id(), rubricStaffPlus.id());
+        assertThat(saved).extracting(ScoreReport::rubricVersion)
+                .containsExactly(1, 2);
+
+        ArgumentCaptor<ScoreReport> savedReports = ArgumentCaptor.forClass(ScoreReport.class);
+        verify(reports, times(2)).save(savedReports.capture());
+        verify(eventPublisher, times(2)).publish(any(JobPostingScored.class));
+    }
+
+    @Test
+    void scoreAllFailsFastWhenAnyRubricMissing() {
+        Rubric rubricBackend = new Rubric(UuidFactory.newId(), Optional.empty(), 1, "backend",
+                List.of(),
+                List.of(new Category("compensation", "pay", 20,
+                        List.of(new Tier("Good", 15, "$200-250k")))),
+                List.of(), new Thresholds(20, 15, 5), Instant.now());
+        when(postings.findById(posting.getId(), orgId)).thenReturn(Optional.of(posting));
+        when(rubrics.findActiveByName("backend", orgId)).thenReturn(Optional.of(rubricBackend));
+        when(rubrics.findActiveByName("missing", orgId)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> scorer.scoreAll(
+                posting.getId(), List.of("backend", "missing"), orgId))
+                .isInstanceOf(EntityNotFoundException.class);
+
+        // No partial state: nothing persisted, no events published.
+        verify(reports, never()).save(any());
+        verify(eventPublisher, never()).publish(any());
+    }
+
+    @Test
+    void scoreAllRejectsEmptyRubricList() {
+        assertThatThrownBy(() -> scorer.scoreAll(posting.getId(), List.of(), orgId))
+                .isInstanceOf(IllegalArgumentException.class);
+        verify(reports, never()).save(any());
+        verify(eventPublisher, never()).publish(any());
+    }
+
+    @Test
+    void scoreAllSingleRubricStillWorks() {
+        when(postings.findById(posting.getId(), orgId)).thenReturn(Optional.of(posting));
+        when(rubrics.findActiveByName("default", orgId)).thenReturn(Optional.of(rubric));
+        when(llm.score(any(), any())).thenReturn(LlmScoreResponse.of(null,
+                List.of(new LlmScoreResponse.CategoryVerdict("compensation", "Good", "listed")),
+                List.of()));
+        when(llm.modelId()).thenReturn("claude-sonnet-4-6");
+        when(reports.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        List<ScoreReport> saved = scorer.scoreAll(
+                posting.getId(), List.of("default"), orgId);
+
+        assertThat(saved).hasSize(1);
+        assertThat(saved.get(0).postingId()).isEqualTo(posting.getId());
+        verify(eventPublisher, times(1)).publish(any(JobPostingScored.class));
     }
 }


### PR DESCRIPTION
## Summary

Adds a new `POST /api/envoy/postings/{id}/score-all` endpoint that scores a single posting against multiple named rubrics. Closes #149.

## API shape

I went with a **new endpoint** (`/score-all`) rather than overloading the existing `/{id}/score`:

- The existing single-rubric endpoint stays exactly as it was — no breaking change to the default `rubricName=default` behaviour, no surprise for anything (UI, scripts) currently calling it.
- The response shape is genuinely different: `ScoreReport` vs `List<ScoreReport>`. Splitting it across two endpoints keeps each return type unambiguous in OpenAPI and in clients.
- The port stays cohesive: `ScoreJobPostingUseCase` now exposes both `score(...)` and `scoreAll(...)`, so the controller injects one collaborator and the operations are discoverable together.

Usage:

```
POST /api/envoy/postings/{id}/score-all?organizationId=…&rubricNames=backend&rubricNames=staff-plus
# or
POST /api/envoy/postings/{id}/score-all?organizationId=…&rubricNames=backend,staff-plus
```

Returns a JSON array of `ScoreReport`, in the same order as the requested rubric names.

## Schema check

Confirmed that `V14__envoy_schema.sql` defines `envoy_score_report` **without** any unique constraint on `(posting_id, rubric_id)`. There are only `org_idx`, `posting_idx`, `org_final_score_idx`, and `org_recommendation_idx`. So multiple reports per `(posting, rubric)` pair are already supported by the schema — this is purely an API + use-case change, no migration needed.

## Partial-failure semantics: fail-fast

If any one of the requested rubrics (or the posting itself) cannot be resolved for the org, the call throws `EntityNotFoundException` (→ 404) **before** any rubric is scored or persisted. Callers never see a partial result where some reports were saved and others were not. Trade-off: a typo in one rubric name wastes the whole call, but the caller can fix it and retry idempotently rather than reasoning about which subset succeeded.

## Per-rubric domain events

Each rubric scored fires its own `JobPostingScored` event with its own `scoreReportId`, `finalScore`, and `recommendation`. This means the per-rubric notifications from #148 fire once per rubric, which is what users expect when they explicitly ask to be scored against several lenses.

## Edge cases covered by tests

- Two rubrics, both exist → two persisted reports referencing same `postingId` but different `rubricId` / `rubricVersion`; two events.
- One rubric missing → `EntityNotFoundException`; **no** reports saved, **no** events.
- Empty `rubricNames` list → `IllegalArgumentException` at the use case; the controller-level case (param entirely omitted) returns 400 via the new `MissingServletRequestParameterException` handler.
- Single-rubric list → degenerate case still works (one report, one event).

## Incidental change

Added a `MissingServletRequestParameterException` handler to `GlobalExceptionHandler` so omitted required `@RequestParam` values return 400 instead of falling into the catch-all 500. This was uncovered while writing the empty-list edge-case test.

## Test plan

- [x] `JobScorerServiceTest` — multi-rubric, fail-fast, empty list, single-rubric (4 new tests, all green)
- [x] `PostingControllerTest` `@WebMvcTest` — endpoint returns list of two reports; missing param returns 400 (2 new tests, all green)
- [x] `./mvnw verify` — full build green (245 tests, Checkstyle, ArchUnit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)