### PR TITLE
feat(envoy): batch rescore + automatic rescore-on-rubric-change, closes #147

### DIFF
--- a/src/main/java/com/majordomo/adapter/in/event/RubricChangeRescoreListener.java
+++ b/src/main/java/com/majordomo/adapter/in/event/RubricChangeRescoreListener.java
@@ -1,0 +1,70 @@
+package com.majordomo.adapter.in.event;
+
+import com.majordomo.domain.model.envoy.JobPosting;
+import com.majordomo.domain.model.event.RubricVersionCreated;
+import com.majordomo.domain.port.in.envoy.ScoreJobPostingUseCase;
+import com.majordomo.domain.port.out.envoy.JobPostingRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+/**
+ * Listens for {@link RubricVersionCreated} and re-scores every posting in the
+ * org against the new rubric version. The scoring path goes through
+ * {@code ScoreJobPostingUseCase}, whose downstream {@code AnthropicMessageClient}
+ * is already protected by the Resilience4j {@code envoy-llm} circuit breaker
+ * and retry — so we get throttling and per-call resilience for free.
+ *
+ * <p>At personal scale (handful of postings) the raw fan-out here is acceptable
+ * (issue #147). If a single rescore fails, we log and continue to the next
+ * posting rather than aborting the whole batch.</p>
+ */
+@Component
+public class RubricChangeRescoreListener {
+
+    private static final Logger LOG = LoggerFactory.getLogger(RubricChangeRescoreListener.class);
+
+    private final JobPostingRepository postings;
+    private final ScoreJobPostingUseCase scoreUseCase;
+
+    /**
+     * Constructs the listener.
+     *
+     * @param postings     outbound port for fetching all postings in an org
+     * @param scoreUseCase inbound scoring port (Resilience4j-protected at the LLM hop)
+     */
+    public RubricChangeRescoreListener(JobPostingRepository postings,
+                                       ScoreJobPostingUseCase scoreUseCase) {
+        this.postings = postings;
+        this.scoreUseCase = scoreUseCase;
+    }
+
+    /**
+     * Re-scores every posting in the org that owns the new rubric version.
+     *
+     * @param event the rubric-version-created event
+     */
+    @EventListener
+    public void onRubricVersionCreated(RubricVersionCreated event) {
+        List<JobPosting> all = postings.findAllByOrganizationId(event.organizationId());
+        LOG.info("Rescoring {} postings against rubric '{}' v{} for org {}",
+                all.size(), event.rubricName(), event.version(), event.organizationId());
+        int succeeded = 0;
+        int failed = 0;
+        for (JobPosting p : all) {
+            try {
+                scoreUseCase.score(p.getId(), event.rubricName(), event.organizationId());
+                succeeded++;
+            } catch (RuntimeException ex) {
+                failed++;
+                LOG.warn("Rescore failed for posting {} in org {}: {}",
+                        p.getId(), event.organizationId(), ex.getMessage());
+            }
+        }
+        LOG.info("Rescore complete: {} succeeded, {} failed (rubric '{}' v{}, org {})",
+                succeeded, failed, event.rubricName(), event.version(), event.organizationId());
+    }
+}

--- a/src/main/java/com/majordomo/adapter/in/web/envoy/PostingController.java
+++ b/src/main/java/com/majordomo/adapter/in/web/envoy/PostingController.java
@@ -7,8 +7,11 @@ import com.majordomo.domain.model.envoy.JobSourceRequest;
 import com.majordomo.domain.model.envoy.ScoreReport;
 import com.majordomo.domain.port.in.envoy.IngestJobPostingUseCase;
 import com.majordomo.domain.port.in.envoy.ScoreJobPostingUseCase;
+import com.majordomo.domain.port.out.envoy.JobPostingRepository;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -18,6 +21,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.net.URI;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
@@ -27,8 +31,11 @@ import java.util.UUID;
 @Tag(name = "Envoy", description = "Job posting ingestion and scoring")
 public class PostingController {
 
+    private static final Logger LOG = LoggerFactory.getLogger(PostingController.class);
+
     private final IngestJobPostingUseCase ingestUseCase;
     private final ScoreJobPostingUseCase scoreUseCase;
+    private final JobPostingRepository jobPostingRepository;
     private final OrganizationAccessService organizationAccessService;
 
     /**
@@ -36,13 +43,16 @@ public class PostingController {
      *
      * @param ingestUseCase             inbound port for ingestion
      * @param scoreUseCase              inbound port for scoring
+     * @param jobPostingRepository      outbound port for listing all postings in an org
      * @param organizationAccessService enforces per-org access control
      */
     public PostingController(IngestJobPostingUseCase ingestUseCase,
                              ScoreJobPostingUseCase scoreUseCase,
+                             JobPostingRepository jobPostingRepository,
                              OrganizationAccessService organizationAccessService) {
         this.ingestUseCase = ingestUseCase;
         this.scoreUseCase = scoreUseCase;
+        this.jobPostingRepository = jobPostingRepository;
         this.organizationAccessService = organizationAccessService;
     }
 
@@ -81,5 +91,39 @@ public class PostingController {
             @RequestParam(defaultValue = "default") String rubricName) {
         organizationAccessService.verifyAccess(organizationId);
         return ResponseEntity.ok(scoreUseCase.score(id, rubricName, organizationId));
+    }
+
+    /**
+     * Manually re-scores every posting in the org against the named rubric. The
+     * automatic counterpart is the {@code RubricVersionCreated} listener fired
+     * when a rubric is edited; this endpoint exposes the same fan-out for ad-hoc
+     * use (e.g. after a model upgrade with no rubric change).
+     *
+     * <p>Throttling is delegated to the existing Resilience4j {@code envoy-llm}
+     * policy on the LLM client — no new config. At personal scale this raw
+     * fan-out is acceptable; queued/chunked backpressure can be added later if
+     * the workload outgrows it.</p>
+     *
+     * @param organizationId owning org (caller must be a member)
+     * @param rubricName     rubric to score against (defaults to {@code "default"})
+     * @return JSON body with {@code count} = number of rescores triggered
+     */
+    @PostMapping("/rescore")
+    public ResponseEntity<Map<String, Integer>> rescoreAll(
+            @RequestParam UUID organizationId,
+            @RequestParam(defaultValue = "default") String rubricName) {
+        organizationAccessService.verifyAccess(organizationId);
+        List<JobPosting> postings = jobPostingRepository.findAllByOrganizationId(organizationId);
+        int succeeded = 0;
+        for (JobPosting p : postings) {
+            try {
+                scoreUseCase.score(p.getId(), rubricName, organizationId);
+                succeeded++;
+            } catch (RuntimeException ex) {
+                LOG.warn("Manual rescore failed for posting {} in org {}: {}",
+                        p.getId(), organizationId, ex.getMessage());
+            }
+        }
+        return ResponseEntity.ok(Map.of("count", succeeded));
     }
 }

--- a/src/main/java/com/majordomo/adapter/out/persistence/envoy/JobPostingRepositoryAdapter.java
+++ b/src/main/java/com/majordomo/adapter/out/persistence/envoy/JobPostingRepositoryAdapter.java
@@ -4,6 +4,7 @@ import com.majordomo.domain.model.envoy.JobPosting;
 import com.majordomo.domain.port.out.envoy.JobPostingRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -38,5 +39,12 @@ public class JobPostingRepositoryAdapter implements JobPostingRepository {
             String source, String externalId, UUID organizationId) {
         return jpa.findBySourceAndExternalIdAndOrganizationId(source, externalId, organizationId)
                 .map(JobPostingMapper::toDomain);
+    }
+
+    @Override
+    public List<JobPosting> findAllByOrganizationId(UUID organizationId) {
+        return jpa.findAllByOrganizationId(organizationId).stream()
+                .map(JobPostingMapper::toDomain)
+                .toList();
     }
 }

--- a/src/main/java/com/majordomo/adapter/out/persistence/envoy/JpaJobPostingRepository.java
+++ b/src/main/java/com/majordomo/adapter/out/persistence/envoy/JpaJobPostingRepository.java
@@ -2,6 +2,7 @@ package com.majordomo.adapter.out.persistence.envoy;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -28,4 +29,14 @@ public interface JpaJobPostingRepository extends JpaRepository<JobPostingEntity,
      */
     Optional<JobPostingEntity> findBySourceAndExternalIdAndOrganizationId(
             String source, String externalId, UUID organizationId);
+
+    /**
+     * Returns all postings owned by the given organization. Used by the rescore
+     * fan-out (manual endpoint and {@code RubricVersionCreated} listener) — at
+     * personal scale (handful of postings) an unpaginated list is acceptable.
+     *
+     * @param organizationId owning org
+     * @return every posting in that org (may be empty)
+     */
+    List<JobPostingEntity> findAllByOrganizationId(UUID organizationId);
 }

--- a/src/main/java/com/majordomo/application/envoy/RubricService.java
+++ b/src/main/java/com/majordomo/application/envoy/RubricService.java
@@ -2,7 +2,9 @@ package com.majordomo.application.envoy;
 
 import com.majordomo.domain.model.UuidFactory;
 import com.majordomo.domain.model.envoy.Rubric;
+import com.majordomo.domain.model.event.RubricVersionCreated;
 import com.majordomo.domain.port.in.envoy.ManageRubricUseCase;
+import com.majordomo.domain.port.out.EventPublisher;
 import com.majordomo.domain.port.out.envoy.RubricRepository;
 import org.springframework.stereotype.Service;
 
@@ -15,14 +17,18 @@ import java.util.UUID;
 public class RubricService implements ManageRubricUseCase {
 
     private final RubricRepository repo;
+    private final EventPublisher eventPublisher;
 
     /**
      * Constructs the service.
      *
-     * @param repo outbound rubric repository
+     * @param repo           outbound rubric repository
+     * @param eventPublisher domain event publisher (fans out a {@link RubricVersionCreated}
+     *                       to drive automatic re-scoring of postings in the org)
      */
-    public RubricService(RubricRepository repo) {
+    public RubricService(RubricRepository repo, EventPublisher eventPublisher) {
         this.repo = repo;
+        this.eventPublisher = eventPublisher;
     }
 
     @Override
@@ -43,6 +49,9 @@ public class RubricService implements ManageRubricUseCase {
                 submitted.flags(),
                 submitted.thresholds(),
                 Instant.now());
-        return repo.save(toSave);
+        Rubric saved = repo.save(toSave);
+        eventPublisher.publish(new RubricVersionCreated(
+                organizationId, name, saved.version(), Instant.now()));
+        return saved;
     }
 }

--- a/src/main/java/com/majordomo/domain/model/event/RubricVersionCreated.java
+++ b/src/main/java/com/majordomo/domain/model/event/RubricVersionCreated.java
@@ -1,0 +1,20 @@
+package com.majordomo.domain.model.event;
+
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * Published after a new rubric version is persisted by {@code RubricService}.
+ * Triggers a fan-out re-score of every posting in the org against the new
+ * version (see {@code RubricChangeRescoreListener}).
+ *
+ * @param organizationId the owning organization
+ * @param rubricName     the rubric name (e.g. "default")
+ * @param version        the newly-minted version number
+ * @param occurredAt     when the event occurred
+ */
+public record RubricVersionCreated(
+        UUID organizationId,
+        String rubricName,
+        int version,
+        Instant occurredAt) { }

--- a/src/main/java/com/majordomo/domain/port/out/envoy/JobPostingRepository.java
+++ b/src/main/java/com/majordomo/domain/port/out/envoy/JobPostingRepository.java
@@ -2,6 +2,7 @@ package com.majordomo.domain.port.out.envoy;
 
 import com.majordomo.domain.model.envoy.JobPosting;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -37,4 +38,14 @@ public interface JobPostingRepository {
      * @return an existing posting with that source+externalId, or empty
      */
     Optional<JobPosting> findBySourceAndExternalId(String source, String externalId, UUID organizationId);
+
+    /**
+     * Returns every posting owned by an organization. Used by the rescore
+     * fan-out (manual endpoint and {@code RubricVersionCreated} listener).
+     * Unpaginated by design — see issue #147 for the personal-scale rationale.
+     *
+     * @param organizationId owning org
+     * @return every posting in that org (may be empty)
+     */
+    List<JobPosting> findAllByOrganizationId(UUID organizationId);
 }

--- a/src/test/java/com/majordomo/adapter/in/event/RubricChangeRescoreListenerTest.java
+++ b/src/test/java/com/majordomo/adapter/in/event/RubricChangeRescoreListenerTest.java
@@ -1,0 +1,85 @@
+package com.majordomo.adapter.in.event;
+
+import com.majordomo.domain.model.UuidFactory;
+import com.majordomo.domain.model.envoy.JobPosting;
+import com.majordomo.domain.model.event.RubricVersionCreated;
+import com.majordomo.domain.port.in.envoy.ScoreJobPostingUseCase;
+import com.majordomo.domain.port.out.envoy.JobPostingRepository;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit test for {@link RubricChangeRescoreListener} — the automatic-rescore
+ * half of issue #147.
+ */
+class RubricChangeRescoreListenerTest {
+
+    @Test
+    void onRubricVersionCreated_scoresEachPostingInOrg() {
+        UUID orgId = UuidFactory.newId();
+        var postings = mock(JobPostingRepository.class);
+        var scoreUseCase = mock(ScoreJobPostingUseCase.class);
+
+        var p1 = posting(orgId);
+        var p2 = posting(orgId);
+        when(postings.findAllByOrganizationId(orgId)).thenReturn(List.of(p1, p2));
+
+        var listener = new RubricChangeRescoreListener(postings, scoreUseCase);
+        listener.onRubricVersionCreated(new RubricVersionCreated(
+                orgId, "default", 4, Instant.now()));
+
+        verify(scoreUseCase).score(eq(p1.getId()), eq("default"), eq(orgId));
+        verify(scoreUseCase).score(eq(p2.getId()), eq("default"), eq(orgId));
+    }
+
+    @Test
+    void onRubricVersionCreated_zeroPostings_noopButExitsCleanly() {
+        UUID orgId = UuidFactory.newId();
+        var postings = mock(JobPostingRepository.class);
+        var scoreUseCase = mock(ScoreJobPostingUseCase.class);
+        when(postings.findAllByOrganizationId(orgId)).thenReturn(List.of());
+
+        var listener = new RubricChangeRescoreListener(postings, scoreUseCase);
+        listener.onRubricVersionCreated(new RubricVersionCreated(
+                orgId, "default", 1, Instant.now()));
+
+        verify(scoreUseCase, never()).score(eq(null), eq("default"), eq(orgId));
+    }
+
+    @Test
+    void onRubricVersionCreated_continuesPastFailureOnSinglePosting() {
+        UUID orgId = UuidFactory.newId();
+        var postings = mock(JobPostingRepository.class);
+        var scoreUseCase = mock(ScoreJobPostingUseCase.class);
+        var p1 = posting(orgId);
+        var p2 = posting(orgId);
+        when(postings.findAllByOrganizationId(orgId)).thenReturn(List.of(p1, p2));
+        when(scoreUseCase.score(eq(p1.getId()), eq("default"), eq(orgId)))
+                .thenThrow(new RuntimeException("LLM circuit open"));
+
+        var listener = new RubricChangeRescoreListener(postings, scoreUseCase);
+        listener.onRubricVersionCreated(new RubricVersionCreated(
+                orgId, "default", 2, Instant.now()));
+
+        // p2 still gets scored even after p1 fails
+        verify(scoreUseCase).score(eq(p2.getId()), eq("default"), eq(orgId));
+    }
+
+    private static JobPosting posting(UUID orgId) {
+        var p = new JobPosting();
+        p.setId(UuidFactory.newId());
+        p.setOrganizationId(orgId);
+        p.setSource("manual");
+        p.setRawText("body");
+        return p;
+    }
+}

--- a/src/test/java/com/majordomo/adapter/in/web/envoy/PostingControllerTest.java
+++ b/src/test/java/com/majordomo/adapter/in/web/envoy/PostingControllerTest.java
@@ -12,6 +12,7 @@ import com.majordomo.domain.model.envoy.Recommendation;
 import com.majordomo.domain.model.envoy.ScoreReport;
 import com.majordomo.domain.port.in.envoy.IngestJobPostingUseCase;
 import com.majordomo.domain.port.in.envoy.ScoreJobPostingUseCase;
+import com.majordomo.domain.port.out.envoy.JobPostingRepository;
 import com.majordomo.domain.port.out.identity.ApiKeyRepository;
 import com.majordomo.domain.port.out.identity.MembershipRepository;
 import com.majordomo.domain.port.out.identity.UserRepository;
@@ -48,6 +49,7 @@ class PostingControllerTest {
 
     @MockitoBean IngestJobPostingUseCase ingestUseCase;
     @MockitoBean ScoreJobPostingUseCase scoreUseCase;
+    @MockitoBean JobPostingRepository jobPostingRepository;
     @MockitoBean OrganizationAccessService organizationAccessService;
 
     // Required by SecurityConfig
@@ -76,6 +78,66 @@ class PostingControllerTest {
                         .content(json.writeValueAsString(body)))
                 .andExpect(status().isCreated())
                 .andExpect(header().exists("Location"));
+    }
+
+    @Test
+    @WithMockUser
+    void rescoreAllReturnsCountAndScoresEachPosting() throws Exception {
+        var p1 = new JobPosting();
+        p1.setId(UuidFactory.newId());
+        p1.setOrganizationId(ORG_ID);
+        p1.setSource("manual");
+        p1.setRawText("body 1");
+        var p2 = new JobPosting();
+        p2.setId(UuidFactory.newId());
+        p2.setOrganizationId(ORG_ID);
+        p2.setSource("manual");
+        p2.setRawText("body 2");
+
+        doNothing().when(organizationAccessService).verifyAccess(any());
+        when(jobPostingRepository.findAllByOrganizationId(ORG_ID)).thenReturn(List.of(p1, p2));
+        var report = new ScoreReport(UuidFactory.newId(), ORG_ID, p1.getId(),
+                UuidFactory.newId(), 1, Optional.empty(),
+                List.of(), List.of(), 70, 70, Recommendation.APPLY,
+                "claude-sonnet-4-6", Instant.now());
+        when(scoreUseCase.score(any(), eq("default"), eq(ORG_ID))).thenReturn(report);
+
+        mvc.perform(post("/api/envoy/postings/rescore")
+                        .param("organizationId", ORG_ID.toString()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.count").value(2));
+
+        org.mockito.Mockito.verify(scoreUseCase)
+                .score(eq(p1.getId()), eq("default"), eq(ORG_ID));
+        org.mockito.Mockito.verify(scoreUseCase)
+                .score(eq(p2.getId()), eq("default"), eq(ORG_ID));
+    }
+
+    @Test
+    @WithMockUser
+    void rescoreAllWithCustomRubricNameUsesIt() throws Exception {
+        var p1 = new JobPosting();
+        p1.setId(UuidFactory.newId());
+        p1.setOrganizationId(ORG_ID);
+        p1.setSource("manual");
+        p1.setRawText("body 1");
+
+        doNothing().when(organizationAccessService).verifyAccess(any());
+        when(jobPostingRepository.findAllByOrganizationId(ORG_ID)).thenReturn(List.of(p1));
+        var report = new ScoreReport(UuidFactory.newId(), ORG_ID, p1.getId(),
+                UuidFactory.newId(), 1, Optional.empty(),
+                List.of(), List.of(), 70, 70, Recommendation.APPLY,
+                "claude-sonnet-4-6", Instant.now());
+        when(scoreUseCase.score(any(), eq("strict"), eq(ORG_ID))).thenReturn(report);
+
+        mvc.perform(post("/api/envoy/postings/rescore")
+                        .param("organizationId", ORG_ID.toString())
+                        .param("rubricName", "strict"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.count").value(1));
+
+        org.mockito.Mockito.verify(scoreUseCase)
+                .score(eq(p1.getId()), eq("strict"), eq(ORG_ID));
     }
 
     @Test

--- a/src/test/java/com/majordomo/adapter/out/persistence/envoy/JpaJobPostingRepositoryTest.java
+++ b/src/test/java/com/majordomo/adapter/out/persistence/envoy/JpaJobPostingRepositoryTest.java
@@ -1,0 +1,60 @@
+package com.majordomo.adapter.out.persistence.envoy;
+
+import com.majordomo.domain.model.UuidFactory;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.ComponentScan;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.beans.factory.annotation.Autowired;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Slice test for {@link JpaJobPostingRepository#findAllByOrganizationId(UUID)}
+ * — confirms the new finder respects org boundaries.
+ */
+@DataJpaTest
+@AutoConfigureTestDatabase
+@ComponentScan(basePackageClasses = JpaJobPostingRepository.class)
+class JpaJobPostingRepositoryTest {
+
+    @Autowired
+    private JpaJobPostingRepository repo;
+
+    @Test
+    void findAllByOrganizationId_returnsOnlyMatchingOrgPostings() {
+        UUID orgA = UuidFactory.newId();
+        UUID orgB = UuidFactory.newId();
+
+        repo.save(posting(orgA, "src", "ext-1"));
+        repo.save(posting(orgA, "src", "ext-2"));
+        repo.save(posting(orgB, "src", "ext-3"));
+
+        List<JobPostingEntity> orgAPostings = repo.findAllByOrganizationId(orgA);
+        assertThat(orgAPostings).hasSize(2);
+        assertThat(orgAPostings).allSatisfy(p ->
+                assertThat(p.getOrganizationId()).isEqualTo(orgA));
+    }
+
+    @Test
+    void findAllByOrganizationId_returnsEmptyWhenNoPostings() {
+        UUID emptyOrg = UuidFactory.newId();
+        assertThat(repo.findAllByOrganizationId(emptyOrg)).isEmpty();
+    }
+
+    private static JobPostingEntity posting(UUID orgId, String source, String externalId) {
+        var e = new JobPostingEntity();
+        e.setId(UuidFactory.newId());
+        e.setOrganizationId(orgId);
+        e.setSource(source);
+        e.setExternalId(externalId);
+        e.setRawText("body");
+        e.setFetchedAt(Instant.now());
+        return e;
+    }
+}

--- a/src/test/java/com/majordomo/application/envoy/RubricServiceTest.java
+++ b/src/test/java/com/majordomo/application/envoy/RubricServiceTest.java
@@ -5,8 +5,11 @@ import com.majordomo.domain.model.envoy.Category;
 import com.majordomo.domain.model.envoy.Rubric;
 import com.majordomo.domain.model.envoy.Thresholds;
 import com.majordomo.domain.model.envoy.Tier;
+import com.majordomo.domain.model.event.RubricVersionCreated;
+import com.majordomo.domain.port.out.EventPublisher;
 import com.majordomo.domain.port.out.envoy.RubricRepository;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
 import java.time.Instant;
 import java.util.List;
@@ -16,6 +19,7 @@ import java.util.UUID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class RubricServiceTest {
@@ -25,6 +29,7 @@ class RubricServiceTest {
     @Test
     void saveNewVersion_incrementsVersionAndStampsFields() {
         var repo = mock(RubricRepository.class);
+        var publisher = mock(EventPublisher.class);
         var existing = new Rubric(UuidFactory.newId(), Optional.of(orgId), 3, "default",
                 List.of(), List.of(cat()), List.of(),
                 new Thresholds(20, 15, 5), Instant.now().minusSeconds(3600));
@@ -34,7 +39,7 @@ class RubricServiceTest {
         var submitted = new Rubric(null, Optional.empty(), 0, "default", List.of(),
                 List.of(cat()), List.of(), new Thresholds(30, 20, 10), null);
 
-        var service = new RubricService(repo);
+        var service = new RubricService(repo, publisher);
         Rubric saved = service.saveNewVersion("default", submitted, orgId);
 
         assertThat(saved.version()).isEqualTo(4);
@@ -47,13 +52,14 @@ class RubricServiceTest {
     @Test
     void saveNewVersion_startsAtV1WhenNoOrgSpecificExists() {
         var repo = mock(RubricRepository.class);
+        var publisher = mock(EventPublisher.class);
         when(repo.findActiveByName("brand-new", orgId)).thenReturn(Optional.empty());
         when(repo.save(any())).thenAnswer(inv -> inv.getArgument(0));
 
         var submitted = new Rubric(null, Optional.empty(), 0, "brand-new", List.of(),
                 List.of(cat()), List.of(), new Thresholds(30, 20, 10), null);
 
-        var saved = new RubricService(repo).saveNewVersion("brand-new", submitted, orgId);
+        var saved = new RubricService(repo, publisher).saveNewVersion("brand-new", submitted, orgId);
 
         assertThat(saved.version()).isEqualTo(1);
         assertThat(saved.organizationId()).contains(orgId);
@@ -64,6 +70,7 @@ class RubricServiceTest {
         // org has no override yet — findActiveByName falls back to the seeded
         // system-default (organizationId.isEmpty()). The new version starts at 1.
         var repo = mock(RubricRepository.class);
+        var publisher = mock(EventPublisher.class);
         var systemDefault = new Rubric(UuidFactory.newId(), Optional.empty(), 1, "default",
                 List.of(), List.of(cat()), List.of(),
                 new Thresholds(20, 15, 5), Instant.now());
@@ -73,9 +80,34 @@ class RubricServiceTest {
         var submitted = new Rubric(null, Optional.empty(), 0, "default", List.of(),
                 List.of(cat()), List.of(), new Thresholds(30, 20, 10), null);
 
-        var saved = new RubricService(repo).saveNewVersion("default", submitted, orgId);
+        var saved = new RubricService(repo, publisher).saveNewVersion("default", submitted, orgId);
 
         assertThat(saved.version()).isEqualTo(1);
+    }
+
+    @Test
+    void saveNewVersion_publishesRubricVersionCreatedEvent() {
+        var repo = mock(RubricRepository.class);
+        var publisher = mock(EventPublisher.class);
+        var existing = new Rubric(UuidFactory.newId(), Optional.of(orgId), 2, "default",
+                List.of(), List.of(cat()), List.of(),
+                new Thresholds(20, 15, 5), Instant.now().minusSeconds(60));
+        when(repo.findActiveByName("default", orgId)).thenReturn(Optional.of(existing));
+        when(repo.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        var submitted = new Rubric(null, Optional.empty(), 0, "default", List.of(),
+                List.of(cat()), List.of(), new Thresholds(30, 20, 10), null);
+
+        new RubricService(repo, publisher).saveNewVersion("default", submitted, orgId);
+
+        var captor = ArgumentCaptor.forClass(Object.class);
+        verify(publisher).publish(captor.capture());
+        assertThat(captor.getValue()).isInstanceOf(RubricVersionCreated.class);
+        var event = (RubricVersionCreated) captor.getValue();
+        assertThat(event.organizationId()).isEqualTo(orgId);
+        assertThat(event.rubricName()).isEqualTo("default");
+        assertThat(event.version()).isEqualTo(3);
+        assertThat(event.occurredAt()).isNotNull();
     }
 
     private Category cat() {


### PR DESCRIPTION
## Summary

Two complementary rescore paths, closing #147.

### Automatic (event-driven)
- New domain event `RubricVersionCreated(organizationId, rubricName, version, occurredAt)`
- `RubricService.saveNewVersion(...)` now injects `EventPublisher` and publishes the event after `repo.save(...)`
- New `RubricChangeRescoreListener` (in `adapter/in/event/`) catches the event, calls `JobPostingRepository.findAllByOrganizationId(...)`, and invokes `ScoreJobPostingUseCase.score(...)` per posting

### Manual (endpoint)
- `POST /api/envoy/postings/rescore?organizationId=…&rubricName=default` fans out the same scoring on demand
- Response body: `{"count": N}` where N is the number of postings that scored successfully

### Plumbing
- `JobPostingRepository.findAllByOrganizationId(UUID)` — new outbound port method, implemented by `JobPostingRepositoryAdapter` and backed by Spring Data's `findAllByOrganizationId` derived query
- Per the issue, unpaginated for v1 (personal scale)

## Throttling

Reuses the existing Resilience4j `envoy-llm` circuit breaker + retry on `AnthropicMessageClient` — every score call goes through that policy, so the rescore fan-out is naturally throttled per-call. **No new Resilience4j config was added.** A failed rescore on one posting is logged and the loop continues to the next.

## Personal-scale assumption

At a handful of postings the synchronous unchunked fan-out is fine. If/when this grows past tens, the natural follow-up is queued/chunked backpressure (a `RescoreJob` table + a scheduler, or moving the listener onto a bounded `Executor`). Out of scope here.

## Tests (strict TDD, each test failed first)

- `RubricServiceTest.saveNewVersion_publishesRubricVersionCreatedEvent` — verifies event publication on save
- `RubricChangeRescoreListenerTest` — three cases: two-posting fan-out, zero-postings clean exit, continue-past-failure
- `PostingControllerTest.rescoreAll*` — `@WebMvcTest` for the new endpoint, count + per-posting `score(...)` invocation
- `JpaJobPostingRepositoryTest` — first `@DataJpaTest` slice in the codebase; covers org-boundary respect and empty-org

## Test plan

- [x] `./mvnw verify` green (247 tests, checkstyle clean, ArchUnit clean)
- [ ] Manual smoke against running app: `PUT /api/envoy/rubrics/default` with two postings in the org → both get `JobPostingScored` audit entries
- [ ] Manual smoke: `POST /api/envoy/postings/rescore?organizationId=...` returns the expected count

🤖 Generated with [Claude Code](https://claude.com/claude-code)