### PR TITLE
feat(envoy): enrich /envoy rows with posting metadata, closes #144

### DIFF
--- a/src/main/java/com/majordomo/adapter/in/web/envoy/EnvoyPageController.java
+++ b/src/main/java/com/majordomo/adapter/in/web/envoy/EnvoyPageController.java
@@ -1,7 +1,9 @@
 package com.majordomo.adapter.in.web.envoy;
 
+import com.majordomo.domain.model.envoy.JobPosting;
 import com.majordomo.domain.model.envoy.ScoreReport;
 import com.majordomo.domain.port.in.envoy.QueryScoreReportsUseCase;
+import com.majordomo.domain.port.out.envoy.JobPostingRepository;
 import com.majordomo.domain.port.out.identity.MembershipRepository;
 import com.majordomo.domain.port.out.identity.UserRepository;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -15,7 +17,8 @@ import java.util.UUID;
 
 /**
  * Thymeleaf controller for the Envoy tab. Renders a paginated list of recent
- * score reports for the authenticated user's first organization.
+ * score reports for the authenticated user's first organization, each enriched
+ * with its source {@link JobPosting}'s company / title / location.
  */
 @Controller
 public class EnvoyPageController {
@@ -23,20 +26,34 @@ public class EnvoyPageController {
     private static final int DEFAULT_LIMIT = 50;
 
     private final QueryScoreReportsUseCase reports;
+    private final JobPostingRepository jobPostingRepository;
     private final UserRepository userRepository;
     private final MembershipRepository membershipRepository;
+
+    /**
+     * View-model row binding a {@link ScoreReport} to its source {@link JobPosting}.
+     * The posting is nullable to defensively handle the case where a report
+     * references a posting that has been deleted from underneath it.
+     *
+     * @param report  the score report
+     * @param posting the source posting, or {@code null} if no longer present
+     */
+    public record ScoreReportRow(ScoreReport report, JobPosting posting) { }
 
     /**
      * Constructs the controller.
      *
      * @param reports              inbound port for report queries
+     * @param jobPostingRepository outbound port for posting lookups
      * @param userRepository       outbound port for user lookups
      * @param membershipRepository outbound port for membership lookups
      */
     public EnvoyPageController(QueryScoreReportsUseCase reports,
+                               JobPostingRepository jobPostingRepository,
                                UserRepository userRepository,
                                MembershipRepository membershipRepository) {
         this.reports = reports;
+        this.jobPostingRepository = jobPostingRepository;
         this.userRepository = userRepository;
         this.membershipRepository = membershipRepository;
     }
@@ -44,6 +61,12 @@ public class EnvoyPageController {
     /**
      * Renders the Envoy report list for the authenticated user's first
      * organization. Redirects home if the user has no membership.
+     *
+     * <p>Each report is paired with its source posting via a per-row
+     * {@link JobPostingRepository#findById(UUID, UUID)} lookup. This is N+1 by
+     * design: at the {@code DEFAULT_LIMIT} of 50 the cost is negligible, and
+     * the read path stays simple. If the page grows we can swap in a join
+     * query without touching the template.</p>
      *
      * @param principal the authenticated user
      * @param model     the Thymeleaf model
@@ -62,7 +85,13 @@ public class EnvoyPageController {
                 .query(orgId, null, null, null, DEFAULT_LIMIT)
                 .items();
 
-        model.addAttribute("reports", recent);
+        List<ScoreReportRow> rows = recent.stream()
+                .map(r -> new ScoreReportRow(
+                        r,
+                        jobPostingRepository.findById(r.postingId(), orgId).orElse(null)))
+                .toList();
+
+        model.addAttribute("rows", rows);
         model.addAttribute("organizationId", orgId);
         model.addAttribute("username", user.getUsername());
         return "envoy";

--- a/src/main/resources/templates/envoy.html
+++ b/src/main/resources/templates/envoy.html
@@ -23,7 +23,7 @@
             </div>
 
             <!-- Empty state -->
-            <div th:if="${#lists.isEmpty(reports)}"
+            <div th:if="${#lists.isEmpty(rows)}"
                  class="bg-white rounded-lg shadow p-8 text-center">
                 <p class="text-gray-500 mb-2">No score reports yet.</p>
                 <p class="text-sm text-gray-400">
@@ -36,7 +36,7 @@
             </div>
 
             <!-- Reports table -->
-            <div th:unless="${#lists.isEmpty(reports)}"
+            <div th:unless="${#lists.isEmpty(rows)}"
                  class="bg-white rounded-lg shadow overflow-hidden">
                 <table class="min-w-full divide-y divide-gray-200">
                     <thead class="bg-gray-50">
@@ -50,9 +50,10 @@
                         </tr>
                     </thead>
                     <tbody class="bg-white divide-y divide-gray-100">
-                        <tr th:each="r : ${reports}" class="hover:bg-gray-50">
+                        <tr th:each="row : ${rows}" class="hover:bg-gray-50">
                             <td class="px-6 py-3 whitespace-nowrap">
-                                <span th:text="${r.recommendation()}"
+                                <span th:with="r=${row.report()}"
+                                      th:text="${r.recommendation()}"
                                       th:classappend="${r.recommendation().name() == 'APPLY_NOW'} ? 'bg-emerald-100 text-emerald-800' :
                                                      (${r.recommendation().name() == 'APPLY'} ? 'bg-indigo-100 text-indigo-800' :
                                                      (${r.recommendation().name() == 'CONSIDER'} ? 'bg-amber-100 text-amber-800' :
@@ -61,16 +62,25 @@
                                 </span>
                             </td>
                             <td class="px-6 py-3 text-right text-lg font-semibold text-gray-900"
-                                th:text="${r.finalScore()}">0</td>
-                            <td class="px-6 py-3 whitespace-nowrap font-mono text-xs text-gray-600"
-                                th:text="${#strings.abbreviate(r.postingId().toString(), 12)}">-</td>
+                                th:text="${row.report().finalScore()}">0</td>
+                            <td class="px-6 py-3 whitespace-nowrap text-sm text-gray-700">
+                                <span th:if="${row.posting() != null}"
+                                      th:text="${(row.posting().getCompany() != null ? row.posting().getCompany() : '—')
+                                              + ' · '
+                                              + (row.posting().getTitle() != null ? row.posting().getTitle() : '—')
+                                              + ' · '
+                                              + (row.posting().getLocation() != null ? row.posting().getLocation() : '—')}">-</span>
+                                <span th:if="${row.posting() == null}"
+                                      class="font-mono text-xs text-gray-400"
+                                      th:text="${#strings.abbreviate(row.report().postingId().toString(), 12) + ' (deleted)'}">-</span>
+                            </td>
                             <td class="px-6 py-3 whitespace-nowrap text-sm text-gray-600"
-                                th:text="${r.llmModel()}">-</td>
+                                th:text="${row.report().llmModel()}">-</td>
                             <td class="px-6 py-3 whitespace-nowrap text-sm text-gray-500"
-                                th:text="${#temporals.format(r.scoredAt(), 'yyyy-MM-dd HH:mm')}">-</td>
+                                th:text="${#temporals.format(row.report().scoredAt(), 'yyyy-MM-dd HH:mm')}">-</td>
                             <td class="px-6 py-3 text-right">
                                 <a class="text-indigo-600 hover:text-indigo-800 text-sm"
-                                   th:href="@{|/api/envoy/reports/${r.id()}|(organizationId=${organizationId})}"
+                                   th:href="@{|/api/envoy/reports/${row.report().id()}|(organizationId=${organizationId})}"
                                    target="_blank">JSON</a>
                             </td>
                         </tr>

--- a/src/test/java/com/majordomo/adapter/in/web/envoy/EnvoyPageControllerTest.java
+++ b/src/test/java/com/majordomo/adapter/in/web/envoy/EnvoyPageControllerTest.java
@@ -4,11 +4,13 @@ import com.majordomo.adapter.in.web.config.OAuth2UserService;
 import com.majordomo.adapter.in.web.config.SecurityConfig;
 import com.majordomo.domain.model.Page;
 import com.majordomo.domain.model.UuidFactory;
+import com.majordomo.domain.model.envoy.JobPosting;
 import com.majordomo.domain.model.envoy.Recommendation;
 import com.majordomo.domain.model.envoy.ScoreReport;
 import com.majordomo.domain.model.identity.Membership;
 import com.majordomo.domain.model.identity.User;
 import com.majordomo.domain.port.in.envoy.QueryScoreReportsUseCase;
+import com.majordomo.domain.port.out.envoy.JobPostingRepository;
 import com.majordomo.domain.port.out.identity.ApiKeyRepository;
 import com.majordomo.domain.port.out.identity.MembershipRepository;
 import com.majordomo.domain.port.out.identity.UserRepository;
@@ -19,12 +21,14 @@ import org.springframework.context.annotation.Import;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
 
 import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
@@ -42,6 +46,7 @@ class EnvoyPageControllerTest {
     @MockitoBean QueryScoreReportsUseCase reports;
     @MockitoBean UserRepository userRepository;
     @MockitoBean MembershipRepository membershipRepository;
+    @MockitoBean JobPostingRepository jobPostingRepository;
     @MockitoBean ApiKeyRepository apiKeyRepository;
     @MockitoBean OAuth2UserService oAuth2UserService;
 
@@ -49,27 +54,126 @@ class EnvoyPageControllerTest {
 
     @Test
     @WithMockUser(username = "robsartin")
-    void rendersEnvoyPageWithReports() throws Exception {
+    void rendersEnvoyPageWithEnrichedRows() throws Exception {
         var user = new User(UuidFactory.newId(), "robsartin", "rob@example.com");
         var membership = new Membership();
         membership.setUserId(user.getId());
         membership.setOrganizationId(ORG_ID);
-        var report = new ScoreReport(UuidFactory.newId(), ORG_ID, UuidFactory.newId(),
+
+        UUID postingId = UuidFactory.newId();
+        var report = new ScoreReport(UuidFactory.newId(), ORG_ID, postingId,
                 UuidFactory.newId(), 1, Optional.empty(),
                 List.of(), List.of(), 87, 87, Recommendation.APPLY_NOW,
+                "claude-sonnet-4-6", Instant.now());
+
+        var posting = new JobPosting();
+        posting.setId(postingId);
+        posting.setOrganizationId(ORG_ID);
+        posting.setCompany("Acme Corp");
+        posting.setTitle("Senior Backend Engineer");
+        posting.setLocation("Remote (US)");
+
+        when(userRepository.findByUsername("robsartin")).thenReturn(Optional.of(user));
+        when(membershipRepository.findByUserId(user.getId())).thenReturn(List.of(membership));
+        when(reports.query(eq(ORG_ID), any(), any(), any(), any(Integer.class)))
+                .thenReturn(new Page<>(List.of(report), null, false));
+        when(jobPostingRepository.findById(postingId, ORG_ID)).thenReturn(Optional.of(posting));
+
+        MvcResult result = mvc.perform(get("/envoy"))
+                .andExpect(status().isOk())
+                .andExpect(view().name("envoy"))
+                .andExpect(model().attributeExists("rows"))
+                .andExpect(model().attribute("organizationId", ORG_ID))
+                .andExpect(model().attribute("username", "robsartin"))
+                .andReturn();
+
+        @SuppressWarnings("unchecked")
+        List<EnvoyPageController.ScoreReportRow> rows =
+                (List<EnvoyPageController.ScoreReportRow>) result.getModelAndView()
+                        .getModel().get("rows");
+        assertThat(rows).hasSize(1);
+        assertThat(rows.get(0).report()).isEqualTo(report);
+        assertThat(rows.get(0).posting()).isNotNull();
+        assertThat(rows.get(0).posting().getCompany()).isEqualTo("Acme Corp");
+        assertThat(rows.get(0).posting().getTitle()).isEqualTo("Senior Backend Engineer");
+        assertThat(rows.get(0).posting().getLocation()).isEqualTo("Remote (US)");
+    }
+
+    @Test
+    @WithMockUser(username = "robsartin")
+    void rendersRowWithPartialPostingMetadata() throws Exception {
+        var user = new User(UuidFactory.newId(), "robsartin", "rob@example.com");
+        var membership = new Membership();
+        membership.setUserId(user.getId());
+        membership.setOrganizationId(ORG_ID);
+
+        UUID postingId = UuidFactory.newId();
+        var report = new ScoreReport(UuidFactory.newId(), ORG_ID, postingId,
+                UuidFactory.newId(), 1, Optional.empty(),
+                List.of(), List.of(), 50, 50, Recommendation.CONSIDER,
+                "claude-sonnet-4-6", Instant.now());
+
+        // posting where LLM extraction couldn't pull company/location, only title is set
+        var posting = new JobPosting();
+        posting.setId(postingId);
+        posting.setOrganizationId(ORG_ID);
+        posting.setCompany(null);
+        posting.setTitle("Software Engineer");
+        posting.setLocation(null);
+
+        when(userRepository.findByUsername("robsartin")).thenReturn(Optional.of(user));
+        when(membershipRepository.findByUserId(user.getId())).thenReturn(List.of(membership));
+        when(reports.query(eq(ORG_ID), any(), any(), any(), any(Integer.class)))
+                .thenReturn(new Page<>(List.of(report), null, false));
+        when(jobPostingRepository.findById(postingId, ORG_ID)).thenReturn(Optional.of(posting));
+
+        MvcResult result = mvc.perform(get("/envoy"))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        @SuppressWarnings("unchecked")
+        List<EnvoyPageController.ScoreReportRow> rows =
+                (List<EnvoyPageController.ScoreReportRow>) result.getModelAndView()
+                        .getModel().get("rows");
+        assertThat(rows).hasSize(1);
+        assertThat(rows.get(0).posting()).isNotNull();
+        assertThat(rows.get(0).posting().getCompany()).isNull();
+        assertThat(rows.get(0).posting().getTitle()).isEqualTo("Software Engineer");
+        assertThat(rows.get(0).posting().getLocation()).isNull();
+    }
+
+    @Test
+    @WithMockUser(username = "robsartin")
+    void rendersRowWhenPostingNoLongerExists() throws Exception {
+        var user = new User(UuidFactory.newId(), "robsartin", "rob@example.com");
+        var membership = new Membership();
+        membership.setUserId(user.getId());
+        membership.setOrganizationId(ORG_ID);
+
+        UUID postingId = UuidFactory.newId();
+        var report = new ScoreReport(UuidFactory.newId(), ORG_ID, postingId,
+                UuidFactory.newId(), 1, Optional.empty(),
+                List.of(), List.of(), 70, 70, Recommendation.APPLY,
                 "claude-sonnet-4-6", Instant.now());
 
         when(userRepository.findByUsername("robsartin")).thenReturn(Optional.of(user));
         when(membershipRepository.findByUserId(user.getId())).thenReturn(List.of(membership));
         when(reports.query(eq(ORG_ID), any(), any(), any(), any(Integer.class)))
                 .thenReturn(new Page<>(List.of(report), null, false));
+        when(jobPostingRepository.findById(postingId, ORG_ID)).thenReturn(Optional.empty());
 
-        mvc.perform(get("/envoy"))
+        MvcResult result = mvc.perform(get("/envoy"))
                 .andExpect(status().isOk())
                 .andExpect(view().name("envoy"))
-                .andExpect(model().attribute("reports", List.of(report)))
-                .andExpect(model().attribute("organizationId", ORG_ID))
-                .andExpect(model().attribute("username", "robsartin"));
+                .andReturn();
+
+        @SuppressWarnings("unchecked")
+        List<EnvoyPageController.ScoreReportRow> rows =
+                (List<EnvoyPageController.ScoreReportRow>) result.getModelAndView()
+                        .getModel().get("rows");
+        assertThat(rows).hasSize(1);
+        assertThat(rows.get(0).report()).isEqualTo(report);
+        assertThat(rows.get(0).posting()).isNull();
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Replaces the bare truncated `postingId` cell on `/envoy` with `company · title · location` pulled from the source `JobPosting`.
- Adds a view-model record `EnvoyPageController.ScoreReportRow(report, posting)` with a nullable `posting` to defensively handle reports whose posting has been deleted.
- Wires `JobPostingRepository` into `EnvoyPageController` and renames the model attribute `reports` → `rows`.

## Implementation choice
Picked **option 1** from the issue: per-row `JobPostingRepository.findById` in the page controller. N+1 is acceptable at the current `DEFAULT_LIMIT` of 50, and it keeps the read path trivial. If the list grows past one page worth, swap in option 2's join query without touching the template.

## Defensive paths
- `JobPostingRepository.findById(...)` returning `Optional.empty()` → `posting` is `null`, template falls back to abbreviated UUID + ` (deleted)` instead of NPE-ing.
- Individual posting metadata fields nullable (e.g. URL fetch where the LLM couldn't extract `company`) → each `${row.posting().getX()}` is guarded with safe-nav, rendering `—` for missing values.

Both paths covered by `EnvoyPageControllerTest`:
- `rendersEnvoyPageWithEnrichedRows` — fully populated metadata
- `rendersRowWithPartialPostingMetadata` — null company/location
- `rendersRowWhenPostingNoLongerExists` — `findById` returns empty

## Verification
- `./mvnw verify` — green (266 tests, 0 failures, 0 errors, Checkstyle + ArchUnit clean).

## Test plan
- [x] `./mvnw verify` passes locally
- [ ] Manual: hit `/envoy` after scoring a posting; row shows `Acme Corp · Senior Backend Engineer · Remote (US)` instead of the UUID stub
- [ ] Manual: delete the posting underneath an existing report; row degrades to `019dcc87-4c… (deleted)` without erroring

🤖 Generated with [Claude Code](https://claude.com/claude-code)