### PR TITLE
feat(envoy): report detail page at /envoy/reports/{id}, closes #145

### DIFF
--- a/src/main/java/com/majordomo/adapter/in/web/envoy/EnvoyPageController.java
+++ b/src/main/java/com/majordomo/adapter/in/web/envoy/EnvoyPageController.java
@@ -2,23 +2,28 @@ package com.majordomo.adapter.in.web.envoy;
 
 import com.majordomo.domain.model.envoy.JobPosting;
 import com.majordomo.domain.model.envoy.ScoreReport;
+import com.majordomo.domain.model.identity.User;
 import com.majordomo.domain.port.in.envoy.QueryScoreReportsUseCase;
 import com.majordomo.domain.port.out.envoy.JobPostingRepository;
 import com.majordomo.domain.port.out.identity.MembershipRepository;
 import com.majordomo.domain.port.out.identity.UserRepository;
+import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 /**
  * Thymeleaf controller for the Envoy tab. Renders a paginated list of recent
  * score reports for the authenticated user's first organization, each enriched
- * with its source {@link JobPosting}'s company / title / location.
+ * with its source {@link JobPosting}'s company / title / location, plus a
+ * per-report detail page at {@code /envoy/reports/{id}}.
  */
 @Controller
 public class EnvoyPageController {
@@ -39,6 +44,16 @@ public class EnvoyPageController {
      * @param posting the source posting, or {@code null} if no longer present
      */
     public record ScoreReportRow(ScoreReport report, JobPosting posting) { }
+
+    /**
+     * Resolved authentication context: the user, plus the first org they
+     * belong to. {@code organizationId} is {@code null} if the user has no
+     * memberships, in which case the caller should redirect home.
+     *
+     * @param user           the authenticated user
+     * @param organizationId the user's first organization id, or {@code null}
+     */
+    private record AuthContext(User user, UUID organizationId) { }
 
     /**
      * Constructs the controller.
@@ -75,12 +90,11 @@ public class EnvoyPageController {
      */
     @GetMapping("/envoy")
     public String envoy(@AuthenticationPrincipal UserDetails principal, Model model) {
-        var user = userRepository.findByUsername(principal.getUsername()).orElseThrow();
-        var memberships = membershipRepository.findByUserId(user.getId());
-        if (memberships.isEmpty()) {
+        AuthContext ctx = resolveContext(principal);
+        if (ctx.organizationId() == null) {
             return "redirect:/";
         }
-        UUID orgId = memberships.get(0).getOrganizationId();
+        UUID orgId = ctx.organizationId();
         List<ScoreReport> recent = reports
                 .query(orgId, null, null, null, DEFAULT_LIMIT)
                 .items();
@@ -93,7 +107,67 @@ public class EnvoyPageController {
 
         model.addAttribute("rows", rows);
         model.addAttribute("organizationId", orgId);
-        model.addAttribute("username", user.getUsername());
+        model.addAttribute("username", ctx.user().getUsername());
         return "envoy";
+    }
+
+    /**
+     * Renders the human-readable detail page for a single score report. The
+     * detail page surfaces every category rationale and flag rationale the LLM
+     * produced, so the user can see <em>why</em> a posting received its
+     * recommendation.
+     *
+     * <p>If the report is not in the user's first organization (or simply
+     * doesn't exist) this returns 404. If the report's source posting has been
+     * deleted from underneath the report we still render — the {@code posting}
+     * model attribute is simply absent and the template degrades gracefully.</p>
+     *
+     * @param id        the report id
+     * @param principal the authenticated user
+     * @param model     the Thymeleaf model
+     * @param response  used to set the 404 status when no report is found
+     * @return the {@code envoy-report} template, {@code error} on 404, or a
+     *         redirect to {@code /} if the user has no organization
+     */
+    @GetMapping("/envoy/reports/{id}")
+    public String getReport(@PathVariable UUID id,
+                            @AuthenticationPrincipal UserDetails principal,
+                            Model model,
+                            HttpServletResponse response) {
+        AuthContext ctx = resolveContext(principal);
+        if (ctx.organizationId() == null) {
+            return "redirect:/";
+        }
+        UUID orgId = ctx.organizationId();
+
+        Optional<ScoreReport> reportOpt = reports.findById(id, orgId);
+        if (reportOpt.isEmpty()) {
+            response.setStatus(HttpServletResponse.SC_NOT_FOUND);
+            model.addAttribute("message", "Score report not found.");
+            return "error";
+        }
+
+        ScoreReport report = reportOpt.get();
+        jobPostingRepository.findById(report.postingId(), orgId)
+                .ifPresent(p -> model.addAttribute("posting", p));
+
+        model.addAttribute("report", report);
+        model.addAttribute("organizationId", orgId);
+        model.addAttribute("username", ctx.user().getUsername());
+        return "envoy-report";
+    }
+
+    /**
+     * Resolves the authenticated user's first organization. Returns an
+     * {@link AuthContext} whose {@code organizationId} is {@code null} when
+     * the user has no membership; callers should redirect home in that case.
+     */
+    private AuthContext resolveContext(UserDetails principal) {
+        var user = userRepository.findByUsername(principal.getUsername()).orElseThrow();
+        var memberships = membershipRepository.findByUserId(user.getId());
+        if (memberships.isEmpty()) {
+            return new AuthContext(user, null);
+        }
+        return new AuthContext(user, memberships.get(0).getOrganizationId());
     }
 }

--- a/src/main/resources/templates/envoy-report.html
+++ b/src/main/resources/templates/envoy-report.html
@@ -1,0 +1,203 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org"
+      xmlns:sec="http://www.thymeleaf.org/extras/spring-security"
+      lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Envoy Report - Majordomo</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-gray-100 min-h-screen">
+
+    <div th:replace="~{fragments/header :: header}"></div>
+
+    <div class="flex min-h-screen">
+        <div th:replace="~{fragments/sidebar :: sidebar('envoy')}"></div>
+
+        <main class="flex-1 p-6">
+
+            <!-- Breadcrumb -->
+            <nav class="mb-4" aria-label="Breadcrumb">
+                <ol class="flex items-center space-x-2 text-sm text-gray-500">
+                    <li><a th:href="@{/envoy}" class="hover:text-indigo-600 transition">Envoy</a></li>
+                    <li class="flex items-center space-x-2">
+                        <span>&rsaquo;</span>
+                        <span class="text-gray-900 font-medium">Report</span>
+                    </li>
+                </ol>
+            </nav>
+
+            <!-- Header card -->
+            <div class="bg-white rounded-lg shadow mb-6">
+                <div class="px-6 py-5 flex items-start justify-between gap-6">
+                    <div class="min-w-0">
+                        <h1 class="text-2xl font-bold text-gray-900 truncate"
+                            th:if="${posting != null}"
+                            th:text="${(posting.getCompany() != null ? posting.getCompany() : '—')
+                                    + ' · '
+                                    + (posting.getTitle() != null ? posting.getTitle() : '—')}">
+                            Company · Title
+                        </h1>
+                        <h1 class="text-2xl font-bold text-gray-900"
+                            th:if="${posting == null}">
+                            Score report
+                            <span class="text-sm font-normal text-gray-500">(source posting deleted)</span>
+                        </h1>
+                        <div class="mt-2 flex flex-wrap gap-x-4 gap-y-1 text-sm text-gray-600">
+                            <span th:if="${posting != null and posting.getLocation() != null}"
+                                  th:text="${posting.getLocation()}">Location</span>
+                            <span th:text="'Scored ' + ${#temporals.format(report.scoredAt(), 'yyyy-MM-dd HH:mm')}">Scored</span>
+                            <span th:text="'Model: ' + ${report.llmModel()}">Model</span>
+                        </div>
+                    </div>
+
+                    <!-- Big score + recommendation badge -->
+                    <div class="text-right shrink-0">
+                        <div class="text-5xl font-bold text-gray-900"
+                             th:text="${report.finalScore()}">0</div>
+                        <div class="text-xs text-gray-500 mt-1"
+                             th:text="'raw ' + ${report.rawScore()}">raw 0</div>
+                        <span class="inline-block mt-2 rounded-full px-3 py-1 text-sm font-semibold"
+                              th:text="${report.recommendation()}"
+                              th:classappend="${report.recommendation().name() == 'APPLY_NOW'} ? 'bg-emerald-100 text-emerald-800' :
+                                             (${report.recommendation().name() == 'APPLY'} ? 'bg-indigo-100 text-indigo-800' :
+                                             (${report.recommendation().name() == 'CONSIDER'} ? 'bg-amber-100 text-amber-800' :
+                                                                                                 'bg-gray-200 text-gray-700'))">
+                        </span>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Disqualified banner -->
+            <div th:if="${report.disqualifiedBy().isPresent()}"
+                 class="bg-red-50 border border-red-200 rounded-lg shadow mb-6 p-5">
+                <div class="flex items-start gap-3">
+                    <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-semibold bg-red-100 text-red-800 uppercase tracking-wider">
+                        Disqualified
+                    </span>
+                    <div class="min-w-0">
+                        <h2 class="text-base font-semibold text-red-900"
+                            th:text="${report.disqualifiedBy().get().key()}">DISQUALIFIER_KEY</h2>
+                        <p class="mt-1 text-sm text-red-800"
+                           th:text="${report.disqualifiedBy().get().description()}">Why this fired.</p>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Category scores -->
+            <section class="bg-white rounded-lg shadow mb-6">
+                <div class="px-6 py-4 border-b border-gray-200">
+                    <h2 class="text-lg font-semibold text-gray-900">Category scores</h2>
+                </div>
+                <div class="p-6">
+                    <p th:if="${#lists.isEmpty(report.categoryScores())}"
+                       class="text-gray-400 text-sm">No category scores recorded.</p>
+                    <ul th:unless="${#lists.isEmpty(report.categoryScores())}"
+                        class="space-y-4">
+                        <li th:each="cat : ${report.categoryScores()}"
+                            class="border border-gray-100 rounded-md p-4">
+                            <div class="flex items-baseline justify-between gap-4">
+                                <div class="min-w-0">
+                                    <span class="font-semibold text-gray-900"
+                                          th:text="${cat.categoryKey()}">category_key</span>
+                                    <span class="ml-2 text-sm text-gray-600"
+                                          th:text="${cat.tierLabel()}">tier label</span>
+                                </div>
+                                <div class="text-right shrink-0">
+                                    <span class="text-lg font-semibold text-gray-900"
+                                          th:text="${cat.points()}">0</span>
+                                    <span class="text-xs text-gray-500 ml-1">pts</span>
+                                </div>
+                            </div>
+                            <blockquote th:if="${cat.rationale() != null}"
+                                        class="mt-3 border-l-4 border-indigo-100 pl-4 text-sm text-gray-700 italic"
+                                        th:text="${cat.rationale()}">
+                                Rationale.
+                            </blockquote>
+                        </li>
+                    </ul>
+                </div>
+            </section>
+
+            <!-- Flag hits -->
+            <section class="bg-white rounded-lg shadow mb-6">
+                <div class="px-6 py-4 border-b border-gray-200">
+                    <h2 class="text-lg font-semibold text-gray-900">Flags</h2>
+                </div>
+                <div class="p-6">
+                    <p th:if="${#lists.isEmpty(report.flagHits())}"
+                       class="text-gray-400 text-sm">No flags raised.</p>
+                    <ul th:unless="${#lists.isEmpty(report.flagHits())}"
+                        class="space-y-3">
+                        <li th:each="flag : ${report.flagHits()}"
+                            class="border border-amber-100 bg-amber-50 rounded-md p-4">
+                            <div class="flex items-baseline justify-between gap-4">
+                                <span class="font-semibold text-amber-900"
+                                      th:text="${flag.flagKey()}">flag_key</span>
+                                <span class="text-sm font-medium text-amber-800"
+                                      th:text="'-' + ${flag.penalty()} + ' pts'">-0 pts</span>
+                            </div>
+                            <p th:if="${flag.rationale() != null}"
+                               class="mt-2 text-sm text-amber-900"
+                               th:text="${flag.rationale()}">Rationale.</p>
+                        </li>
+                    </ul>
+                </div>
+            </section>
+
+            <!-- Footer card: rubric + posting metadata -->
+            <section class="bg-white rounded-lg shadow mb-6">
+                <div class="px-6 py-4 border-b border-gray-200">
+                    <h2 class="text-lg font-semibold text-gray-900">Provenance</h2>
+                </div>
+                <div class="p-6 space-y-4">
+                    <div class="grid grid-cols-1 sm:grid-cols-2 gap-4 text-sm">
+                        <div>
+                            <dt class="text-xs font-medium text-gray-500 uppercase tracking-wide">Rubric</dt>
+                            <dd class="mt-1 text-gray-900 font-mono text-xs"
+                                th:text="${#strings.abbreviate(report.rubricId().toString(), 12)} + ' v' + ${report.rubricVersion()}">
+                                rubric-id v1
+                            </dd>
+                        </div>
+                        <div th:if="${posting != null}">
+                            <dt class="text-xs font-medium text-gray-500 uppercase tracking-wide">Posting source</dt>
+                            <dd class="mt-1 text-gray-900"
+                                th:text="${posting.getSource() + ' · ' + (posting.getExternalId() != null ? posting.getExternalId() : '—')}">
+                                source · ext-id
+                            </dd>
+                        </div>
+                        <div th:if="${posting == null}">
+                            <dt class="text-xs font-medium text-gray-500 uppercase tracking-wide">Posting</dt>
+                            <dd class="mt-1 text-gray-500 italic">Source posting has been deleted.</dd>
+                        </div>
+                    </div>
+
+                    <details th:if="${posting != null and posting.getRawText() != null}"
+                             class="border border-gray-100 rounded-md">
+                        <summary class="cursor-pointer px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50">
+                            Show posting raw text
+                        </summary>
+                        <pre class="px-4 py-3 bg-gray-50 text-xs text-gray-800 whitespace-pre-wrap break-words"
+                             th:text="${posting.getRawText()}">posting body</pre>
+                    </details>
+
+                    <details class="border border-gray-100 rounded-md">
+                        <summary class="cursor-pointer px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50">
+                            Raw JSON
+                        </summary>
+                        <div class="px-4 py-3">
+                            <a class="text-indigo-600 hover:text-indigo-800 text-sm"
+                               th:href="@{|/api/envoy/reports/${report.id()}|(organizationId=${organizationId})}"
+                               target="_blank">
+                                Open <code class="bg-gray-100 px-1 rounded text-xs">/api/envoy/reports/{id}</code>
+                            </a>
+                        </div>
+                    </details>
+                </div>
+            </section>
+
+        </main>
+    </div>
+</body>
+</html>

--- a/src/main/resources/templates/envoy.html
+++ b/src/main/resources/templates/envoy.html
@@ -79,9 +79,8 @@
                             <td class="px-6 py-3 whitespace-nowrap text-sm text-gray-500"
                                 th:text="${#temporals.format(row.report().scoredAt(), 'yyyy-MM-dd HH:mm')}">-</td>
                             <td class="px-6 py-3 text-right">
-                                <a class="text-indigo-600 hover:text-indigo-800 text-sm"
-                                   th:href="@{|/api/envoy/reports/${row.report().id()}|(organizationId=${organizationId})}"
-                                   target="_blank">JSON</a>
+                                <a class="text-indigo-600 hover:text-indigo-800 text-sm font-medium"
+                                   th:href="@{/envoy/reports/{id}(id=${row.report().id()})}">View</a>
                             </td>
                         </tr>
                     </tbody>

--- a/src/test/java/com/majordomo/adapter/in/web/envoy/EnvoyPageControllerTest.java
+++ b/src/test/java/com/majordomo/adapter/in/web/envoy/EnvoyPageControllerTest.java
@@ -4,6 +4,9 @@ import com.majordomo.adapter.in.web.config.OAuth2UserService;
 import com.majordomo.adapter.in.web.config.SecurityConfig;
 import com.majordomo.domain.model.Page;
 import com.majordomo.domain.model.UuidFactory;
+import com.majordomo.domain.model.envoy.CategoryScore;
+import com.majordomo.domain.model.envoy.Disqualifier;
+import com.majordomo.domain.model.envoy.FlagHit;
 import com.majordomo.domain.model.envoy.JobPosting;
 import com.majordomo.domain.model.envoy.Recommendation;
 import com.majordomo.domain.model.envoy.ScoreReport;
@@ -29,10 +32,12 @@ import java.util.Optional;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.model;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
@@ -191,6 +196,167 @@ class EnvoyPageControllerTest {
     @Test
     void unauthenticatedRedirectsToLogin() throws Exception {
         mvc.perform(get("/envoy"))
+                .andExpect(status().is3xxRedirection());
+    }
+
+    // -------------------- detail page tests (issue #145) --------------------
+
+    @Test
+    @WithMockUser(username = "robsartin")
+    void getReport_rendersDetailPage() throws Exception {
+        var user = new User(UuidFactory.newId(), "robsartin", "rob@example.com");
+        var membership = new Membership();
+        membership.setUserId(user.getId());
+        membership.setOrganizationId(ORG_ID);
+
+        UUID reportId = UuidFactory.newId();
+        UUID postingId = UuidFactory.newId();
+
+        var category = new CategoryScore("compensation", 25, "Strong",
+                "Base salary listed at $200k.");
+        var flag = new FlagHit("legacy_stack", 5, "Mentions COBOL.");
+
+        var report = new ScoreReport(reportId, ORG_ID, postingId,
+                UuidFactory.newId(), 3, Optional.empty(),
+                List.of(category), List.of(flag), 80, 75,
+                Recommendation.APPLY, "claude-sonnet-4-6", Instant.now());
+
+        var posting = new JobPosting();
+        posting.setId(postingId);
+        posting.setOrganizationId(ORG_ID);
+        posting.setSource("greenhouse");
+        posting.setExternalId("ext-1234");
+        posting.setCompany("Acme Corp");
+        posting.setTitle("Senior Backend Engineer");
+        posting.setLocation("Remote (US)");
+        posting.setRawText("Full posting body goes here.");
+
+        when(userRepository.findByUsername("robsartin")).thenReturn(Optional.of(user));
+        when(membershipRepository.findByUserId(user.getId())).thenReturn(List.of(membership));
+        when(reports.findById(reportId, ORG_ID)).thenReturn(Optional.of(report));
+        when(jobPostingRepository.findById(postingId, ORG_ID)).thenReturn(Optional.of(posting));
+
+        MvcResult result = mvc.perform(get("/envoy/reports/{id}", reportId))
+                .andExpect(status().isOk())
+                .andExpect(view().name("envoy-report"))
+                .andExpect(model().attribute("report", report))
+                .andExpect(model().attribute("posting", posting))
+                .andExpect(model().attribute("organizationId", ORG_ID))
+                .andExpect(model().attribute("username", "robsartin"))
+                .andExpect(content().string(containsString("Acme Corp")))
+                .andExpect(content().string(containsString("Senior Backend Engineer")))
+                .andExpect(content().string(containsString("Base salary listed at $200k.")))
+                .andExpect(content().string(containsString("Mentions COBOL.")))
+                .andExpect(content().string(containsString("Full posting body goes here.")))
+                .andReturn();
+
+        // sidebar should have envoy highlighted
+        assertThat(result.getResponse().getContentAsString()).contains("envoy");
+    }
+
+    @Test
+    @WithMockUser(username = "robsartin")
+    void getReport_rendersDisqualifiedBanner() throws Exception {
+        var user = new User(UuidFactory.newId(), "robsartin", "rob@example.com");
+        var membership = new Membership();
+        membership.setUserId(user.getId());
+        membership.setOrganizationId(ORG_ID);
+
+        UUID reportId = UuidFactory.newId();
+        UUID postingId = UuidFactory.newId();
+
+        var dq = new Disqualifier("ON_SITE_ONLY",
+                "Posting requires 5 days a week in office.");
+
+        var report = new ScoreReport(reportId, ORG_ID, postingId,
+                UuidFactory.newId(), 3, Optional.of(dq),
+                List.of(), List.of(), 50, 0,
+                Recommendation.SKIP, "claude-sonnet-4-6", Instant.now());
+
+        var posting = new JobPosting();
+        posting.setId(postingId);
+        posting.setOrganizationId(ORG_ID);
+        posting.setSource("manual");
+        posting.setExternalId("ext-9");
+        posting.setCompany("RTO Co");
+        posting.setTitle("Engineer");
+        posting.setLocation("San Francisco, CA");
+        posting.setRawText("Body.");
+
+        when(userRepository.findByUsername("robsartin")).thenReturn(Optional.of(user));
+        when(membershipRepository.findByUserId(user.getId())).thenReturn(List.of(membership));
+        when(reports.findById(reportId, ORG_ID)).thenReturn(Optional.of(report));
+        when(jobPostingRepository.findById(postingId, ORG_ID)).thenReturn(Optional.of(posting));
+
+        mvc.perform(get("/envoy/reports/{id}", reportId))
+                .andExpect(status().isOk())
+                .andExpect(view().name("envoy-report"))
+                .andExpect(content().string(containsString("ON_SITE_ONLY")))
+                .andExpect(content().string(
+                        containsString("Posting requires 5 days a week in office.")));
+    }
+
+    @Test
+    @WithMockUser(username = "robsartin")
+    void getReport_rendersWhenPostingIsGone() throws Exception {
+        var user = new User(UuidFactory.newId(), "robsartin", "rob@example.com");
+        var membership = new Membership();
+        membership.setUserId(user.getId());
+        membership.setOrganizationId(ORG_ID);
+
+        UUID reportId = UuidFactory.newId();
+        UUID postingId = UuidFactory.newId();
+
+        var report = new ScoreReport(reportId, ORG_ID, postingId,
+                UuidFactory.newId(), 1, Optional.empty(),
+                List.of(), List.of(), 60, 60,
+                Recommendation.CONSIDER, "claude-sonnet-4-6", Instant.now());
+
+        when(userRepository.findByUsername("robsartin")).thenReturn(Optional.of(user));
+        when(membershipRepository.findByUserId(user.getId())).thenReturn(List.of(membership));
+        when(reports.findById(reportId, ORG_ID)).thenReturn(Optional.of(report));
+        when(jobPostingRepository.findById(postingId, ORG_ID)).thenReturn(Optional.empty());
+
+        mvc.perform(get("/envoy/reports/{id}", reportId))
+                .andExpect(status().isOk())
+                .andExpect(view().name("envoy-report"))
+                .andExpect(model().attribute("report", report))
+                .andExpect(model().attributeDoesNotExist("posting"));
+    }
+
+    @Test
+    @WithMockUser(username = "robsartin")
+    void getReport_returns404WhenNotFound() throws Exception {
+        var user = new User(UuidFactory.newId(), "robsartin", "rob@example.com");
+        var membership = new Membership();
+        membership.setUserId(user.getId());
+        membership.setOrganizationId(ORG_ID);
+
+        UUID reportId = UuidFactory.newId();
+
+        when(userRepository.findByUsername("robsartin")).thenReturn(Optional.of(user));
+        when(membershipRepository.findByUserId(user.getId())).thenReturn(List.of(membership));
+        when(reports.findById(reportId, ORG_ID)).thenReturn(Optional.empty());
+
+        mvc.perform(get("/envoy/reports/{id}", reportId))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @WithMockUser(username = "robsartin")
+    void getReport_redirectsHomeWhenUserHasNoMembership() throws Exception {
+        var user = new User(UuidFactory.newId(), "robsartin", "rob@example.com");
+        when(userRepository.findByUsername("robsartin")).thenReturn(Optional.of(user));
+        when(membershipRepository.findByUserId(user.getId())).thenReturn(List.of());
+
+        mvc.perform(get("/envoy/reports/{id}", UuidFactory.newId()))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(view().name("redirect:/"));
+    }
+
+    @Test
+    void getReport_unauthenticatedRedirectsToLogin() throws Exception {
+        mvc.perform(get("/envoy/reports/{id}", UuidFactory.newId()))
                 .andExpect(status().is3xxRedirection());
     }
 }


### PR DESCRIPTION
## Summary

- New `GET /envoy/reports/{id}` Thymeleaf page on `EnvoyPageController`. The envoy table-row link now points at this page (renamed `JSON` → `View`); the raw JSON is still reachable via a "Raw JSON" disclosure on the detail page itself.
- `envoy-report.html` lays out: header card (company / title / location / scoredAt / model / large finalScore + recommendation badge), red disqualifier banner when `report.disqualifiedBy()` is present, per-`CategoryScore` cards with rationale blockquotes, per-`FlagHit` cards, and a provenance footer (rubric id+version, posting source/externalId, raw-text `<details>`).
- Org scoping enforced via the existing `QueryScoreReportsUseCase.findById(id, orgId)` — cross-org or unknown ids surface 404 via the existing `error.html` template.
- Auth-context resolution (user + first-org membership) extracted to a private `AuthContext` helper so the list and detail handlers stay symmetric.

## Test plan

- [x] `EnvoyPageControllerTest.getReport_rendersDetailPage` — 200, view name `envoy-report`, model attributes (`report`, `posting`, `organizationId`, `username`), and rendered content includes company / title / category rationale / flag rationale / posting raw text.
- [x] `getReport_rendersDisqualifiedBanner` — disqualifier key + description appear on the page.
- [x] `getReport_rendersWhenPostingIsGone` — orphaned posting still renders the report; `posting` model attribute is absent.
- [x] `getReport_returns404WhenNotFound` — cross-org / unknown id returns 404.
- [x] `getReport_redirectsHomeWhenUserHasNoMembership` — redirect to `/`.
- [x] `getReport_unauthenticatedRedirectsToLogin` — Spring Security redirect.
- [x] `./mvnw verify` — green (280 tests, 0 failures).