### PR TITLE
feat(envoy): filter controls on /envoy (min score, recommendation), closes #146

### DIFF
--- a/src/main/java/com/majordomo/adapter/in/web/envoy/EnvoyPageController.java
+++ b/src/main/java/com/majordomo/adapter/in/web/envoy/EnvoyPageController.java
@@ -1,6 +1,7 @@
 package com.majordomo.adapter.in.web.envoy;
 
 import com.majordomo.domain.model.envoy.JobPosting;
+import com.majordomo.domain.model.envoy.Recommendation;
 import com.majordomo.domain.model.envoy.ScoreReport;
 import com.majordomo.domain.model.identity.User;
 import com.majordomo.domain.port.in.envoy.QueryScoreReportsUseCase;
@@ -14,6 +15,7 @@ import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
 
 import java.util.List;
 import java.util.Optional;
@@ -83,20 +85,30 @@ public class EnvoyPageController {
      * the read path stays simple. If the page grows we can swap in a join
      * query without touching the template.</p>
      *
-     * @param principal the authenticated user
-     * @param model     the Thymeleaf model
+     * <p>Optional filters {@code minFinalScore} and {@code recommendation} are
+     * threaded straight through to the use case. The raw values are also
+     * exposed on the model so the filter strip can pre-populate after a
+     * submit.</p>
+     *
+     * @param minFinalScore  optional min score lower bound (null = no filter)
+     * @param recommendation optional recommendation tier filter (null = any)
+     * @param principal      the authenticated user
+     * @param model          the Thymeleaf model
      * @return the {@code envoy} template name, or a redirect to {@code /} if
      *         the user has no organization
      */
     @GetMapping("/envoy")
-    public String envoy(@AuthenticationPrincipal UserDetails principal, Model model) {
+    public String envoy(@RequestParam(required = false) Integer minFinalScore,
+                        @RequestParam(required = false) Recommendation recommendation,
+                        @AuthenticationPrincipal UserDetails principal,
+                        Model model) {
         AuthContext ctx = resolveContext(principal);
         if (ctx.organizationId() == null) {
             return "redirect:/";
         }
         UUID orgId = ctx.organizationId();
         List<ScoreReport> recent = reports
-                .query(orgId, null, null, null, DEFAULT_LIMIT)
+                .query(orgId, minFinalScore, recommendation, null, DEFAULT_LIMIT)
                 .items();
 
         List<ScoreReportRow> rows = recent.stream()
@@ -106,6 +118,8 @@ public class EnvoyPageController {
                 .toList();
 
         model.addAttribute("rows", rows);
+        model.addAttribute("minFinalScore", minFinalScore);
+        model.addAttribute("recommendation", recommendation);
         model.addAttribute("organizationId", orgId);
         model.addAttribute("username", ctx.user().getUsername());
         return "envoy";

--- a/src/main/resources/templates/envoy.html
+++ b/src/main/resources/templates/envoy.html
@@ -22,6 +22,50 @@
                 <span class="text-sm text-gray-500">Job posting scores</span>
             </div>
 
+            <!-- Filter strip -->
+            <div class="bg-white rounded-lg shadow p-4 mb-6">
+                <form method="get" th:action="@{/envoy}" class="flex flex-wrap items-end gap-4">
+                    <div class="flex flex-col">
+                        <label for="recommendation"
+                               class="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-1">
+                            Recommendation
+                        </label>
+                        <select id="recommendation" name="recommendation"
+                                class="block rounded border-gray-300 text-sm focus:border-indigo-500 focus:ring-indigo-500 px-2 py-1.5">
+                            <option value=""
+                                    th:selected="${recommendation == null}">All</option>
+                            <option value="APPLY_NOW"
+                                    th:selected="${recommendation != null and recommendation.name() == 'APPLY_NOW'}">APPLY_NOW</option>
+                            <option value="APPLY"
+                                    th:selected="${recommendation != null and recommendation.name() == 'APPLY'}">APPLY</option>
+                            <option value="CONSIDER"
+                                    th:selected="${recommendation != null and recommendation.name() == 'CONSIDER'}">CONSIDER</option>
+                            <option value="SKIP"
+                                    th:selected="${recommendation != null and recommendation.name() == 'SKIP'}">SKIP</option>
+                        </select>
+                    </div>
+                    <div class="flex flex-col">
+                        <label for="minFinalScore"
+                               class="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-1">
+                            Min score
+                        </label>
+                        <input id="minFinalScore" name="minFinalScore" type="number"
+                               min="0" max="100"
+                               th:value="${minFinalScore}"
+                               placeholder="0-100"
+                               class="block w-28 rounded border-gray-300 text-sm focus:border-indigo-500 focus:ring-indigo-500 px-2 py-1.5">
+                    </div>
+                    <div class="flex items-center gap-3">
+                        <button type="submit"
+                                class="inline-flex items-center rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-indigo-700">
+                            Apply
+                        </button>
+                        <a th:href="@{/envoy}"
+                           class="text-sm text-gray-500 hover:text-gray-700">Clear</a>
+                    </div>
+                </form>
+            </div>
+
             <!-- Empty state -->
             <div th:if="${#lists.isEmpty(rows)}"
                  class="bg-white rounded-lg shadow p-8 text-center">

--- a/src/test/java/com/majordomo/adapter/in/web/envoy/EnvoyPageControllerTest.java
+++ b/src/test/java/com/majordomo/adapter/in/web/envoy/EnvoyPageControllerTest.java
@@ -34,7 +34,10 @@ import java.util.UUID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
@@ -197,6 +200,126 @@ class EnvoyPageControllerTest {
     void unauthenticatedRedirectsToLogin() throws Exception {
         mvc.perform(get("/envoy"))
                 .andExpect(status().is3xxRedirection());
+    }
+
+    // -------------------- filter tests (issue #146) --------------------
+
+    @Test
+    @WithMockUser(username = "robsartin")
+    void unfilteredRequestPassesNullsThrough() throws Exception {
+        var user = new User(UuidFactory.newId(), "robsartin", "rob@example.com");
+        var membership = new Membership();
+        membership.setUserId(user.getId());
+        membership.setOrganizationId(ORG_ID);
+
+        when(userRepository.findByUsername("robsartin")).thenReturn(Optional.of(user));
+        when(membershipRepository.findByUserId(user.getId())).thenReturn(List.of(membership));
+        when(reports.query(eq(ORG_ID), any(), any(), any(), any(Integer.class)))
+                .thenReturn(new Page<>(List.of(), null, false));
+
+        mvc.perform(get("/envoy"))
+                .andExpect(status().isOk())
+                .andExpect(model().attribute("minFinalScore", (Object) null))
+                .andExpect(model().attribute("recommendation", (Object) null));
+
+        verify(reports).query(eq(ORG_ID), isNull(), isNull(), isNull(), anyInt());
+    }
+
+    @Test
+    @WithMockUser(username = "robsartin")
+    void filtersByRecommendationOnly() throws Exception {
+        var user = new User(UuidFactory.newId(), "robsartin", "rob@example.com");
+        var membership = new Membership();
+        membership.setUserId(user.getId());
+        membership.setOrganizationId(ORG_ID);
+
+        when(userRepository.findByUsername("robsartin")).thenReturn(Optional.of(user));
+        when(membershipRepository.findByUserId(user.getId())).thenReturn(List.of(membership));
+        when(reports.query(eq(ORG_ID), any(), any(), any(), any(Integer.class)))
+                .thenReturn(new Page<>(List.of(), null, false));
+
+        mvc.perform(get("/envoy").param("recommendation", "APPLY_NOW"))
+                .andExpect(status().isOk())
+                .andExpect(model().attribute("minFinalScore", (Object) null))
+                .andExpect(model().attribute("recommendation", Recommendation.APPLY_NOW));
+
+        verify(reports).query(eq(ORG_ID), isNull(),
+                eq(Recommendation.APPLY_NOW), isNull(), anyInt());
+    }
+
+    @Test
+    @WithMockUser(username = "robsartin")
+    void filtersByMinFinalScoreOnly() throws Exception {
+        var user = new User(UuidFactory.newId(), "robsartin", "rob@example.com");
+        var membership = new Membership();
+        membership.setUserId(user.getId());
+        membership.setOrganizationId(ORG_ID);
+
+        when(userRepository.findByUsername("robsartin")).thenReturn(Optional.of(user));
+        when(membershipRepository.findByUserId(user.getId())).thenReturn(List.of(membership));
+        when(reports.query(eq(ORG_ID), any(), any(), any(), any(Integer.class)))
+                .thenReturn(new Page<>(List.of(), null, false));
+
+        mvc.perform(get("/envoy").param("minFinalScore", "70"))
+                .andExpect(status().isOk())
+                .andExpect(model().attribute("minFinalScore", 70))
+                .andExpect(model().attribute("recommendation", (Object) null));
+
+        verify(reports).query(eq(ORG_ID), eq(70), isNull(), isNull(), anyInt());
+    }
+
+    @Test
+    @WithMockUser(username = "robsartin")
+    void filtersByBothMinFinalScoreAndRecommendation() throws Exception {
+        var user = new User(UuidFactory.newId(), "robsartin", "rob@example.com");
+        var membership = new Membership();
+        membership.setUserId(user.getId());
+        membership.setOrganizationId(ORG_ID);
+
+        when(userRepository.findByUsername("robsartin")).thenReturn(Optional.of(user));
+        when(membershipRepository.findByUserId(user.getId())).thenReturn(List.of(membership));
+        when(reports.query(eq(ORG_ID), any(), any(), any(), any(Integer.class)))
+                .thenReturn(new Page<>(List.of(), null, false));
+
+        mvc.perform(get("/envoy")
+                        .param("minFinalScore", "70")
+                        .param("recommendation", "APPLY_NOW"))
+                .andExpect(status().isOk())
+                .andExpect(model().attribute("minFinalScore", 70))
+                .andExpect(model().attribute("recommendation", Recommendation.APPLY_NOW));
+
+        verify(reports).query(eq(ORG_ID), eq(70),
+                eq(Recommendation.APPLY_NOW), isNull(), anyInt());
+    }
+
+    @Test
+    @WithMockUser(username = "robsartin")
+    void rendersFilterStripWithPrePopulatedValues() throws Exception {
+        var user = new User(UuidFactory.newId(), "robsartin", "rob@example.com");
+        var membership = new Membership();
+        membership.setUserId(user.getId());
+        membership.setOrganizationId(ORG_ID);
+
+        when(userRepository.findByUsername("robsartin")).thenReturn(Optional.of(user));
+        when(membershipRepository.findByUserId(user.getId())).thenReturn(List.of(membership));
+        when(reports.query(eq(ORG_ID), any(), any(), any(), any(Integer.class)))
+                .thenReturn(new Page<>(List.of(), null, false));
+
+        MvcResult result = mvc.perform(get("/envoy")
+                        .param("minFinalScore", "70")
+                        .param("recommendation", "APPLY_NOW"))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        String body = result.getResponse().getContentAsString();
+        // form should target /envoy via GET
+        assertThat(body).contains("action=\"/envoy\"");
+        // min score input should be pre-populated
+        assertThat(body).contains("name=\"minFinalScore\"");
+        assertThat(body).contains("value=\"70\"");
+        // recommendation select option for APPLY_NOW should be selected
+        assertThat(body).contains("name=\"recommendation\"");
+        assertThat(body).contains("APPLY_NOW");
     }
 
     // -------------------- detail page tests (issue #145) --------------------


### PR DESCRIPTION
## Summary

- Adds optional `minFinalScore` and `recommendation` `@RequestParam`s on `GET /envoy` and threads them straight into `QueryScoreReportsUseCase.query(...)`. The query path already supported these args (per `ScoreReportRepository.query` and `QueryScoreReportsUseCase.query`) — no use-case, application-service, or repository changes were required.
- New filter strip above the report table in `envoy.html`: a `<select>` for recommendation tier (All / APPLY_NOW / APPLY / CONSIDER / SKIP), a `0–100` numeric input for min score, an Apply submit, and a Clear link back to plain `/envoy`. Tailwind, matched to the existing card aesthetic.
- The form preserves the currently selected filters across submits — `minFinalScore` and `recommendation` are added to the model so the input pre-fills its `value` and the matching `<option>` is `selected`.

## Test plan

- [x] `EnvoyPageControllerTest`: new slice tests cover all four filter combinations (none, recommendation only, min score only, both) and verify the args reach `reports.query(...)` via `verify(... eq(70), eq(Recommendation.APPLY_NOW), isNull(), anyInt())`.
- [x] Additional test asserts the model carries `minFinalScore` / `recommendation` and that the rendered HTML contains `action="/envoy"`, the numeric `value="70"`, and the `APPLY_NOW` option, so the UI round-trips selected filters.
- [x] `./mvnw verify` is green (285 tests, 0 failures).
- [ ] Manual: `/envoy?recommendation=APPLY_NOW&minFinalScore=70` is bookmarkable; the strip shows those values pre-populated; Clear returns to unfiltered.

Closes #146.

Generated with Claude Code.