### PR TITLE
feat(envoy): add rubric author UI at /envoy/rubrics

### DIFF
--- a/src/main/java/com/majordomo/adapter/in/web/envoy/RubricAuthorController.java
+++ b/src/main/java/com/majordomo/adapter/in/web/envoy/RubricAuthorController.java
@@ -1,0 +1,295 @@
+package com.majordomo.adapter.in.web.envoy;
+
+import com.majordomo.domain.model.UuidFactory;
+import com.majordomo.domain.model.envoy.Category;
+import com.majordomo.domain.model.envoy.Rubric;
+import com.majordomo.domain.model.envoy.Thresholds;
+import com.majordomo.domain.model.envoy.Tier;
+import com.majordomo.domain.model.identity.User;
+import com.majordomo.domain.port.in.envoy.ManageRubricUseCase;
+import com.majordomo.domain.port.out.envoy.RubricRepository;
+import com.majordomo.domain.port.out.identity.MembershipRepository;
+import com.majordomo.domain.port.out.identity.UserRepository;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.util.StringUtils;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * Thymeleaf controller for the rubric author UI. Renders a list of all
+ * rubrics visible to the active org and an edit form that
+ * authors/versions a rubric without hand-writing JSON.
+ *
+ * <p>This controller is the UI counterpart to {@link RubricController} (the
+ * JSON {@code PUT /api/envoy/rubrics/{name}} endpoint) and reuses the same
+ * {@link ManageRubricUseCase}; both surfaces produce the same persisted
+ * domain model.</p>
+ */
+@Controller
+public class RubricAuthorController {
+
+    private final ManageRubricUseCase rubrics;
+    private final RubricRepository rubricRepository;
+    private final UserRepository userRepository;
+    private final MembershipRepository membershipRepository;
+
+    /**
+     * Resolved authentication context: the user, plus the first org they belong
+     * to. {@code organizationId} is {@code null} if the user has no memberships,
+     * in which case callers should redirect home.
+     *
+     * @param user           the authenticated user
+     * @param organizationId the user's first organization id, or {@code null}
+     */
+    private record AuthContext(User user, UUID organizationId) { }
+
+    /**
+     * Constructs the controller.
+     *
+     * @param rubrics              inbound port for rubric authoring
+     * @param rubricRepository     outbound port for rubric reads
+     * @param userRepository       outbound port for user lookups
+     * @param membershipRepository outbound port for membership lookups
+     */
+    public RubricAuthorController(ManageRubricUseCase rubrics,
+                                  RubricRepository rubricRepository,
+                                  UserRepository userRepository,
+                                  MembershipRepository membershipRepository) {
+        this.rubrics = rubrics;
+        this.rubricRepository = rubricRepository;
+        this.userRepository = userRepository;
+        this.membershipRepository = membershipRepository;
+    }
+
+    /**
+     * Renders the list of active rubrics visible to the authenticated user's
+     * first organization (org-specific actives plus system-default rubrics
+     * the org has not yet authored).
+     *
+     * @param principal the authenticated user
+     * @param model     the Thymeleaf model
+     * @return the {@code rubrics-list} template, or a redirect home if the
+     *         user has no organization
+     */
+    @GetMapping("/envoy/rubrics")
+    public String list(@AuthenticationPrincipal UserDetails principal, Model model) {
+        AuthContext ctx = resolveContext(principal);
+        if (ctx.organizationId() == null) {
+            return "redirect:/";
+        }
+        UUID orgId = ctx.organizationId();
+        List<Rubric> activeRubrics = rubricRepository.findActiveRubricsForOrg(orgId);
+        model.addAttribute("rubrics", activeRubrics);
+        model.addAttribute("organizationId", orgId);
+        model.addAttribute("username", ctx.user().getUsername());
+        return "rubrics-list";
+    }
+
+    /**
+     * Renders the edit form for the named rubric. Pre-populates from the active
+     * rubric for the org if one exists; otherwise renders a blank form for
+     * authoring a new rubric under that name.
+     *
+     * @param name      logical rubric name (path variable)
+     * @param principal the authenticated user
+     * @param model     the Thymeleaf model
+     * @return the {@code rubric-edit} template, or a redirect home if the
+     *         user has no organization
+     */
+    @GetMapping("/envoy/rubrics/{name}/edit")
+    public String editForm(@PathVariable String name,
+                           @AuthenticationPrincipal UserDetails principal,
+                           Model model) {
+        AuthContext ctx = resolveContext(principal);
+        if (ctx.organizationId() == null) {
+            return "redirect:/";
+        }
+        UUID orgId = ctx.organizationId();
+        Optional<Rubric> existing = rubricRepository.findActiveByName(name, orgId);
+        RubricFormDto form = existing.map(RubricAuthorController::toForm)
+                .orElseGet(RubricFormDto::new);
+
+        model.addAttribute("form", form);
+        model.addAttribute("rubricName", name);
+        model.addAttribute("isNew", existing.isEmpty());
+        model.addAttribute("organizationId", orgId);
+        model.addAttribute("username", ctx.user().getUsername());
+        return "rubric-edit";
+    }
+
+    /**
+     * Handles the submitted rubric form. On validation success, calls
+     * {@link ManageRubricUseCase#saveNewVersion(String, Rubric, UUID)} and
+     * redirects to the list page with a flash message; on failure re-renders
+     * the form with the submitted values and field-level errors preserved.
+     *
+     * @param name      logical rubric name (path variable)
+     * @param form      the submitted form (auto-bound)
+     * @param result    binding/validation result
+     * @param principal the authenticated user
+     * @param model     the Thymeleaf model used for re-render on error
+     * @param redirect  flash attribute target on success
+     * @return the list redirect on success, or {@code rubric-edit} on error;
+     *         redirect home if user has no organization
+     */
+    @PostMapping("/envoy/rubrics/{name}")
+    public String submit(@PathVariable String name,
+                         @ModelAttribute("form") RubricFormDto form,
+                         BindingResult result,
+                         @AuthenticationPrincipal UserDetails principal,
+                         Model model,
+                         RedirectAttributes redirect) {
+        AuthContext ctx = resolveContext(principal);
+        if (ctx.organizationId() == null) {
+            return "redirect:/";
+        }
+        UUID orgId = ctx.organizationId();
+
+        validate(form, result);
+        if (result.hasErrors()) {
+            model.addAttribute("rubricName", name);
+            model.addAttribute("isNew", rubricRepository.findActiveByName(name, orgId).isEmpty());
+            model.addAttribute("organizationId", orgId);
+            model.addAttribute("username", ctx.user().getUsername());
+            return "rubric-edit";
+        }
+
+        Rubric submitted = toDomain(name, form);
+        Rubric saved = rubrics.saveNewVersion(name, submitted, orgId);
+        redirect.addFlashAttribute("flashMessage",
+                "Saved rubric \"" + name + "\" as version " + saved.version() + ".");
+        return "redirect:/envoy/rubrics";
+    }
+
+    private void validate(RubricFormDto form, BindingResult result) {
+        if (form.getCategories() == null || form.getCategories().isEmpty()) {
+            result.rejectValue("categories", "categories.empty",
+                    "At least one category is required.");
+        } else {
+            for (int i = 0; i < form.getCategories().size(); i++) {
+                var c = form.getCategories().get(i);
+                if (!StringUtils.hasText(c.getKey())) {
+                    result.rejectValue("categories[" + i + "].key", "category.key.blank",
+                            "Category key is required.");
+                }
+                if (c.getMaxPoints() == null || c.getMaxPoints() < 0) {
+                    result.rejectValue("categories[" + i + "].maxPoints",
+                            "category.maxPoints.invalid",
+                            "Max points must be zero or greater.");
+                }
+                if (c.getTiers() == null || c.getTiers().isEmpty()) {
+                    result.rejectValue("categories[" + i + "].tiers", "category.tiers.empty",
+                            "Each category needs at least one tier.");
+                } else {
+                    for (int j = 0; j < c.getTiers().size(); j++) {
+                        var t = c.getTiers().get(j);
+                        if (!StringUtils.hasText(t.getLabel())) {
+                            result.rejectValue("categories[" + i + "].tiers[" + j + "].label",
+                                    "tier.label.blank", "Tier label is required.");
+                        }
+                        if (t.getPoints() == null) {
+                            result.rejectValue("categories[" + i + "].tiers[" + j + "].points",
+                                    "tier.points.required", "Tier points are required.");
+                        }
+                    }
+                }
+            }
+        }
+
+        var th = form.getThresholds();
+        if (th == null || th.getApplyImmediately() == null
+                || th.getApply() == null || th.getConsiderOnly() == null) {
+            result.rejectValue("thresholds", "thresholds.required",
+                    "All three thresholds are required.");
+        } else if (!(th.getApplyImmediately() > th.getApply()
+                && th.getApply() > th.getConsiderOnly())) {
+            result.rejectValue("thresholds", "thresholds.ordering",
+                    "Thresholds must satisfy applyImmediately > apply > considerOnly.");
+        }
+    }
+
+    private static RubricFormDto toForm(Rubric r) {
+        var dto = new RubricFormDto();
+        List<RubricFormDto.CategoryForm> cats = new ArrayList<>();
+        for (Category c : r.categories()) {
+            var cf = new RubricFormDto.CategoryForm();
+            cf.setKey(c.key());
+            cf.setDescription(c.description());
+            cf.setMaxPoints(c.maxPoints());
+            List<RubricFormDto.TierForm> tiers = new ArrayList<>();
+            for (Tier t : c.tiers()) {
+                var tf = new RubricFormDto.TierForm();
+                tf.setLabel(t.label());
+                tf.setPoints(t.points());
+                tf.setCriteria(t.criteria());
+                tiers.add(tf);
+            }
+            cf.setTiers(tiers);
+            cats.add(cf);
+        }
+        dto.setCategories(cats);
+        var thresholds = new RubricFormDto.ThresholdsForm();
+        thresholds.setApplyImmediately(r.thresholds().applyImmediately());
+        thresholds.setApply(r.thresholds().apply());
+        thresholds.setConsiderOnly(r.thresholds().considerOnly());
+        dto.setThresholds(thresholds);
+        return dto;
+    }
+
+    private static Rubric toDomain(String name, RubricFormDto form) {
+        List<Category> categories = new ArrayList<>();
+        for (var cf : form.getCategories()) {
+            List<Tier> tiers = new ArrayList<>();
+            for (var tf : cf.getTiers()) {
+                tiers.add(new Tier(
+                        tf.getLabel(),
+                        tf.getPoints() == null ? 0 : tf.getPoints(),
+                        tf.getCriteria()));
+            }
+            categories.add(new Category(
+                    cf.getKey(),
+                    cf.getDescription(),
+                    cf.getMaxPoints() == null ? 0 : cf.getMaxPoints(),
+                    tiers));
+        }
+        var t = form.getThresholds();
+        var thresholds = new Thresholds(
+                t.getApplyImmediately(),
+                t.getApply(),
+                t.getConsiderOnly());
+        // id, organizationId, version, effectiveFrom are assigned by the
+        // service; supply placeholders that the service will overwrite.
+        return new Rubric(
+                UuidFactory.newId(),
+                Optional.empty(),
+                0,
+                name,
+                List.of(),
+                categories,
+                List.of(),
+                thresholds,
+                Instant.now());
+    }
+
+    private AuthContext resolveContext(UserDetails principal) {
+        var user = userRepository.findByUsername(principal.getUsername()).orElseThrow();
+        var memberships = membershipRepository.findByUserId(user.getId());
+        if (memberships.isEmpty()) {
+            return new AuthContext(user, null);
+        }
+        return new AuthContext(user, memberships.get(0).getOrganizationId());
+    }
+}

--- a/src/main/java/com/majordomo/adapter/in/web/envoy/RubricFormDto.java
+++ b/src/main/java/com/majordomo/adapter/in/web/envoy/RubricFormDto.java
@@ -1,0 +1,149 @@
+package com.majordomo.adapter.in.web.envoy;
+
+import org.springframework.util.AutoPopulatingList;
+
+import java.util.List;
+
+/**
+ * Mutable form-binding DTO for the rubric author UI.
+ *
+ * <p>Records make poor form-backing objects for Spring's
+ * {@code WebDataBinder} because they have no public no-arg constructor and no
+ * setters — and the form needs indexed binding like
+ * {@code categories[0].tiers[1].points} which requires
+ * {@code List#get(int)} returning a mutable instance to populate. So the
+ * author flow uses these plain classes for binding and converts to the
+ * immutable domain {@link com.majordomo.domain.model.envoy.Rubric} only on a
+ * successful submit.</p>
+ *
+ * <p>The list fields use Spring's {@link AutoPopulatingList} so that
+ * indexed binding paths like {@code categories[3].key} grow the list on
+ * demand rather than throwing {@code IndexOutOfBoundsException}.</p>
+ */
+public class RubricFormDto {
+
+    private List<CategoryForm> categories = new AutoPopulatingList<>(CategoryForm.class);
+    private ThresholdsForm thresholds = new ThresholdsForm();
+
+    /** @return the editable category list */
+    public List<CategoryForm> getCategories() {
+        return categories;
+    }
+
+    /** @param categories the bound category list */
+    public void setCategories(List<CategoryForm> categories) {
+        this.categories = categories;
+    }
+
+    /** @return the editable thresholds */
+    public ThresholdsForm getThresholds() {
+        return thresholds;
+    }
+
+    /** @param thresholds the bound thresholds */
+    public void setThresholds(ThresholdsForm thresholds) {
+        this.thresholds = thresholds;
+    }
+
+    /** Form-binding row for a single scoring category. */
+    public static class CategoryForm {
+        private String key;
+        private String description;
+        private Integer maxPoints;
+        private List<TierForm> tiers = new AutoPopulatingList<>(TierForm.class);
+
+        public String getKey() {
+            return key;
+        }
+
+        public void setKey(String key) {
+            this.key = key;
+        }
+
+        public String getDescription() {
+            return description;
+        }
+
+        public void setDescription(String description) {
+            this.description = description;
+        }
+
+        public Integer getMaxPoints() {
+            return maxPoints;
+        }
+
+        public void setMaxPoints(Integer maxPoints) {
+            this.maxPoints = maxPoints;
+        }
+
+        public List<TierForm> getTiers() {
+            return tiers;
+        }
+
+        public void setTiers(List<TierForm> tiers) {
+            this.tiers = tiers;
+        }
+    }
+
+    /** Form-binding row for a single tier within a category. */
+    public static class TierForm {
+        private String label;
+        private Integer points;
+        private String criteria;
+
+        public String getLabel() {
+            return label;
+        }
+
+        public void setLabel(String label) {
+            this.label = label;
+        }
+
+        public Integer getPoints() {
+            return points;
+        }
+
+        public void setPoints(Integer points) {
+            this.points = points;
+        }
+
+        public String getCriteria() {
+            return criteria;
+        }
+
+        public void setCriteria(String criteria) {
+            this.criteria = criteria;
+        }
+    }
+
+    /** Form-binding object for the thresholds triple. */
+    public static class ThresholdsForm {
+        private Integer applyImmediately;
+        private Integer apply;
+        private Integer considerOnly;
+
+        public Integer getApplyImmediately() {
+            return applyImmediately;
+        }
+
+        public void setApplyImmediately(Integer applyImmediately) {
+            this.applyImmediately = applyImmediately;
+        }
+
+        public Integer getApply() {
+            return apply;
+        }
+
+        public void setApply(Integer apply) {
+            this.apply = apply;
+        }
+
+        public Integer getConsiderOnly() {
+            return considerOnly;
+        }
+
+        public void setConsiderOnly(Integer considerOnly) {
+            this.considerOnly = considerOnly;
+        }
+    }
+}

--- a/src/main/java/com/majordomo/adapter/out/persistence/envoy/JpaRubricRepository.java
+++ b/src/main/java/com/majordomo/adapter/out/persistence/envoy/JpaRubricRepository.java
@@ -36,4 +36,22 @@ public interface JpaRubricRepository extends JpaRepository<RubricEntity, UUID> {
      */
     List<RubricEntity> findAllByOrganizationIdAndNameOrderByVersionAsc(
             UUID organizationId, String name);
+
+    /**
+     * All org-specific rows for {@code organizationId}, ordered by name ascending
+     * then version descending. Used to pick the highest-version row per name.
+     *
+     * @param organizationId org scope
+     * @return rows grouped by name with newest version first within each group
+     */
+    List<RubricEntity> findAllByOrganizationIdOrderByNameAscVersionDesc(UUID organizationId);
+
+    /**
+     * All system-default rows ({@code organization_id IS NULL}), ordered by name
+     * ascending then version descending. Used to pick the highest-version
+     * system-default row per name.
+     *
+     * @return system-default rows grouped by name with newest version first
+     */
+    List<RubricEntity> findAllByOrganizationIdIsNullOrderByNameAscVersionDesc();
 }

--- a/src/main/java/com/majordomo/adapter/out/persistence/envoy/RubricRepositoryAdapter.java
+++ b/src/main/java/com/majordomo/adapter/out/persistence/envoy/RubricRepositoryAdapter.java
@@ -4,7 +4,10 @@ import com.majordomo.domain.model.envoy.Rubric;
 import com.majordomo.domain.port.out.envoy.RubricRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -48,6 +51,26 @@ public class RubricRepositoryAdapter implements RubricRepository {
         return jpa.findAllByOrganizationIdAndNameOrderByVersionAsc(organizationId, name).stream()
                 .map(RubricMapper::toDomain)
                 .toList();
+    }
+
+    @Override
+    public List<Rubric> findActiveRubricsForOrg(UUID organizationId) {
+        // For each distinct name, prefer the org-specific highest-version row;
+        // otherwise fall back to the system-default highest-version row.
+        Map<String, RubricEntity> byName = new HashMap<>();
+        // Org-specific rows (highest version first by ORDER BY in query).
+        for (RubricEntity row : jpa.findAllByOrganizationIdOrderByNameAscVersionDesc(organizationId)) {
+            byName.putIfAbsent(row.getName(), row);
+        }
+        // System-default rows fill in any names the org has not authored.
+        for (RubricEntity row : jpa.findAllByOrganizationIdIsNullOrderByNameAscVersionDesc()) {
+            byName.putIfAbsent(row.getName(), row);
+        }
+        List<Rubric> result = new ArrayList<>(byName.size());
+        for (RubricEntity row : byName.values()) {
+            result.add(RubricMapper.toDomain(row));
+        }
+        return result;
     }
 
     @Override

--- a/src/main/java/com/majordomo/domain/port/out/envoy/RubricRepository.java
+++ b/src/main/java/com/majordomo/domain/port/out/envoy/RubricRepository.java
@@ -43,6 +43,17 @@ public interface RubricRepository {
     List<Rubric> findAllVersionsByName(String name, UUID organizationId);
 
     /**
+     * Lists the active rubric for every distinct rubric name visible to
+     * {@code organizationId}: the highest-version org-specific rubric per name,
+     * plus the highest-version system-default rubric for any name where the org
+     * has not authored its own version yet. Order is unspecified.
+     *
+     * @param organizationId org scope
+     * @return one active rubric per distinct name visible to this org
+     */
+    List<Rubric> findActiveRubricsForOrg(UUID organizationId);
+
+    /**
      * Persists a rubric. Caller is responsible for setting id, version, and effectiveFrom.
      *
      * @param rubric the rubric to persist

--- a/src/main/resources/templates/rubric-edit.html
+++ b/src/main/resources/templates/rubric-edit.html
@@ -1,0 +1,358 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org"
+      xmlns:sec="http://www.thymeleaf.org/extras/spring-security"
+      lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title th:text="'Edit rubric: ' + ${rubricName} + ' - Majordomo'">Edit rubric - Majordomo</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-gray-100 min-h-screen">
+
+    <div th:replace="~{fragments/header :: header}"></div>
+
+    <div class="flex min-h-screen">
+        <div th:replace="~{fragments/sidebar :: sidebar('envoy')}"></div>
+
+        <main class="flex-1 p-6">
+
+            <nav class="mb-4" aria-label="Breadcrumb">
+                <ol class="flex items-center space-x-2 text-sm text-gray-500">
+                    <li><a th:href="@{/envoy}" class="hover:text-indigo-600 transition">Envoy</a></li>
+                    <li class="flex items-center space-x-2">
+                        <span>&rsaquo;</span>
+                        <a th:href="@{/envoy/rubrics}" class="hover:text-indigo-600 transition">Rubrics</a>
+                    </li>
+                    <li class="flex items-center space-x-2">
+                        <span>&rsaquo;</span>
+                        <span class="text-gray-900 font-medium" th:text="${rubricName}">name</span>
+                    </li>
+                </ol>
+            </nav>
+
+            <div class="flex items-baseline justify-between mb-6">
+                <h1 class="text-2xl font-bold text-gray-900">
+                    <span th:if="${isNew}">New rubric:</span>
+                    <span th:unless="${isNew}">Edit rubric:</span>
+                    <span th:text="${rubricName}">name</span>
+                </h1>
+                <span class="text-sm text-gray-500">
+                    <span th:if="${isNew}">Will be saved as version 1.</span>
+                    <span th:unless="${isNew}">Saving creates a new version.</span>
+                </span>
+            </div>
+
+            <form th:action="@{/envoy/rubrics/{name}(name=${rubricName})}"
+                  th:object="${form}"
+                  method="post"
+                  class="space-y-6">
+
+                <div th:if="${#fields.hasGlobalErrors()}"
+                     class="bg-red-50 border border-red-200 text-red-800 rounded-md px-4 py-3 text-sm">
+                    <ul class="list-disc list-inside">
+                        <li th:each="err : ${#fields.globalErrors()}"
+                            th:text="${err}">global error</li>
+                    </ul>
+                </div>
+
+                <!-- Categories -->
+                <section class="bg-white rounded-lg shadow">
+                    <div class="px-6 py-4 border-b border-gray-200 flex items-baseline justify-between">
+                        <h2 class="text-lg font-semibold text-gray-900">Categories</h2>
+                        <button type="button" id="addCategoryBtn"
+                                class="text-sm text-indigo-600 hover:text-indigo-800 font-medium">
+                            + Add category
+                        </button>
+                    </div>
+
+                    <div th:if="${#fields.hasErrors('categories')}"
+                         class="px-6 pt-4 text-sm text-red-700">
+                        <p th:each="err : ${#fields.errors('categories')}"
+                           th:text="${err}">err</p>
+                    </div>
+
+                    <div id="categoriesContainer" class="p-6 space-y-6">
+                        <div th:each="cat, catStat : *{categories}"
+                             class="border border-gray-200 rounded-md p-4 category-row"
+                             th:attr="data-cat-index=${catStat.index}">
+                            <div class="flex items-center justify-between mb-3">
+                                <h3 class="text-sm font-semibold text-gray-700">
+                                    Category <span th:text="${catStat.index + 1}">1</span>
+                                </h3>
+                                <button type="button"
+                                        class="text-xs text-red-600 hover:text-red-800 remove-category-btn">
+                                    Remove category
+                                </button>
+                            </div>
+
+                            <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                                <div>
+                                    <label class="block text-xs font-medium text-gray-500 uppercase tracking-wider mb-1">Key</label>
+                                    <input type="text"
+                                           th:field="*{categories[__${catStat.index}__].key}"
+                                           class="block w-full rounded border-gray-300 text-sm focus:border-indigo-500 focus:ring-indigo-500 px-2 py-1.5"
+                                           th:classappend="${#fields.hasErrors('categories[__${catStat.index}__].key')} ? 'border-red-500' : ''">
+                                    <p th:if="${#fields.hasErrors('categories[__${catStat.index}__].key')}"
+                                       class="mt-1 text-xs text-red-700"
+                                       th:errors="*{categories[__${catStat.index}__].key}">err</p>
+                                </div>
+                                <div>
+                                    <label class="block text-xs font-medium text-gray-500 uppercase tracking-wider mb-1">Max points</label>
+                                    <input type="number" min="0"
+                                           th:field="*{categories[__${catStat.index}__].maxPoints}"
+                                           class="block w-full rounded border-gray-300 text-sm focus:border-indigo-500 focus:ring-indigo-500 px-2 py-1.5 cat-maxpoints"
+                                           th:classappend="${#fields.hasErrors('categories[__${catStat.index}__].maxPoints')} ? 'border-red-500' : ''">
+                                    <p th:if="${#fields.hasErrors('categories[__${catStat.index}__].maxPoints')}"
+                                       class="mt-1 text-xs text-red-700"
+                                       th:errors="*{categories[__${catStat.index}__].maxPoints}">err</p>
+                                </div>
+                                <div class="sm:col-span-2">
+                                    <label class="block text-xs font-medium text-gray-500 uppercase tracking-wider mb-1">Description</label>
+                                    <input type="text"
+                                           th:field="*{categories[__${catStat.index}__].description}"
+                                           class="block w-full rounded border-gray-300 text-sm focus:border-indigo-500 focus:ring-indigo-500 px-2 py-1.5">
+                                </div>
+                            </div>
+
+                            <div class="mt-4">
+                                <div class="flex items-center justify-between mb-2">
+                                    <h4 class="text-xs font-semibold text-gray-500 uppercase tracking-wider">Tiers</h4>
+                                    <button type="button"
+                                            class="text-xs text-indigo-600 hover:text-indigo-800 add-tier-btn">
+                                        + Add tier
+                                    </button>
+                                </div>
+                                <p th:if="${#fields.hasErrors('categories[__${catStat.index}__].tiers')}"
+                                   class="text-xs text-red-700 mb-2"
+                                   th:errors="*{categories[__${catStat.index}__].tiers}">err</p>
+                                <div class="tiers-container space-y-2">
+                                    <div th:each="tier, tierStat : *{categories[__${catStat.index}__].tiers}"
+                                         class="grid grid-cols-1 sm:grid-cols-12 gap-2 tier-row"
+                                         th:attr="data-tier-index=${tierStat.index}">
+                                        <div class="sm:col-span-3">
+                                            <label class="block text-xs font-medium text-gray-500 mb-1">Label</label>
+                                            <input type="text"
+                                                   th:field="*{categories[__${catStat.index}__].tiers[__${tierStat.index}__].label}"
+                                                   class="block w-full rounded border-gray-300 text-sm focus:border-indigo-500 focus:ring-indigo-500 px-2 py-1.5"
+                                                   th:classappend="${#fields.hasErrors('categories[__${catStat.index}__].tiers[__${tierStat.index}__].label')} ? 'border-red-500' : ''">
+                                        </div>
+                                        <div class="sm:col-span-2">
+                                            <label class="block text-xs font-medium text-gray-500 mb-1">Points</label>
+                                            <input type="number"
+                                                   th:field="*{categories[__${catStat.index}__].tiers[__${tierStat.index}__].points}"
+                                                   class="block w-full rounded border-gray-300 text-sm focus:border-indigo-500 focus:ring-indigo-500 px-2 py-1.5"
+                                                   th:classappend="${#fields.hasErrors('categories[__${catStat.index}__].tiers[__${tierStat.index}__].points')} ? 'border-red-500' : ''">
+                                        </div>
+                                        <div class="sm:col-span-6">
+                                            <label class="block text-xs font-medium text-gray-500 mb-1">Criteria</label>
+                                            <input type="text"
+                                                   th:field="*{categories[__${catStat.index}__].tiers[__${tierStat.index}__].criteria}"
+                                                   class="block w-full rounded border-gray-300 text-sm focus:border-indigo-500 focus:ring-indigo-500 px-2 py-1.5">
+                                        </div>
+                                        <div class="sm:col-span-1 flex items-end">
+                                            <button type="button"
+                                                    class="text-xs text-red-600 hover:text-red-800 remove-tier-btn">
+                                                Remove
+                                            </button>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </section>
+
+                <!-- Thresholds -->
+                <section class="bg-white rounded-lg shadow">
+                    <div class="px-6 py-4 border-b border-gray-200 flex items-baseline justify-between">
+                        <h2 class="text-lg font-semibold text-gray-900">Thresholds</h2>
+                        <span class="text-sm text-gray-500">
+                            Total max points:
+                            <span id="totalPoints" class="font-semibold text-gray-900">0</span>
+                        </span>
+                    </div>
+                    <div class="p-6">
+                        <p th:if="${#fields.hasErrors('thresholds')}"
+                           class="text-sm text-red-700 mb-3"
+                           th:errors="*{thresholds}">err</p>
+                        <div class="grid grid-cols-1 sm:grid-cols-3 gap-4">
+                            <div>
+                                <label class="block text-xs font-medium text-gray-500 uppercase tracking-wider mb-1">Apply immediately</label>
+                                <input type="number"
+                                       th:field="*{thresholds.applyImmediately}"
+                                       class="block w-full rounded border-gray-300 text-sm focus:border-indigo-500 focus:ring-indigo-500 px-2 py-1.5">
+                            </div>
+                            <div>
+                                <label class="block text-xs font-medium text-gray-500 uppercase tracking-wider mb-1">Apply</label>
+                                <input type="number"
+                                       th:field="*{thresholds.apply}"
+                                       class="block w-full rounded border-gray-300 text-sm focus:border-indigo-500 focus:ring-indigo-500 px-2 py-1.5">
+                            </div>
+                            <div>
+                                <label class="block text-xs font-medium text-gray-500 uppercase tracking-wider mb-1">Consider only</label>
+                                <input type="number"
+                                       th:field="*{thresholds.considerOnly}"
+                                       class="block w-full rounded border-gray-300 text-sm focus:border-indigo-500 focus:ring-indigo-500 px-2 py-1.5">
+                            </div>
+                        </div>
+                        <p class="text-xs text-gray-500 mt-3">
+                            Must satisfy: applyImmediately &gt; apply &gt; considerOnly. Below considerOnly &rarr; SKIP.
+                        </p>
+                    </div>
+                </section>
+
+                <div class="flex items-center justify-end gap-3">
+                    <a th:href="@{/envoy/rubrics}"
+                       class="text-sm text-gray-500 hover:text-gray-700">Cancel</a>
+                    <button type="submit"
+                            class="inline-flex items-center rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700">
+                        Save new version
+                    </button>
+                </div>
+
+            </form>
+
+            <!-- Hidden template rows used by the inline JS to clone new
+                 categories/tiers. Field name placeholders are __IDX__ /
+                 __TIDX__; the JS rewrites them to the next index. -->
+            <template id="categoryTemplate">
+                <div class="border border-gray-200 rounded-md p-4 category-row" data-cat-index="__IDX__">
+                    <div class="flex items-center justify-between mb-3">
+                        <h3 class="text-sm font-semibold text-gray-700">
+                            Category <span class="cat-num">__IDX_PLUS_1__</span>
+                        </h3>
+                        <button type="button" class="text-xs text-red-600 hover:text-red-800 remove-category-btn">Remove category</button>
+                    </div>
+                    <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                        <div>
+                            <label class="block text-xs font-medium text-gray-500 uppercase tracking-wider mb-1">Key</label>
+                            <input type="text" name="categories[__IDX__].key" id="categories__IDX__.key"
+                                   class="block w-full rounded border-gray-300 text-sm focus:border-indigo-500 focus:ring-indigo-500 px-2 py-1.5">
+                        </div>
+                        <div>
+                            <label class="block text-xs font-medium text-gray-500 uppercase tracking-wider mb-1">Max points</label>
+                            <input type="number" min="0" name="categories[__IDX__].maxPoints" id="categories__IDX__.maxPoints"
+                                   class="block w-full rounded border-gray-300 text-sm focus:border-indigo-500 focus:ring-indigo-500 px-2 py-1.5 cat-maxpoints">
+                        </div>
+                        <div class="sm:col-span-2">
+                            <label class="block text-xs font-medium text-gray-500 uppercase tracking-wider mb-1">Description</label>
+                            <input type="text" name="categories[__IDX__].description" id="categories__IDX__.description"
+                                   class="block w-full rounded border-gray-300 text-sm focus:border-indigo-500 focus:ring-indigo-500 px-2 py-1.5">
+                        </div>
+                    </div>
+                    <div class="mt-4">
+                        <div class="flex items-center justify-between mb-2">
+                            <h4 class="text-xs font-semibold text-gray-500 uppercase tracking-wider">Tiers</h4>
+                            <button type="button" class="text-xs text-indigo-600 hover:text-indigo-800 add-tier-btn">+ Add tier</button>
+                        </div>
+                        <div class="tiers-container space-y-2"></div>
+                    </div>
+                </div>
+            </template>
+
+            <template id="tierTemplate">
+                <div class="grid grid-cols-1 sm:grid-cols-12 gap-2 tier-row" data-tier-index="__TIDX__">
+                    <div class="sm:col-span-3">
+                        <label class="block text-xs font-medium text-gray-500 mb-1">Label</label>
+                        <input type="text" name="categories[__IDX__].tiers[__TIDX__].label" id="categories__IDX__.tiers__TIDX__.label"
+                               class="block w-full rounded border-gray-300 text-sm focus:border-indigo-500 focus:ring-indigo-500 px-2 py-1.5">
+                    </div>
+                    <div class="sm:col-span-2">
+                        <label class="block text-xs font-medium text-gray-500 mb-1">Points</label>
+                        <input type="number" name="categories[__IDX__].tiers[__TIDX__].points" id="categories__IDX__.tiers__TIDX__.points"
+                               class="block w-full rounded border-gray-300 text-sm focus:border-indigo-500 focus:ring-indigo-500 px-2 py-1.5">
+                    </div>
+                    <div class="sm:col-span-6">
+                        <label class="block text-xs font-medium text-gray-500 mb-1">Criteria</label>
+                        <input type="text" name="categories[__IDX__].tiers[__TIDX__].criteria" id="categories__IDX__.tiers__TIDX__.criteria"
+                               class="block w-full rounded border-gray-300 text-sm focus:border-indigo-500 focus:ring-indigo-500 px-2 py-1.5">
+                    </div>
+                    <div class="sm:col-span-1 flex items-end">
+                        <button type="button" class="text-xs text-red-600 hover:text-red-800 remove-tier-btn">Remove</button>
+                    </div>
+                </div>
+            </template>
+
+            <script>
+            (function() {
+                'use strict';
+                const container = document.getElementById('categoriesContainer');
+                const totalEl = document.getElementById('totalPoints');
+
+                function recomputeTotal() {
+                    let total = 0;
+                    document.querySelectorAll('.cat-maxpoints').forEach(el => {
+                        const v = parseInt(el.value, 10);
+                        if (!Number.isNaN(v)) total += v;
+                    });
+                    totalEl.textContent = String(total);
+                }
+
+                function reindexHtml(html, catIdx, tierIdx) {
+                    return html
+                        .replace(/__IDX_PLUS_1__/g, String(catIdx + 1))
+                        .replace(/__IDX__/g, String(catIdx))
+                        .replace(/__TIDX__/g, String(tierIdx == null ? 0 : tierIdx));
+                }
+
+                function nextCategoryIndex() {
+                    return container.querySelectorAll('.category-row').length;
+                }
+                function nextTierIndex(catRow) {
+                    return catRow.querySelectorAll('.tier-row').length;
+                }
+
+                document.getElementById('addCategoryBtn').addEventListener('click', function() {
+                    const tpl = document.getElementById('categoryTemplate');
+                    const idx = nextCategoryIndex();
+                    const html = reindexHtml(tpl.innerHTML, idx, 0);
+                    const wrapper = document.createElement('div');
+                    wrapper.innerHTML = html.trim();
+                    const newRow = wrapper.firstChild;
+                    container.appendChild(newRow);
+                    // start with one tier row
+                    addTier(newRow);
+                    recomputeTotal();
+                });
+
+                function addTier(catRow) {
+                    const catIdx = parseInt(catRow.dataset.catIndex, 10);
+                    const tiersContainer = catRow.querySelector('.tiers-container');
+                    const tierIdx = nextTierIndex(catRow);
+                    const tpl = document.getElementById('tierTemplate');
+                    const html = reindexHtml(tpl.innerHTML, catIdx, tierIdx);
+                    const wrapper = document.createElement('div');
+                    wrapper.innerHTML = html.trim();
+                    tiersContainer.appendChild(wrapper.firstChild);
+                }
+
+                container.addEventListener('click', function(e) {
+                    const t = e.target;
+                    if (t.classList.contains('add-tier-btn')) {
+                        const catRow = t.closest('.category-row');
+                        if (catRow) addTier(catRow);
+                    } else if (t.classList.contains('remove-tier-btn')) {
+                        const tierRow = t.closest('.tier-row');
+                        if (tierRow) tierRow.remove();
+                    } else if (t.classList.contains('remove-category-btn')) {
+                        const catRow = t.closest('.category-row');
+                        if (catRow) catRow.remove();
+                        recomputeTotal();
+                    }
+                });
+
+                container.addEventListener('input', function(e) {
+                    if (e.target.classList.contains('cat-maxpoints')) {
+                        recomputeTotal();
+                    }
+                });
+
+                recomputeTotal();
+            })();
+            </script>
+
+        </main>
+    </div>
+</body>
+</html>

--- a/src/main/resources/templates/rubrics-list.html
+++ b/src/main/resources/templates/rubrics-list.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org"
+      xmlns:sec="http://www.thymeleaf.org/extras/spring-security"
+      lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Rubrics - Majordomo</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-gray-100 min-h-screen">
+
+    <div th:replace="~{fragments/header :: header}"></div>
+
+    <div class="flex min-h-screen">
+        <div th:replace="~{fragments/sidebar :: sidebar('envoy')}"></div>
+
+        <main class="flex-1 p-6">
+
+            <nav class="mb-4" aria-label="Breadcrumb">
+                <ol class="flex items-center space-x-2 text-sm text-gray-500">
+                    <li><a th:href="@{/envoy}" class="hover:text-indigo-600 transition">Envoy</a></li>
+                    <li class="flex items-center space-x-2">
+                        <span>&rsaquo;</span>
+                        <span class="text-gray-900 font-medium">Rubrics</span>
+                    </li>
+                </ol>
+            </nav>
+
+            <div class="flex items-baseline justify-between mb-6">
+                <h1 class="text-2xl font-bold text-gray-900">Rubrics</h1>
+                <a th:href="@{/envoy/rubrics/new/edit}"
+                   class="inline-flex items-center rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-indigo-700">
+                    New rubric
+                </a>
+            </div>
+
+            <div th:if="${flashMessage}"
+                 class="bg-emerald-50 border border-emerald-200 text-emerald-800 rounded-md px-4 py-3 mb-4 text-sm"
+                 th:text="${flashMessage}">flash</div>
+
+            <div th:if="${#lists.isEmpty(rubrics)}"
+                 class="bg-white rounded-lg shadow p-8 text-center">
+                <p class="text-gray-500 mb-2">No rubrics yet for this organization.</p>
+            </div>
+
+            <div th:unless="${#lists.isEmpty(rubrics)}"
+                 class="bg-white rounded-lg shadow overflow-hidden">
+                <table class="min-w-full divide-y divide-gray-200">
+                    <thead class="bg-gray-50">
+                        <tr>
+                            <th class="px-6 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider">Name</th>
+                            <th class="px-6 py-3 text-right text-xs font-semibold text-gray-500 uppercase tracking-wider">Version</th>
+                            <th class="px-6 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider">Scope</th>
+                            <th class="px-6 py-3 text-right text-xs font-semibold text-gray-500 uppercase tracking-wider">Categories</th>
+                            <th class="px-6 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider">Effective from</th>
+                            <th class="px-6 py-3"></th>
+                        </tr>
+                    </thead>
+                    <tbody class="bg-white divide-y divide-gray-100">
+                        <tr th:each="r : ${rubrics}" class="hover:bg-gray-50">
+                            <td class="px-6 py-3 whitespace-nowrap text-sm font-medium text-gray-900"
+                                th:text="${r.name()}">name</td>
+                            <td class="px-6 py-3 whitespace-nowrap text-right text-sm text-gray-700"
+                                th:text="${'v' + r.version()}">v0</td>
+                            <td class="px-6 py-3 whitespace-nowrap text-sm">
+                                <span th:if="${r.organizationId().isPresent()}"
+                                      class="inline-block rounded-full px-2 py-0.5 text-xs font-medium bg-indigo-100 text-indigo-800">org</span>
+                                <span th:unless="${r.organizationId().isPresent()}"
+                                      class="inline-block rounded-full px-2 py-0.5 text-xs font-medium bg-gray-200 text-gray-700">system default</span>
+                            </td>
+                            <td class="px-6 py-3 whitespace-nowrap text-right text-sm text-gray-700"
+                                th:text="${#lists.size(r.categories())}">0</td>
+                            <td class="px-6 py-3 whitespace-nowrap text-sm text-gray-500"
+                                th:text="${#temporals.format(r.effectiveFrom(), 'yyyy-MM-dd')}">2026-01-01</td>
+                            <td class="px-6 py-3 text-right">
+                                <a class="text-indigo-600 hover:text-indigo-800 text-sm font-medium"
+                                   th:href="@{/envoy/rubrics/{name}/edit(name=${r.name()})}">Edit</a>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+
+        </main>
+    </div>
+</body>
+</html>

--- a/src/test/java/com/majordomo/adapter/in/web/envoy/RubricAuthorControllerTest.java
+++ b/src/test/java/com/majordomo/adapter/in/web/envoy/RubricAuthorControllerTest.java
@@ -1,0 +1,281 @@
+package com.majordomo.adapter.in.web.envoy;
+
+import com.majordomo.adapter.in.web.config.OAuth2UserService;
+import com.majordomo.adapter.in.web.config.SecurityConfig;
+import com.majordomo.domain.model.UuidFactory;
+import com.majordomo.domain.model.envoy.Category;
+import com.majordomo.domain.model.envoy.Rubric;
+import com.majordomo.domain.model.envoy.Thresholds;
+import com.majordomo.domain.model.envoy.Tier;
+import com.majordomo.domain.model.identity.Membership;
+import com.majordomo.domain.model.identity.User;
+import com.majordomo.domain.port.in.envoy.ManageRubricUseCase;
+import com.majordomo.domain.port.out.envoy.RubricRepository;
+import com.majordomo.domain.port.out.identity.ApiKeyRepository;
+import com.majordomo.domain.port.out.identity.MembershipRepository;
+import com.majordomo.domain.port.out.identity.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.flash;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.model;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
+
+@WebMvcTest(RubricAuthorController.class)
+@Import(SecurityConfig.class)
+class RubricAuthorControllerTest {
+
+    @Autowired MockMvc mvc;
+
+    @MockitoBean ManageRubricUseCase rubrics;
+    @MockitoBean RubricRepository rubricRepository;
+    @MockitoBean UserRepository userRepository;
+    @MockitoBean MembershipRepository membershipRepository;
+    @MockitoBean ApiKeyRepository apiKeyRepository;
+    @MockitoBean OAuth2UserService oAuth2UserService;
+
+    private static final UUID ORG_ID = UuidFactory.newId();
+
+    private void stubMembership(String username) {
+        var user = new User(UuidFactory.newId(), username, username + "@example.com");
+        var membership = new Membership();
+        membership.setUserId(user.getId());
+        membership.setOrganizationId(ORG_ID);
+        when(userRepository.findByUsername(username)).thenReturn(Optional.of(user));
+        when(membershipRepository.findByUserId(user.getId())).thenReturn(List.of(membership));
+    }
+
+    private static Rubric sampleRubric(String name, int version) {
+        return new Rubric(
+                UuidFactory.newId(),
+                Optional.of(ORG_ID),
+                version,
+                name,
+                List.of(),
+                List.of(new Category("compensation", "Pay", 25,
+                        List.of(new Tier("Excellent", 25, "great")))),
+                List.of(),
+                new Thresholds(75, 55, 35),
+                Instant.now());
+    }
+
+    // 1. GET list page shows org's rubrics.
+    @Test
+    @WithMockUser(username = "robsartin")
+    void listPage_showsOrgsRubrics() throws Exception {
+        stubMembership("robsartin");
+        var defaultRubric = sampleRubric("default", 3);
+        var customRubric = sampleRubric("aggressive", 1);
+        when(rubricRepository.findActiveRubricsForOrg(ORG_ID))
+                .thenReturn(List.of(defaultRubric, customRubric));
+
+        MvcResult result = mvc.perform(get("/envoy/rubrics"))
+                .andExpect(status().isOk())
+                .andExpect(view().name("rubrics-list"))
+                .andExpect(model().attribute("organizationId", ORG_ID))
+                .andReturn();
+
+        @SuppressWarnings("unchecked")
+        List<Rubric> shown = (List<Rubric>) result.getModelAndView().getModel().get("rubrics");
+        assertThat(shown).hasSize(2);
+        String body = result.getResponse().getContentAsString();
+        assertThat(body).contains("default");
+        assertThat(body).contains("aggressive");
+    }
+
+    // 2. GET edit page for existing rubric pre-populates fields.
+    @Test
+    @WithMockUser(username = "robsartin")
+    void editPage_existingRubricPrepopulatesFields() throws Exception {
+        stubMembership("robsartin");
+        var existing = sampleRubric("default", 3);
+        when(rubricRepository.findActiveByName("default", ORG_ID))
+                .thenReturn(Optional.of(existing));
+
+        MvcResult result = mvc.perform(get("/envoy/rubrics/{name}/edit", "default"))
+                .andExpect(status().isOk())
+                .andExpect(view().name("rubric-edit"))
+                .andExpect(model().attributeExists("form"))
+                .andExpect(model().attribute("rubricName", "default"))
+                .andExpect(model().attribute("isNew", false))
+                .andReturn();
+
+        String body = result.getResponse().getContentAsString();
+        assertThat(body).contains("compensation");
+        assertThat(body).contains("Excellent");
+    }
+
+    // 3. GET edit page for new name shows blank form.
+    @Test
+    @WithMockUser(username = "robsartin")
+    void editPage_newNameShowsBlankForm() throws Exception {
+        stubMembership("robsartin");
+        when(rubricRepository.findActiveByName("brand-new", ORG_ID))
+                .thenReturn(Optional.empty());
+
+        mvc.perform(get("/envoy/rubrics/{name}/edit", "brand-new"))
+                .andExpect(status().isOk())
+                .andExpect(view().name("rubric-edit"))
+                .andExpect(model().attribute("rubricName", "brand-new"))
+                .andExpect(model().attribute("isNew", true))
+                .andExpect(model().attributeExists("form"));
+    }
+
+    // 4. POST valid form calls saveNewVersion with a correctly assembled Rubric.
+    @Test
+    @WithMockUser(username = "robsartin")
+    void postValid_callsSaveNewVersionWithAssembledRubric() throws Exception {
+        stubMembership("robsartin");
+        var saved = sampleRubric("default", 4);
+        when(rubrics.saveNewVersion(eq("default"), any(), eq(ORG_ID))).thenReturn(saved);
+
+        mvc.perform(post("/envoy/rubrics/{name}", "default")
+                        .with(csrf())
+                        .param("categories[0].key", "compensation")
+                        .param("categories[0].description", "Pay and equity")
+                        .param("categories[0].maxPoints", "25")
+                        .param("categories[0].tiers[0].label", "Excellent")
+                        .param("categories[0].tiers[0].points", "25")
+                        .param("categories[0].tiers[0].criteria", "Top of market")
+                        .param("categories[0].tiers[1].label", "Good")
+                        .param("categories[0].tiers[1].points", "15")
+                        .param("categories[0].tiers[1].criteria", "Market")
+                        .param("thresholds.applyImmediately", "75")
+                        .param("thresholds.apply", "55")
+                        .param("thresholds.considerOnly", "35"))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/envoy/rubrics"))
+                .andExpect(flash().attributeExists("flashMessage"));
+
+        ArgumentCaptor<Rubric> captor = ArgumentCaptor.forClass(Rubric.class);
+        verify(rubrics).saveNewVersion(eq("default"), captor.capture(), eq(ORG_ID));
+        Rubric submitted = captor.getValue();
+        assertThat(submitted.name()).isEqualTo("default");
+        assertThat(submitted.categories()).hasSize(1);
+        assertThat(submitted.categories().get(0).key()).isEqualTo("compensation");
+        assertThat(submitted.categories().get(0).maxPoints()).isEqualTo(25);
+        assertThat(submitted.categories().get(0).tiers()).hasSize(2);
+        assertThat(submitted.categories().get(0).tiers().get(0).label()).isEqualTo("Excellent");
+        assertThat(submitted.categories().get(0).tiers().get(0).points()).isEqualTo(25);
+        assertThat(submitted.thresholds().applyImmediately()).isEqualTo(75);
+        assertThat(submitted.thresholds().apply()).isEqualTo(55);
+        assertThat(submitted.thresholds().considerOnly()).isEqualTo(35);
+    }
+
+    // 5. POST with apply <= consider re-renders form with validation error, no save.
+    @Test
+    @WithMockUser(username = "robsartin")
+    void postInvalidThresholds_rerendersFormWithError() throws Exception {
+        stubMembership("robsartin");
+
+        mvc.perform(post("/envoy/rubrics/{name}", "default")
+                        .with(csrf())
+                        .param("categories[0].key", "compensation")
+                        .param("categories[0].description", "Pay")
+                        .param("categories[0].maxPoints", "25")
+                        .param("categories[0].tiers[0].label", "Tier")
+                        .param("categories[0].tiers[0].points", "10")
+                        .param("categories[0].tiers[0].criteria", "x")
+                        .param("thresholds.applyImmediately", "50")
+                        .param("thresholds.apply", "60")
+                        .param("thresholds.considerOnly", "30"))
+                .andExpect(status().isOk())
+                .andExpect(view().name("rubric-edit"))
+                .andExpect(model().attributeHasErrors("form"));
+
+        verify(rubrics, never()).saveNewVersion(any(), any(), any());
+    }
+
+    // 6. POST with zero categories re-renders with error.
+    @Test
+    @WithMockUser(username = "robsartin")
+    void postZeroCategories_rerendersWithError() throws Exception {
+        stubMembership("robsartin");
+
+        mvc.perform(post("/envoy/rubrics/{name}", "default")
+                        .with(csrf())
+                        .param("thresholds.applyImmediately", "75")
+                        .param("thresholds.apply", "55")
+                        .param("thresholds.considerOnly", "35"))
+                .andExpect(status().isOk())
+                .andExpect(view().name("rubric-edit"))
+                .andExpect(model().attributeHasErrors("form"));
+
+        verify(rubrics, never()).saveNewVersion(any(), any(), any());
+    }
+
+    // 7. POST with a category that has zero tiers re-renders with error.
+    @Test
+    @WithMockUser(username = "robsartin")
+    void postCategoryWithoutTiers_rerendersWithError() throws Exception {
+        stubMembership("robsartin");
+
+        mvc.perform(post("/envoy/rubrics/{name}", "default")
+                        .with(csrf())
+                        .param("categories[0].key", "compensation")
+                        .param("categories[0].description", "Pay")
+                        .param("categories[0].maxPoints", "25")
+                        .param("thresholds.applyImmediately", "75")
+                        .param("thresholds.apply", "55")
+                        .param("thresholds.considerOnly", "35"))
+                .andExpect(status().isOk())
+                .andExpect(view().name("rubric-edit"))
+                .andExpect(model().attributeHasErrors("form"));
+
+        verify(rubrics, never()).saveNewVersion(any(), any(), any());
+    }
+
+    // 8. CSRF rejection: POST without token -> 403, no save.
+    @Test
+    @WithMockUser(username = "robsartin")
+    void postWithoutCsrf_returns403AndDoesNotSave() throws Exception {
+        stubMembership("robsartin");
+
+        mvc.perform(post("/envoy/rubrics/{name}", "default")
+                        .param("categories[0].key", "compensation")
+                        .param("categories[0].description", "Pay")
+                        .param("categories[0].maxPoints", "25")
+                        .param("categories[0].tiers[0].label", "Tier")
+                        .param("categories[0].tiers[0].points", "10")
+                        .param("categories[0].tiers[0].criteria", "x")
+                        .param("thresholds.applyImmediately", "75")
+                        .param("thresholds.apply", "55")
+                        .param("thresholds.considerOnly", "35"))
+                .andExpect(status().isForbidden());
+
+        verify(rubrics, never()).saveNewVersion(any(), any(), any());
+    }
+
+    // 9. Unauthenticated -> redirect to /login.
+    @Test
+    void unauthenticated_redirectsToLogin() throws Exception {
+        mvc.perform(get("/envoy/rubrics"))
+                .andExpect(status().is3xxRedirection());
+
+        mvc.perform(get("/envoy/rubrics/default/edit"))
+                .andExpect(status().is3xxRedirection());
+    }
+}


### PR DESCRIPTION
## Summary

- New Thymeleaf-rendered author UI for envoy rubrics: `/envoy/rubrics` (list) + `/envoy/rubrics/{name}/edit` (form). POST `/envoy/rubrics/{name}` reuses `ManageRubricUseCase.saveNewVersion`.
- Server-side validation only (≥1 category, ≥1 tier per category, thresholds ordering). Inline JS handles add/remove rows; live total of `maxPoints` shown alongside thresholds. Errors re-render the form with submitted values preserved.
- Existing JSON API (`PUT /api/envoy/rubrics/{name}`) is untouched; both surfaces coexist.
- Adds `RubricRepository.findActiveRubricsForOrg(orgId)` for the list page (org-specific actives + system defaults the org has not authored).

Closes #160

## Test plan

- [x] `./mvnw verify` passes (294 tests, 0 failures, checkstyle clean)
- [x] 9 controller tests added per the issue's TDD list:
  1. GET list shows org's rubrics
  2. GET edit pre-populates from existing
  3. GET edit for new name shows blank form
  4. POST valid form calls `saveNewVersion` with correctly assembled `Rubric` (verified via `ArgumentCaptor`)
  5. POST `apply <= consider` re-renders with field error, no save
  6. POST zero categories re-renders with error
  7. POST category without tiers re-renders with error
  8. POST without CSRF returns 403, no save
  9. Unauthenticated GETs redirect to login
- [ ] Manual smoke: log in, navigate to `/envoy/rubrics`, edit `default`, save, observe new version in list with flash message
- [ ] Manual smoke: add a new rubric under a fresh name, verify it persists at v1

🤖 Generated with [Claude Code](https://claude.com/claude-code)