### PR TITLE
envoy: inline ingest form on /envoy

### DIFF
--- a/src/main/java/com/majordomo/adapter/in/web/envoy/EnvoyPageController.java
+++ b/src/main/java/com/majordomo/adapter/in/web/envoy/EnvoyPageController.java
@@ -1,23 +1,32 @@
 package com.majordomo.adapter.in.web.envoy;
 
+import com.majordomo.application.envoy.LlmScoringException;
 import com.majordomo.domain.model.envoy.JobPosting;
+import com.majordomo.domain.model.envoy.JobSourceRequest;
 import com.majordomo.domain.model.envoy.Recommendation;
 import com.majordomo.domain.model.envoy.ScoreReport;
 import com.majordomo.domain.model.identity.User;
+import com.majordomo.domain.port.in.envoy.IngestJobPostingUseCase;
 import com.majordomo.domain.port.in.envoy.QueryScoreReportsUseCase;
+import com.majordomo.domain.port.in.envoy.ScoreJobPostingUseCase;
 import com.majordomo.domain.port.out.envoy.JobPostingRepository;
 import com.majordomo.domain.port.out.identity.MembershipRepository;
 import com.majordomo.domain.port.out.identity.UserRepository;
 import jakarta.servlet.http.HttpServletResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -30,9 +39,16 @@ import java.util.UUID;
 @Controller
 public class EnvoyPageController {
 
+    private static final Logger LOG = LoggerFactory.getLogger(EnvoyPageController.class);
+
     private static final int DEFAULT_LIMIT = 50;
 
+    /** Rubric used by the inline ingest form. v1 hardcodes "default"; rubric picker is out of scope. */
+    private static final String DEFAULT_RUBRIC = "default";
+
     private final QueryScoreReportsUseCase reports;
+    private final IngestJobPostingUseCase ingestUseCase;
+    private final ScoreJobPostingUseCase scoreUseCase;
     private final JobPostingRepository jobPostingRepository;
     private final UserRepository userRepository;
     private final MembershipRepository membershipRepository;
@@ -61,15 +77,21 @@ public class EnvoyPageController {
      * Constructs the controller.
      *
      * @param reports              inbound port for report queries
+     * @param ingestUseCase        inbound port for ingesting a posting from any source
+     * @param scoreUseCase         inbound port for scoring an ingested posting
      * @param jobPostingRepository outbound port for posting lookups
      * @param userRepository       outbound port for user lookups
      * @param membershipRepository outbound port for membership lookups
      */
     public EnvoyPageController(QueryScoreReportsUseCase reports,
+                               IngestJobPostingUseCase ingestUseCase,
+                               ScoreJobPostingUseCase scoreUseCase,
                                JobPostingRepository jobPostingRepository,
                                UserRepository userRepository,
                                MembershipRepository membershipRepository) {
         this.reports = reports;
+        this.ingestUseCase = ingestUseCase;
+        this.scoreUseCase = scoreUseCase;
         this.jobPostingRepository = jobPostingRepository;
         this.userRepository = userRepository;
         this.membershipRepository = membershipRepository;
@@ -106,6 +128,84 @@ public class EnvoyPageController {
         if (ctx.organizationId() == null) {
             return "redirect:/";
         }
+        renderEnvoyPage(ctx, minFinalScore, recommendation, model);
+        return "envoy";
+    }
+
+    /**
+     * Handles the inline "Score a posting" form on {@code /envoy}. Ingests the
+     * pasted payload via the appropriate {@code JobSource}, scores the resulting
+     * posting against the {@code default} rubric, then redirects to {@code GET
+     * /envoy} so the new row renders at the top of the list.
+     *
+     * <p>If ingest fails ({@link IllegalArgumentException} — typically "no
+     * JobSource supports type: …") or scoring fails ({@link
+     * LlmScoringException}), the page is re-rendered in place with an
+     * {@code ingestError} model attribute so the message survives without a
+     * separate flash redirect. This keeps the failure path stateless and
+     * trivially testable.</p>
+     *
+     * <p>Optional hint fields ({@code company}, {@code title}, {@code location})
+     * are forwarded to the use case as a {@code Map} with blank values
+     * filtered out, so the LLM extractor only sees hints the caller actually
+     * provided.</p>
+     *
+     * @param type      source discriminator (defaults to {@code "manual"})
+     * @param payload   raw posting text / URL / source-specific id
+     * @param company   optional company hint
+     * @param title     optional title hint
+     * @param location  optional location hint
+     * @param principal the authenticated user
+     * @param model     the Thymeleaf model
+     * @return {@code redirect:/envoy} on success; {@code envoy} (with an
+     *         {@code ingestError} attribute) on a handled failure;
+     *         {@code redirect:/} if the user has no organization
+     */
+    @PostMapping("/envoy")
+    public String submitIngest(@RequestParam(defaultValue = "manual") String type,
+                               @RequestParam(required = false) String payload,
+                               @RequestParam(required = false) String company,
+                               @RequestParam(required = false) String title,
+                               @RequestParam(required = false) String location,
+                               @AuthenticationPrincipal UserDetails principal,
+                               Model model) {
+        AuthContext ctx = resolveContext(principal);
+        if (ctx.organizationId() == null) {
+            return "redirect:/";
+        }
+        UUID orgId = ctx.organizationId();
+
+        if (payload == null || payload.isBlank()) {
+            renderEnvoyPage(ctx, null, null, model);
+            model.addAttribute("ingestError", "Payload is required.");
+            return "envoy";
+        }
+
+        Map<String, String> hints = buildHints(company, title, location);
+        JobSourceRequest request = new JobSourceRequest(type, payload, hints);
+
+        try {
+            JobPosting saved = ingestUseCase.ingest(request, orgId);
+            scoreUseCase.score(saved.getId(), DEFAULT_RUBRIC, orgId);
+            return "redirect:/envoy";
+        } catch (IllegalArgumentException | LlmScoringException ex) {
+            LOG.warn("Inline ingest+score failed for org {} (type={}): {}",
+                    orgId, type, ex.getMessage());
+            renderEnvoyPage(ctx, null, null, model);
+            model.addAttribute("ingestError", ex.getMessage());
+            return "envoy";
+        }
+    }
+
+    /**
+     * Populates the model with the data needed to render the envoy list page
+     * (rows, filter echo values, org id, username). Shared between the GET
+     * handler and the POST handler's error path.
+     */
+    private void renderEnvoyPage(AuthContext ctx,
+                                 Integer minFinalScore,
+                                 Recommendation recommendation,
+                                 Model model) {
         UUID orgId = ctx.organizationId();
         List<ScoreReport> recent = reports
                 .query(orgId, minFinalScore, recommendation, null, DEFAULT_LIMIT)
@@ -122,7 +222,26 @@ public class EnvoyPageController {
         model.addAttribute("recommendation", recommendation);
         model.addAttribute("organizationId", orgId);
         model.addAttribute("username", ctx.user().getUsername());
-        return "envoy";
+    }
+
+    /**
+     * Builds the hint map for the ingest request, dropping blank entries so the
+     * downstream LLM extractor doesn't see noise.
+     */
+    private static Map<String, String> buildHints(String company,
+                                                  String title,
+                                                  String location) {
+        Map<String, String> hints = new LinkedHashMap<>();
+        putIfNotBlank(hints, "company", company);
+        putIfNotBlank(hints, "title", title);
+        putIfNotBlank(hints, "location", location);
+        return hints;
+    }
+
+    private static void putIfNotBlank(Map<String, String> hints, String key, String value) {
+        if (value != null && !value.isBlank()) {
+            hints.put(key, value.trim());
+        }
     }
 
     /**

--- a/src/main/resources/templates/envoy.html
+++ b/src/main/resources/templates/envoy.html
@@ -22,6 +22,80 @@
                 <span class="text-sm text-gray-500">Job posting scores</span>
             </div>
 
+            <!-- Ingest error banner -->
+            <div th:if="${ingestError}"
+                 class="mb-4 rounded-lg bg-red-50 border border-red-200 px-4 py-3 text-sm text-red-700"
+                 th:text="${ingestError}">
+                Error message goes here.
+            </div>
+
+            <!-- Score a posting (inline ingest form) -->
+            <details class="bg-white rounded-lg shadow mb-6"
+                     th:attr="open=${ingestError != null ? 'open' : null}">
+                <summary class="cursor-pointer px-4 py-3 flex items-center justify-between hover:bg-gray-50 rounded-lg">
+                    <span class="font-semibold text-gray-900">Score a posting</span>
+                    <span class="text-xs text-gray-500">paste posting text + optional hints, scored against the
+                        <code class="bg-gray-100 px-1 rounded">default</code> rubric</span>
+                </summary>
+                <form method="post" th:action="@{/envoy}" class="px-4 pb-4 pt-2 space-y-4"
+                      onsubmit="(function(b){if(b){b.disabled=true;b.textContent='Scoring…';}})(this.querySelector('button[type=submit]'));">
+                    <div class="grid grid-cols-1 md:grid-cols-4 gap-4">
+                        <div class="flex flex-col">
+                            <label for="ingest-type"
+                                   class="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-1">
+                                Source
+                            </label>
+                            <select id="ingest-type" name="type"
+                                    class="block rounded border-gray-300 text-sm focus:border-indigo-500 focus:ring-indigo-500 px-2 py-1.5">
+                                <option value="manual" selected>manual</option>
+                                <option value="url">url</option>
+                                <option value="greenhouse">greenhouse</option>
+                            </select>
+                        </div>
+                        <div class="flex flex-col">
+                            <label for="ingest-company"
+                                   class="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-1">
+                                Company (optional)
+                            </label>
+                            <input id="ingest-company" name="company" type="text"
+                                   class="block rounded border-gray-300 text-sm focus:border-indigo-500 focus:ring-indigo-500 px-2 py-1.5">
+                        </div>
+                        <div class="flex flex-col">
+                            <label for="ingest-title"
+                                   class="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-1">
+                                Title (optional)
+                            </label>
+                            <input id="ingest-title" name="title" type="text"
+                                   class="block rounded border-gray-300 text-sm focus:border-indigo-500 focus:ring-indigo-500 px-2 py-1.5">
+                        </div>
+                        <div class="flex flex-col">
+                            <label for="ingest-location"
+                                   class="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-1">
+                                Location (optional)
+                            </label>
+                            <input id="ingest-location" name="location" type="text"
+                                   class="block rounded border-gray-300 text-sm focus:border-indigo-500 focus:ring-indigo-500 px-2 py-1.5">
+                        </div>
+                    </div>
+                    <div class="flex flex-col">
+                        <label for="ingest-payload"
+                               class="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-1">
+                            Payload (posting text, URL, or source-specific id)
+                        </label>
+                        <textarea id="ingest-payload" name="payload" rows="8" required
+                                  placeholder="Paste the full posting text here…"
+                                  class="block rounded border-gray-300 text-sm font-mono focus:border-indigo-500 focus:ring-indigo-500 px-2 py-1.5"></textarea>
+                    </div>
+                    <div class="flex items-center gap-3">
+                        <button type="submit"
+                                class="inline-flex items-center rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-indigo-700 disabled:opacity-60 disabled:cursor-progress">
+                            Score now
+                        </button>
+                        <span class="text-xs text-gray-500">scoring takes 2-5s while we wait on the LLM</span>
+                    </div>
+                </form>
+            </details>
+
             <!-- Filter strip -->
             <div class="bg-white rounded-lg shadow p-4 mb-6">
                 <form method="get" th:action="@{/envoy}" class="flex flex-wrap items-end gap-4">

--- a/src/test/java/com/majordomo/adapter/in/web/envoy/EnvoyPageControllerTest.java
+++ b/src/test/java/com/majordomo/adapter/in/web/envoy/EnvoyPageControllerTest.java
@@ -12,7 +12,9 @@ import com.majordomo.domain.model.envoy.Recommendation;
 import com.majordomo.domain.model.envoy.ScoreReport;
 import com.majordomo.domain.model.identity.Membership;
 import com.majordomo.domain.model.identity.User;
+import com.majordomo.domain.port.in.envoy.IngestJobPostingUseCase;
 import com.majordomo.domain.port.in.envoy.QueryScoreReportsUseCase;
+import com.majordomo.domain.port.in.envoy.ScoreJobPostingUseCase;
 import com.majordomo.domain.port.out.envoy.JobPostingRepository;
 import com.majordomo.domain.port.out.identity.ApiKeyRepository;
 import com.majordomo.domain.port.out.identity.MembershipRepository;
@@ -52,6 +54,8 @@ class EnvoyPageControllerTest {
     @Autowired MockMvc mvc;
 
     @MockitoBean QueryScoreReportsUseCase reports;
+    @MockitoBean IngestJobPostingUseCase ingestUseCase;
+    @MockitoBean ScoreJobPostingUseCase scoreUseCase;
     @MockitoBean UserRepository userRepository;
     @MockitoBean MembershipRepository membershipRepository;
     @MockitoBean JobPostingRepository jobPostingRepository;

--- a/src/test/java/com/majordomo/adapter/in/web/envoy/EnvoyPageIngestFormTest.java
+++ b/src/test/java/com/majordomo/adapter/in/web/envoy/EnvoyPageIngestFormTest.java
@@ -1,0 +1,269 @@
+package com.majordomo.adapter.in.web.envoy;
+
+import com.majordomo.adapter.in.web.config.OAuth2UserService;
+import com.majordomo.adapter.in.web.config.SecurityConfig;
+import com.majordomo.application.envoy.LlmScoringException;
+import com.majordomo.domain.model.Page;
+import com.majordomo.domain.model.UuidFactory;
+import com.majordomo.domain.model.envoy.JobPosting;
+import com.majordomo.domain.model.envoy.JobSourceRequest;
+import com.majordomo.domain.model.envoy.Recommendation;
+import com.majordomo.domain.model.envoy.ScoreReport;
+import com.majordomo.domain.model.identity.Membership;
+import com.majordomo.domain.model.identity.User;
+import com.majordomo.domain.port.in.envoy.IngestJobPostingUseCase;
+import com.majordomo.domain.port.in.envoy.QueryScoreReportsUseCase;
+import com.majordomo.domain.port.in.envoy.ScoreJobPostingUseCase;
+import com.majordomo.domain.port.out.envoy.JobPostingRepository;
+import com.majordomo.domain.port.out.identity.ApiKeyRepository;
+import com.majordomo.domain.port.out.identity.MembershipRepository;
+import com.majordomo.domain.port.out.identity.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.model;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
+
+@WebMvcTest(EnvoyPageController.class)
+@Import(SecurityConfig.class)
+class EnvoyPageIngestFormTest {
+
+    @Autowired MockMvc mvc;
+
+    @MockitoBean QueryScoreReportsUseCase reports;
+    @MockitoBean IngestJobPostingUseCase ingestUseCase;
+    @MockitoBean ScoreJobPostingUseCase scoreUseCase;
+    @MockitoBean UserRepository userRepository;
+    @MockitoBean MembershipRepository membershipRepository;
+    @MockitoBean JobPostingRepository jobPostingRepository;
+    @MockitoBean ApiKeyRepository apiKeyRepository;
+    @MockitoBean OAuth2UserService oAuth2UserService;
+
+    private static final UUID ORG_ID = UuidFactory.newId();
+
+    @Test
+    @WithMockUser(username = "robsartin")
+    void postEnvoy_ingestsAndScoresAndRedirects() throws Exception {
+        var user = new User(UuidFactory.newId(), "robsartin", "rob@example.com");
+        var membership = new Membership();
+        membership.setUserId(user.getId());
+        membership.setOrganizationId(ORG_ID);
+
+        UUID postingId = UuidFactory.newId();
+        var saved = new JobPosting();
+        saved.setId(postingId);
+        saved.setOrganizationId(ORG_ID);
+
+        var report = new ScoreReport(UuidFactory.newId(), ORG_ID, postingId,
+                UuidFactory.newId(), 1, Optional.empty(),
+                List.of(), List.of(), 90, 90, Recommendation.APPLY_NOW,
+                "claude-sonnet-4-6", Instant.now());
+
+        when(userRepository.findByUsername("robsartin")).thenReturn(Optional.of(user));
+        when(membershipRepository.findByUserId(user.getId())).thenReturn(List.of(membership));
+        when(ingestUseCase.ingest(any(JobSourceRequest.class), eq(ORG_ID))).thenReturn(saved);
+        when(scoreUseCase.score(eq(postingId), eq("default"), eq(ORG_ID))).thenReturn(report);
+
+        mvc.perform(post("/envoy")
+                        .with(csrf())
+                        .param("type", "manual")
+                        .param("payload", "Senior Backend Engineer at Acme")
+                        .param("company", "Acme")
+                        .param("title", "Senior Backend Engineer")
+                        .param("location", "Remote (US)"))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/envoy"));
+
+        ArgumentCaptor<JobSourceRequest> captor = ArgumentCaptor.forClass(JobSourceRequest.class);
+        verify(ingestUseCase).ingest(captor.capture(), eq(ORG_ID));
+        JobSourceRequest req = captor.getValue();
+        assertThat(req.type()).isEqualTo("manual");
+        assertThat(req.payload()).isEqualTo("Senior Backend Engineer at Acme");
+        assertThat(req.hints()).containsEntry("company", "Acme");
+        assertThat(req.hints()).containsEntry("title", "Senior Backend Engineer");
+        assertThat(req.hints()).containsEntry("location", "Remote (US)");
+
+        verify(scoreUseCase).score(postingId, "default", ORG_ID);
+    }
+
+    @Test
+    @WithMockUser(username = "robsartin")
+    void postEnvoy_omitsBlankHints() throws Exception {
+        var user = new User(UuidFactory.newId(), "robsartin", "rob@example.com");
+        var membership = new Membership();
+        membership.setUserId(user.getId());
+        membership.setOrganizationId(ORG_ID);
+
+        UUID postingId = UuidFactory.newId();
+        var saved = new JobPosting();
+        saved.setId(postingId);
+        saved.setOrganizationId(ORG_ID);
+
+        var report = new ScoreReport(UuidFactory.newId(), ORG_ID, postingId,
+                UuidFactory.newId(), 1, Optional.empty(),
+                List.of(), List.of(), 50, 50, Recommendation.CONSIDER,
+                "claude-sonnet-4-6", Instant.now());
+
+        when(userRepository.findByUsername("robsartin")).thenReturn(Optional.of(user));
+        when(membershipRepository.findByUserId(user.getId())).thenReturn(List.of(membership));
+        when(ingestUseCase.ingest(any(JobSourceRequest.class), eq(ORG_ID))).thenReturn(saved);
+        when(scoreUseCase.score(eq(postingId), eq("default"), eq(ORG_ID))).thenReturn(report);
+
+        mvc.perform(post("/envoy")
+                        .with(csrf())
+                        .param("type", "manual")
+                        .param("payload", "Some posting body")
+                        .param("company", "")
+                        .param("title", "  ")
+                        .param("location", ""))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/envoy"));
+
+        ArgumentCaptor<JobSourceRequest> captor = ArgumentCaptor.forClass(JobSourceRequest.class);
+        verify(ingestUseCase).ingest(captor.capture(), eq(ORG_ID));
+        assertThat(captor.getValue().hints()).isEmpty();
+    }
+
+    @Test
+    @WithMockUser(username = "robsartin")
+    void postEnvoy_renderEnvoyWithErrorWhenIngestThrows() throws Exception {
+        var user = new User(UuidFactory.newId(), "robsartin", "rob@example.com");
+        var membership = new Membership();
+        membership.setUserId(user.getId());
+        membership.setOrganizationId(ORG_ID);
+
+        when(userRepository.findByUsername("robsartin")).thenReturn(Optional.of(user));
+        when(membershipRepository.findByUserId(user.getId())).thenReturn(List.of(membership));
+        when(ingestUseCase.ingest(any(JobSourceRequest.class), eq(ORG_ID)))
+                .thenThrow(new IllegalArgumentException("no JobSource supports type: bogus"));
+        when(reports.query(eq(ORG_ID), any(), any(), any(), any(Integer.class)))
+                .thenReturn(new Page<>(List.of(), null, false));
+
+        mvc.perform(post("/envoy")
+                        .with(csrf())
+                        .param("type", "bogus")
+                        .param("payload", "Some posting body"))
+                .andExpect(status().isOk())
+                .andExpect(view().name("envoy"))
+                .andExpect(model().attribute("ingestError",
+                        containsString("no JobSource supports type: bogus")));
+
+        verify(scoreUseCase, never()).score(any(), any(), any());
+    }
+
+    @Test
+    @WithMockUser(username = "robsartin")
+    void postEnvoy_renderEnvoyWithErrorWhenScoreThrows() throws Exception {
+        var user = new User(UuidFactory.newId(), "robsartin", "rob@example.com");
+        var membership = new Membership();
+        membership.setUserId(user.getId());
+        membership.setOrganizationId(ORG_ID);
+
+        UUID postingId = UuidFactory.newId();
+        var saved = new JobPosting();
+        saved.setId(postingId);
+        saved.setOrganizationId(ORG_ID);
+
+        when(userRepository.findByUsername("robsartin")).thenReturn(Optional.of(user));
+        when(membershipRepository.findByUserId(user.getId())).thenReturn(List.of(membership));
+        when(ingestUseCase.ingest(any(JobSourceRequest.class), eq(ORG_ID))).thenReturn(saved);
+        when(scoreUseCase.score(eq(postingId), eq("default"), eq(ORG_ID)))
+                .thenThrow(new LlmScoringException("LLM returned malformed JSON"));
+        when(reports.query(eq(ORG_ID), any(), any(), any(), any(Integer.class)))
+                .thenReturn(new Page<>(List.of(), null, false));
+
+        mvc.perform(post("/envoy")
+                        .with(csrf())
+                        .param("type", "manual")
+                        .param("payload", "Some posting body"))
+                .andExpect(status().isOk())
+                .andExpect(view().name("envoy"))
+                .andExpect(model().attribute("ingestError",
+                        containsString("LLM returned malformed JSON")));
+    }
+
+    @Test
+    void postEnvoy_unauthenticatedRedirectsToLogin() throws Exception {
+        mvc.perform(post("/envoy")
+                        .with(csrf())
+                        .param("type", "manual")
+                        .param("payload", "Some posting body"))
+                .andExpect(status().is3xxRedirection());
+    }
+
+    @Test
+    @WithMockUser(username = "robsartin")
+    void postEnvoy_redirectsHomeWhenUserHasNoMembership() throws Exception {
+        var user = new User(UuidFactory.newId(), "robsartin", "rob@example.com");
+        when(userRepository.findByUsername("robsartin")).thenReturn(Optional.of(user));
+        when(membershipRepository.findByUserId(user.getId())).thenReturn(List.of());
+
+        mvc.perform(post("/envoy")
+                        .with(csrf())
+                        .param("type", "manual")
+                        .param("payload", "Some posting body"))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(view().name("redirect:/"));
+
+        verify(ingestUseCase, never()).ingest(any(), any());
+        verify(scoreUseCase, never()).score(any(), any(), any());
+    }
+
+    @Test
+    @WithMockUser(username = "robsartin")
+    void postEnvoy_rejectsMissingCsrf() throws Exception {
+        mvc.perform(post("/envoy")
+                        .param("type", "manual")
+                        .param("payload", "Some posting body"))
+                .andExpect(status().isForbidden());
+
+        verify(ingestUseCase, never()).ingest(any(), any());
+    }
+
+    @Test
+    @WithMockUser(username = "robsartin")
+    void postEnvoy_rendersEnvoyWithErrorWhenPayloadIsBlank() throws Exception {
+        var user = new User(UuidFactory.newId(), "robsartin", "rob@example.com");
+        var membership = new Membership();
+        membership.setUserId(user.getId());
+        membership.setOrganizationId(ORG_ID);
+
+        when(userRepository.findByUsername("robsartin")).thenReturn(Optional.of(user));
+        when(membershipRepository.findByUserId(user.getId())).thenReturn(List.of(membership));
+        when(reports.query(eq(ORG_ID), any(), any(), any(), any(Integer.class)))
+                .thenReturn(new Page<>(List.of(), null, false));
+
+        mvc.perform(post("/envoy")
+                        .with(csrf())
+                        .param("type", "manual")
+                        .param("payload", "   "))
+                .andExpect(status().isOk())
+                .andExpect(view().name("envoy"))
+                .andExpect(model().attributeExists("ingestError"));
+
+        verify(ingestUseCase, never()).ingest(any(), any());
+        verify(scoreUseCase, never()).score(any(), any(), any());
+    }
+}


### PR DESCRIPTION
## Summary

- Adds POST `/envoy` to ingest + score a posting against the default rubric and redirect back to the list.
- New collapsible "Score a posting" card on `/envoy` (above the filter strip) with source select, hint inputs, and payload textarea.
- On ingest or scoring failure, re-renders the page with an inline `ingestError` banner instead of a redirect — the user keeps the form context.

## Test Plan

- [x] `postEnvoy_ingestsAndScoresAndRedirects` — happy path captures hints + scores against `default`
- [x] `postEnvoy_omitsBlankHints` — blank/whitespace hints are dropped
- [x] `postEnvoy_renderEnvoyWithErrorWhenIngestThrows` — `IllegalArgumentException` re-renders with error
- [x] `postEnvoy_renderEnvoyWithErrorWhenScoreThrows` — `LlmScoringException` re-renders with error
- [x] `postEnvoy_unauthenticatedRedirectsToLogin`
- [x] `postEnvoy_redirectsHomeWhenUserHasNoMembership`
- [x] `postEnvoy_rejectsMissingCsrf` — POST without CSRF token returns 403, no ingest call
- [x] `postEnvoy_rendersEnvoyWithErrorWhenPayloadIsBlank` — short-circuits on whitespace-only payload
- [x] `./mvnw verify` — BUILD SUCCESS, 293 tests, 0 failures, 0 Checkstyle violations

Ingest-form tests split into `EnvoyPageIngestFormTest` so the original page-controller test file stays under the 500-line Checkstyle limit.

Closes #143

🤖 Generated with [Claude Code](https://claude.com/claude-code)