### PR TITLE
envoy: posting comparator at /envoy/compare

### DIFF
--- a/src/main/java/com/majordomo/adapter/in/web/envoy/EnvoyComparatorController.java
+++ b/src/main/java/com/majordomo/adapter/in/web/envoy/EnvoyComparatorController.java
@@ -1,0 +1,269 @@
+package com.majordomo.adapter.in.web.envoy;
+
+import com.majordomo.domain.model.envoy.Category;
+import com.majordomo.domain.model.envoy.CategoryScore;
+import com.majordomo.domain.model.envoy.JobPosting;
+import com.majordomo.domain.model.envoy.Rubric;
+import com.majordomo.domain.model.envoy.ScoreReport;
+import com.majordomo.domain.model.identity.User;
+import com.majordomo.domain.port.in.envoy.QueryScoreReportsUseCase;
+import com.majordomo.domain.port.out.envoy.JobPostingRepository;
+import com.majordomo.domain.port.out.envoy.RubricRepository;
+import com.majordomo.domain.port.out.identity.MembershipRepository;
+import com.majordomo.domain.port.out.identity.UserRepository;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * Thymeleaf controller for the Envoy posting comparator. Renders a side-by-side
+ * view of 2&ndash;5 scored postings under a single rubric, surfacing where the
+ * postings agree, where they diverge, and which are closest to or above the
+ * apply threshold.
+ *
+ * <p>Postings whose latest report is against a different rubric are shown as
+ * "not scored" columns rather than dropped, so the user keeps full context for
+ * the URL they bookmarked.</p>
+ */
+@Controller
+public class EnvoyComparatorController {
+
+    private static final int MIN_IDS = 2;
+    private static final int MAX_IDS = 5;
+    private static final String DEFAULT_RUBRIC = "default";
+
+    private final QueryScoreReportsUseCase reports;
+    private final RubricRepository rubricRepository;
+    private final JobPostingRepository jobPostingRepository;
+    private final UserRepository userRepository;
+    private final MembershipRepository membershipRepository;
+
+    /**
+     * One column in the comparator table — a posting plus (optionally) the
+     * report for the requested rubric.
+     *
+     * @param reportId               the requested report id from the {@code ids} param
+     * @param report                 the matching {@link ScoreReport} when present and
+     *                               scored against the requested rubric; {@code null} otherwise
+     * @param posting                the source posting metadata; {@code null} if the
+     *                               posting was deleted
+     * @param notScored              {@code true} when the posting has no report for the
+     *                               requested rubric (column is dimmed in the UI)
+     * @param gapFromApplyThreshold  signed gap from the rubric's APPLY threshold
+     *                               ({@code finalScore - thresholds.apply()}); always 0
+     *                               when {@link #notScored()} is true
+     */
+    public record Column(
+            UUID reportId,
+            ScoreReport report,
+            JobPosting posting,
+            boolean notScored,
+            int gapFromApplyThreshold) { }
+
+    /**
+     * One cell within a category row in the comparator table.
+     *
+     * @param tierLabel  selected tier label from the report; {@code null} when the
+     *                   column is not scored or the report didn't score this category
+     * @param points     points awarded; 0 when missing
+     * @param isHighest  {@code true} when this cell ties or beats every other scored
+     *                   cell in the row (gets the highlight class in the template)
+     * @param scored     {@code false} when no score was found for this column/category
+     */
+    public record Cell(String tierLabel, int points, boolean isHighest, boolean scored) { }
+
+    /**
+     * One row in the comparator table — one entry per rubric category, in
+     * rubric order, with one {@link Cell} per column.
+     *
+     * @param categoryKey the {@link Category#key()}
+     * @param cells       cells aligned to the column ordering
+     */
+    public record Row(String categoryKey, List<Cell> cells) { }
+
+    /** Resolved authentication context. */
+    private record AuthContext(User user, UUID organizationId) { }
+
+    /**
+     * Constructs the controller.
+     *
+     * @param reports              inbound port for report queries
+     * @param rubricRepository     outbound port for rubric lookups
+     * @param jobPostingRepository outbound port for posting lookups
+     * @param userRepository       outbound port for user lookups
+     * @param membershipRepository outbound port for membership lookups
+     */
+    public EnvoyComparatorController(QueryScoreReportsUseCase reports,
+                                     RubricRepository rubricRepository,
+                                     JobPostingRepository jobPostingRepository,
+                                     UserRepository userRepository,
+                                     MembershipRepository membershipRepository) {
+        this.reports = reports;
+        this.rubricRepository = rubricRepository;
+        this.jobPostingRepository = jobPostingRepository;
+        this.userRepository = userRepository;
+        this.membershipRepository = membershipRepository;
+    }
+
+    /**
+     * Renders the comparator page for the given {@code ids} (2&ndash;5 report
+     * ids, comma-separated) under the named {@code rubric} (defaults to
+     * {@code default}).
+     *
+     * <p>Behaviours:
+     * <ul>
+     *   <li>Returns 400 when fewer than 2 or more than 5 ids are supplied.</li>
+     *   <li>Returns 400 when the requested rubric does not exist for the org
+     *       (handled by the global {@code IllegalArgumentException} mapper).</li>
+     *   <li>Redirects to {@code /} when the user has no organization membership.</li>
+     *   <li>Reports against a different rubric show as "not scored" columns
+     *       (the user still sees the company / title / location).</li>
+     * </ul>
+     *
+     * @param idsParam  comma-separated report ids
+     * @param rubric    rubric name to compare against (default {@code default})
+     * @param principal authenticated user
+     * @param model     Thymeleaf model
+     * @return the {@code envoy-compare} template name, or a redirect to {@code /}
+     *         when the user has no organization
+     */
+    @GetMapping("/envoy/compare")
+    public String compare(@RequestParam(name = "ids") String idsParam,
+                          @RequestParam(name = "rubric", defaultValue = DEFAULT_RUBRIC)
+                          String rubric,
+                          @AuthenticationPrincipal UserDetails principal,
+                          Model model) {
+        List<UUID> ids = parseIds(idsParam);
+
+        AuthContext ctx = resolveContext(principal);
+        if (ctx.organizationId() == null) {
+            return "redirect:/";
+        }
+        UUID orgId = ctx.organizationId();
+
+        Rubric activeRubric = rubricRepository.findActiveByName(rubric, orgId)
+                .orElseThrow(() -> new IllegalArgumentException(
+                        "Rubric not found: " + rubric));
+
+        List<Column> columns = new ArrayList<>(ids.size());
+        for (UUID reportId : ids) {
+            columns.add(buildColumn(reportId, orgId, activeRubric));
+        }
+
+        List<Row> rows = buildRows(activeRubric, columns);
+
+        model.addAttribute("rubric", activeRubric);
+        model.addAttribute("rubricName", rubric);
+        model.addAttribute("columns", columns);
+        model.addAttribute("rows", rows);
+        model.addAttribute("organizationId", orgId);
+        model.addAttribute("username", ctx.user().getUsername());
+        return "envoy-compare";
+    }
+
+    private List<UUID> parseIds(String raw) {
+        if (raw == null || raw.isBlank()) {
+            throw new IllegalArgumentException("ids is required");
+        }
+        // De-duplicate while preserving order.
+        var uniq = new LinkedHashSet<UUID>();
+        for (String part : raw.split(",")) {
+            String trimmed = part.trim();
+            if (trimmed.isEmpty()) {
+                continue;
+            }
+            try {
+                uniq.add(UUID.fromString(trimmed));
+            } catch (IllegalArgumentException ex) {
+                throw new IllegalArgumentException("Invalid UUID: " + trimmed);
+            }
+        }
+        if (uniq.size() < MIN_IDS) {
+            throw new IllegalArgumentException(
+                    "At least " + MIN_IDS + " ids are required");
+        }
+        if (uniq.size() > MAX_IDS) {
+            throw new IllegalArgumentException(
+                    "At most " + MAX_IDS + " ids are allowed");
+        }
+        return new ArrayList<>(uniq);
+    }
+
+    private Column buildColumn(UUID reportId, UUID orgId, Rubric activeRubric) {
+        Optional<ScoreReport> reportOpt = reports.findById(reportId, orgId);
+        if (reportOpt.isEmpty()) {
+            // Unknown id — treat as not scored so the page still renders.
+            return new Column(reportId, null, null, true, 0);
+        }
+        ScoreReport report = reportOpt.get();
+        JobPosting posting = jobPostingRepository.findById(report.postingId(), orgId)
+                .orElse(null);
+
+        boolean sameRubric = report.rubricId().equals(activeRubric.id());
+        if (!sameRubric) {
+            return new Column(reportId, null, posting, true, 0);
+        }
+        int gap = report.finalScore() - activeRubric.thresholds().apply();
+        return new Column(reportId, report, posting, false, gap);
+    }
+
+    private List<Row> buildRows(Rubric rubric, List<Column> columns) {
+        List<Row> rows = new ArrayList<>(rubric.categories().size());
+        for (Category category : rubric.categories()) {
+            List<Cell> cells = new ArrayList<>(columns.size());
+            int max = Integer.MIN_VALUE;
+            for (Column col : columns) {
+                ScoreReport r = col.report();
+                if (r == null) {
+                    cells.add(new Cell(null, 0, false, false));
+                    continue;
+                }
+                Optional<CategoryScore> match = r.categoryScores().stream()
+                        .filter(cs -> cs.categoryKey().equals(category.key()))
+                        .findFirst();
+                if (match.isEmpty()) {
+                    cells.add(new Cell(null, 0, false, false));
+                    continue;
+                }
+                CategoryScore cs = match.get();
+                cells.add(new Cell(cs.tierLabel(), cs.points(), false, true));
+                if (cs.points() > max) {
+                    max = cs.points();
+                }
+            }
+            // Mark every scored cell whose points equal the row max as highest.
+            // If no cells were scored, no highlight.
+            if (max != Integer.MIN_VALUE) {
+                List<Cell> highlighted = new ArrayList<>(cells.size());
+                for (Cell c : cells) {
+                    if (c.scored() && c.points() == max) {
+                        highlighted.add(new Cell(c.tierLabel(), c.points(), true, true));
+                    } else {
+                        highlighted.add(c);
+                    }
+                }
+                cells = highlighted;
+            }
+            rows.add(new Row(category.key(), cells));
+        }
+        return rows;
+    }
+
+    private AuthContext resolveContext(UserDetails principal) {
+        var user = userRepository.findByUsername(principal.getUsername()).orElseThrow();
+        var memberships = membershipRepository.findByUserId(user.getId());
+        if (memberships.isEmpty()) {
+            return new AuthContext(user, null);
+        }
+        return new AuthContext(user, memberships.get(0).getOrganizationId());
+    }
+}

--- a/src/main/resources/templates/envoy-compare.html
+++ b/src/main/resources/templates/envoy-compare.html
@@ -1,0 +1,135 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org"
+      xmlns:sec="http://www.thymeleaf.org/extras/spring-security"
+      lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Envoy Compare - Majordomo</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-gray-100 min-h-screen">
+
+    <div th:replace="~{fragments/header :: header}"></div>
+
+    <div class="flex min-h-screen">
+        <div th:replace="~{fragments/sidebar :: sidebar('envoy')}"></div>
+
+        <main class="flex-1 p-6">
+
+            <!-- Breadcrumb -->
+            <nav class="mb-4" aria-label="Breadcrumb">
+                <ol class="flex items-center space-x-2 text-sm text-gray-500">
+                    <li><a th:href="@{/envoy}" class="hover:text-indigo-600 transition">Envoy</a></li>
+                    <li class="flex items-center space-x-2">
+                        <span>&rsaquo;</span>
+                        <span class="text-gray-900 font-medium">Compare</span>
+                    </li>
+                </ol>
+            </nav>
+
+            <div class="flex items-baseline justify-between mb-6">
+                <h1 class="text-2xl font-bold text-gray-900">Compare postings</h1>
+                <span class="text-sm text-gray-500">
+                    Rubric: <code class="bg-gray-200 px-1 rounded"
+                                  th:text="${rubric.name() + ' v' + rubric.version()}">default v1</code>
+                </span>
+            </div>
+
+            <div class="bg-white rounded-lg shadow overflow-x-auto">
+                <table class="min-w-full divide-y divide-gray-200 text-sm">
+                    <thead class="bg-gray-50">
+                        <tr>
+                            <th class="px-4 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider w-48">
+                                Category
+                            </th>
+                            <th th:each="col : ${columns}"
+                                class="px-4 py-3 text-left text-xs font-semibold text-gray-700 align-top">
+                                <!-- Posting metadata -->
+                                <div th:if="${col.posting() != null}">
+                                    <div class="font-semibold text-gray-900 truncate"
+                                         th:text="${col.posting().getCompany() != null ? col.posting().getCompany() : '—'}">
+                                        Company
+                                    </div>
+                                    <div class="text-gray-700 truncate"
+                                         th:text="${col.posting().getTitle() != null ? col.posting().getTitle() : '—'}">
+                                        Title
+                                    </div>
+                                    <div class="text-gray-500 text-xs truncate"
+                                         th:text="${col.posting().getLocation() != null ? col.posting().getLocation() : '—'}">
+                                        Location
+                                    </div>
+                                </div>
+                                <div th:if="${col.posting() == null}"
+                                     class="font-mono text-xs text-gray-400">
+                                    Posting deleted
+                                </div>
+
+                                <!-- Total score + recommendation -->
+                                <div th:if="${col.report() != null}" class="mt-3 flex items-baseline gap-2">
+                                    <span class="text-2xl font-bold text-gray-900"
+                                          th:text="${col.report().finalScore()}">0</span>
+                                    <span class="rounded-full px-2 py-0.5 text-xs font-medium"
+                                          th:text="${col.report().recommendation()}"
+                                          th:classappend="${col.report().recommendation().name() == 'APPLY_NOW'} ? 'bg-emerald-100 text-emerald-800' :
+                                                         (${col.report().recommendation().name() == 'APPLY'} ? 'bg-indigo-100 text-indigo-800' :
+                                                         (${col.report().recommendation().name() == 'CONSIDER'} ? 'bg-amber-100 text-amber-800' :
+                                                                                                                   'bg-gray-200 text-gray-700'))">
+                                    </span>
+                                </div>
+                                <div th:if="${col.notScored()}"
+                                     class="mt-3 inline-block rounded-full px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-500 italic">
+                                    not scored
+                                </div>
+
+                                <!-- Detail link -->
+                                <div th:if="${col.report() != null}" class="mt-2">
+                                    <a class="text-indigo-600 hover:text-indigo-800 text-xs font-medium"
+                                       th:href="@{/envoy/reports/{id}(id=${col.report().id()})}">View detail &rarr;</a>
+                                </div>
+                            </th>
+                        </tr>
+                    </thead>
+                    <tbody class="bg-white divide-y divide-gray-100">
+                        <tr th:each="row : ${rows}" class="align-top">
+                            <td class="px-4 py-3 font-medium text-gray-700"
+                                th:text="${row.categoryKey()}">category_key</td>
+                            <td th:each="cell : ${row.cells()}"
+                                class="px-4 py-3"
+                                th:classappend="${cell.isHighest()} ? 'bg-emerald-50' : ''">
+                                <div th:if="${cell.scored()}" class="flex items-baseline gap-2">
+                                    <span class="font-semibold"
+                                          th:classappend="${cell.isHighest()} ? 'text-emerald-900' : 'text-gray-900'"
+                                          th:text="${cell.points()}">0</span>
+                                    <span class="text-xs text-gray-500"
+                                          th:text="${cell.tierLabel()}">tier</span>
+                                </div>
+                                <span th:unless="${cell.scored()}"
+                                      class="text-xs text-gray-400 italic">—</span>
+                            </td>
+                        </tr>
+                    </tbody>
+                    <tfoot class="bg-gray-50">
+                        <tr>
+                            <td class="px-4 py-3 text-xs font-semibold text-gray-500 uppercase tracking-wider">
+                                Gap from APPLY (<span th:text="${rubric.thresholds().apply()}">0</span>)
+                            </td>
+                            <td th:each="col : ${columns}" class="px-4 py-3">
+                                <span th:if="${col.report() != null}"
+                                      class="text-sm font-semibold"
+                                      th:classappend="${col.gapFromApplyThreshold() >= 0} ? 'text-emerald-700' : 'text-red-700'"
+                                      th:text="${col.gapFromApplyThreshold() >= 0 ? '+' + col.gapFromApplyThreshold() : col.gapFromApplyThreshold()}">
+                                    +0
+                                </span>
+                                <span th:if="${col.notScored()}"
+                                      class="text-xs text-gray-400 italic">—</span>
+                            </td>
+                        </tr>
+                    </tfoot>
+                </table>
+            </div>
+
+        </main>
+    </div>
+</body>
+</html>

--- a/src/test/java/com/majordomo/adapter/in/web/envoy/EnvoyComparatorControllerTest.java
+++ b/src/test/java/com/majordomo/adapter/in/web/envoy/EnvoyComparatorControllerTest.java
@@ -1,0 +1,255 @@
+package com.majordomo.adapter.in.web.envoy;
+
+import com.majordomo.adapter.in.web.config.OAuth2UserService;
+import com.majordomo.adapter.in.web.config.SecurityConfig;
+import com.majordomo.domain.model.UuidFactory;
+import com.majordomo.domain.model.envoy.Category;
+import com.majordomo.domain.model.envoy.CategoryScore;
+import com.majordomo.domain.model.envoy.JobPosting;
+import com.majordomo.domain.model.envoy.Recommendation;
+import com.majordomo.domain.model.envoy.Rubric;
+import com.majordomo.domain.model.envoy.ScoreReport;
+import com.majordomo.domain.model.envoy.Thresholds;
+import com.majordomo.domain.model.envoy.Tier;
+import com.majordomo.domain.model.identity.Membership;
+import com.majordomo.domain.model.identity.User;
+import com.majordomo.domain.port.in.envoy.QueryScoreReportsUseCase;
+import com.majordomo.domain.port.out.envoy.JobPostingRepository;
+import com.majordomo.domain.port.out.envoy.RubricRepository;
+import com.majordomo.domain.port.out.identity.ApiKeyRepository;
+import com.majordomo.domain.port.out.identity.MembershipRepository;
+import com.majordomo.domain.port.out.identity.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.model;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
+
+@WebMvcTest(EnvoyComparatorController.class)
+@Import(SecurityConfig.class)
+class EnvoyComparatorControllerTest {
+
+    @Autowired MockMvc mvc;
+
+    @MockitoBean QueryScoreReportsUseCase reports;
+    @MockitoBean RubricRepository rubricRepository;
+    @MockitoBean JobPostingRepository jobPostingRepository;
+    @MockitoBean UserRepository userRepository;
+    @MockitoBean MembershipRepository membershipRepository;
+    @MockitoBean ApiKeyRepository apiKeyRepository;
+    @MockitoBean OAuth2UserService oAuth2UserService;
+
+    private static final UUID ORG_ID = UuidFactory.newId();
+
+    private Rubric rubric() {
+        return new Rubric(
+                UuidFactory.newId(),
+                Optional.of(ORG_ID),
+                1,
+                "default",
+                List.of(),
+                List.of(
+                        new Category("compensation", "Comp", 30,
+                                List.of(new Tier("Excellent", 30, "x"),
+                                        new Tier("Good", 20, "x"))),
+                        new Category("remote", "Remote", 20,
+                                List.of(new Tier("Fully", 20, "x")))),
+                List.of(),
+                new Thresholds(80, 60, 40),
+                Instant.now());
+    }
+
+    private ScoreReport report(UUID postingId, int finalScore, Recommendation rec,
+                               UUID rubricId, List<CategoryScore> scores) {
+        return new ScoreReport(
+                UuidFactory.newId(), ORG_ID, postingId, rubricId, 1,
+                Optional.empty(), scores, List.of(),
+                finalScore, finalScore, rec, "claude-sonnet-4-6", Instant.now());
+    }
+
+    private JobPosting posting(UUID id, String company, String title, String location) {
+        var p = new JobPosting();
+        p.setId(id);
+        p.setOrganizationId(ORG_ID);
+        p.setCompany(company);
+        p.setTitle(title);
+        p.setLocation(location);
+        return p;
+    }
+
+    private void stubAuthedUser() {
+        var user = new User(UuidFactory.newId(), "robsartin", "rob@example.com");
+        var membership = new Membership();
+        membership.setUserId(user.getId());
+        membership.setOrganizationId(ORG_ID);
+        when(userRepository.findByUsername("robsartin")).thenReturn(Optional.of(user));
+        when(membershipRepository.findByUserId(user.getId())).thenReturn(List.of(membership));
+    }
+
+    @Test
+    @WithMockUser(username = "robsartin")
+    void rendersComparisonForTwoValidReportsUnderSameRubric() throws Exception {
+        stubAuthedUser();
+        Rubric r = rubric();
+        when(rubricRepository.findActiveByName("default", ORG_ID)).thenReturn(Optional.of(r));
+
+        UUID postingA = UuidFactory.newId();
+        UUID postingB = UuidFactory.newId();
+        var reportA = report(postingA, 85, Recommendation.APPLY_NOW, r.id(), List.of(
+                new CategoryScore("compensation", 30, "Excellent", "Top of band"),
+                new CategoryScore("remote", 20, "Fully", "Remote-first")));
+        var reportB = report(postingB, 60, Recommendation.APPLY, r.id(), List.of(
+                new CategoryScore("compensation", 20, "Good", "Mid band"),
+                new CategoryScore("remote", 20, "Fully", "Remote-first")));
+
+        when(reports.findById(reportA.id(), ORG_ID)).thenReturn(Optional.of(reportA));
+        when(reports.findById(reportB.id(), ORG_ID)).thenReturn(Optional.of(reportB));
+        when(jobPostingRepository.findById(postingA, ORG_ID))
+                .thenReturn(Optional.of(posting(postingA, "Acme", "SBE", "Remote")));
+        when(jobPostingRepository.findById(postingB, ORG_ID))
+                .thenReturn(Optional.of(posting(postingB, "Globex", "BE", "NYC")));
+
+        MvcResult result = mvc.perform(get("/envoy/compare")
+                        .param("ids", reportA.id() + "," + reportB.id()))
+                .andExpect(status().isOk())
+                .andExpect(view().name("envoy-compare"))
+                .andExpect(model().attributeExists("columns"))
+                .andExpect(model().attributeExists("rubric"))
+                .andExpect(model().attributeExists("rows"))
+                .andReturn();
+
+        // Two columns, both scored, all rubric categories represented in rows.
+        @SuppressWarnings("unchecked")
+        List<EnvoyComparatorController.Column> columns =
+                (List<EnvoyComparatorController.Column>)
+                        result.getModelAndView().getModel().get("columns");
+        assertThat(columns).hasSize(2);
+        assertThat(columns).allMatch(c -> c.report() != null);
+
+        @SuppressWarnings("unchecked")
+        List<EnvoyComparatorController.Row> rows =
+                (List<EnvoyComparatorController.Row>)
+                        result.getModelAndView().getModel().get("rows");
+        assertThat(rows).hasSize(2);
+        assertThat(rows.stream().map(EnvoyComparatorController.Row::categoryKey).toList())
+                .containsExactly("compensation", "remote");
+
+        // Highest highlight on compensation should belong to column 0 (reportA: 30 > 20).
+        var compRow = rows.get(0);
+        assertThat(compRow.cells().get(0).isHighest()).isTrue();
+        assertThat(compRow.cells().get(1).isHighest()).isFalse();
+        // Tie on remote (20 vs 20): both should highlight.
+        var remoteRow = rows.get(1);
+        assertThat(remoteRow.cells().stream().allMatch(EnvoyComparatorController.Cell::isHighest))
+                .isTrue();
+
+        // Footer summary: gap from APPLY threshold (60) per posting.
+        assertThat(columns.get(0).gapFromApplyThreshold()).isEqualTo(85 - 60);
+        assertThat(columns.get(1).gapFromApplyThreshold()).isEqualTo(60 - 60);
+    }
+
+    @Test
+    @WithMockUser(username = "robsartin")
+    void returns400WhenFewerThanTwoIds() throws Exception {
+        stubAuthedUser();
+        when(rubricRepository.findActiveByName("default", ORG_ID))
+                .thenReturn(Optional.of(rubric()));
+
+        mvc.perform(get("/envoy/compare").param("ids", UuidFactory.newId().toString()))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @WithMockUser(username = "robsartin")
+    void returns400WhenMoreThanFiveIds() throws Exception {
+        stubAuthedUser();
+        when(rubricRepository.findActiveByName("default", ORG_ID))
+                .thenReturn(Optional.of(rubric()));
+
+        String tooMany = String.join(",", Stream.generate(() -> UuidFactory.newId().toString())
+                .limit(6).toList());
+
+        mvc.perform(get("/envoy/compare").param("ids", tooMany))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @WithMockUser(username = "robsartin")
+    void marksPostingAsNotScoredWhenNoReportForRequestedRubric() throws Exception {
+        stubAuthedUser();
+        Rubric r = rubric();
+        UUID otherRubricId = UuidFactory.newId();
+        when(rubricRepository.findActiveByName("default", ORG_ID)).thenReturn(Optional.of(r));
+
+        UUID postingA = UuidFactory.newId();
+        UUID postingB = UuidFactory.newId();
+        var reportA = report(postingA, 70, Recommendation.APPLY, r.id(), List.of(
+                new CategoryScore("compensation", 30, "Excellent", "Top"),
+                new CategoryScore("remote", 20, "Fully", "Remote")));
+        // reportB is scored under a *different* rubric — should surface as "not scored".
+        var reportB = report(postingB, 50, Recommendation.CONSIDER, otherRubricId, List.of(
+                new CategoryScore("compensation", 20, "Good", "Mid"),
+                new CategoryScore("remote", 20, "Fully", "Remote")));
+
+        when(reports.findById(reportA.id(), ORG_ID)).thenReturn(Optional.of(reportA));
+        when(reports.findById(reportB.id(), ORG_ID)).thenReturn(Optional.of(reportB));
+        when(jobPostingRepository.findById(postingA, ORG_ID))
+                .thenReturn(Optional.of(posting(postingA, "Acme", "SBE", "Remote")));
+        when(jobPostingRepository.findById(postingB, ORG_ID))
+                .thenReturn(Optional.of(posting(postingB, "Globex", "BE", "NYC")));
+
+        MvcResult result = mvc.perform(get("/envoy/compare")
+                        .param("ids", reportA.id() + "," + reportB.id()))
+                .andExpect(status().isOk())
+                .andExpect(view().name("envoy-compare"))
+                .andReturn();
+
+        @SuppressWarnings("unchecked")
+        List<EnvoyComparatorController.Column> columns =
+                (List<EnvoyComparatorController.Column>)
+                        result.getModelAndView().getModel().get("columns");
+        assertThat(columns).hasSize(2);
+        assertThat(columns.get(0).report()).isNotNull();
+        assertThat(columns.get(0).notScored()).isFalse();
+        assertThat(columns.get(1).report()).isNull();
+        assertThat(columns.get(1).notScored()).isTrue();
+        // Posting metadata still surfaced for the not-scored column.
+        assertThat(columns.get(1).posting()).isNotNull();
+    }
+
+    @Test
+    @WithMockUser(username = "robsartin")
+    void redirectsHomeWhenUserHasNoMembership() throws Exception {
+        var user = new User(UuidFactory.newId(), "robsartin", "rob@example.com");
+        when(userRepository.findByUsername("robsartin")).thenReturn(Optional.of(user));
+        when(membershipRepository.findByUserId(user.getId())).thenReturn(List.of());
+
+        mvc.perform(get("/envoy/compare")
+                        .param("ids", UuidFactory.newId() + "," + UuidFactory.newId()))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(view().name("redirect:/"));
+    }
+
+    @Test
+    void unauthenticatedRedirectsToLogin() throws Exception {
+        mvc.perform(get("/envoy/compare")
+                        .param("ids", UuidFactory.newId() + "," + UuidFactory.newId()))
+                .andExpect(status().is3xxRedirection());
+    }
+}


### PR DESCRIPTION
## Summary

- New Thymeleaf page `/envoy/compare?ids=<uuid>,<uuid>[,...]&rubric=<name>` that renders a side-by-side comparison of 2 to 5 scored postings under a single rubric (default rubric: `default`).
- One row per rubric category, with the highest-scoring cell highlighted (ties highlight all winners). Footer surfaces each posting's signed gap from the rubric's APPLY threshold.
- Reports scored against a different rubric appear as "not scored" columns rather than being dropped, so bookmarkable URLs degrade gracefully.
- 400 when fewer than 2 or more than 5 ids; redirect to `/` when the user has no org membership; standard Spring Security redirect for unauthenticated.

## Test plan

- [x] `./mvnw verify` green (291 tests, checkstyle + ArchUnit clean)
- [x] 6 controller-slice tests under `EnvoyComparatorControllerTest` (renders 2-report comparison + highlight + gap, 400 fewer than 2, 400 more than 5, posting marked "not scored" when rubric mismatch, redirect home when no membership, redirect login when unauthenticated)

Closes #159