### PR TITLE
envoy: LLM cost & latency metrics

### DIFF
--- a/infra/grafana/dashboards/envoy-llm.json
+++ b/infra/grafana/dashboards/envoy-llm.json
@@ -1,0 +1,68 @@
+{
+  "dashboard": {
+    "id": null,
+    "uid": "envoy-llm",
+    "title": "Envoy LLM Cost & Latency",
+    "tags": ["majordomo", "envoy"],
+    "timezone": "browser",
+    "schemaVersion": 39,
+    "version": 1,
+    "templating": {
+      "list": [
+        {
+          "name": "input_price_per_million",
+          "label": "Input price ($/Mtok)",
+          "type": "constant",
+          "query": "3.0",
+          "current": { "text": "3.0", "value": "3.0" }
+        },
+        {
+          "name": "output_price_per_million",
+          "label": "Output price ($/Mtok)",
+          "type": "constant",
+          "query": "15.0",
+          "current": { "text": "15.0", "value": "15.0" }
+        }
+      ]
+    },
+    "panels": [
+      {
+        "title": "Tokens / minute",
+        "type": "timeseries",
+        "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+        "targets": [
+          {
+            "expr": "sum by (model) (rate(envoy_llm_input_tokens_total[1m]) * 60)",
+            "legendFormat": "input {{model}}"
+          },
+          {
+            "expr": "sum by (model) (rate(envoy_llm_output_tokens_total[1m]) * 60)",
+            "legendFormat": "output {{model}}"
+          }
+        ]
+      },
+      {
+        "title": "p95 LLM call duration by model",
+        "type": "timeseries",
+        "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+        "targets": [
+          {
+            "expr": "histogram_quantile(0.95, sum by (model, le) (rate(envoy_llm_call_duration_seconds_bucket[5m])))",
+            "legendFormat": "{{model}}"
+          }
+        ]
+      },
+      {
+        "title": "Spend / hour ($)",
+        "type": "timeseries",
+        "gridPos": { "h": 8, "w": 24, "x": 0, "y": 8 },
+        "targets": [
+          {
+            "expr": "sum by (model) (rate(envoy_llm_input_tokens_total[5m]) * 3600 / 1000000 * $input_price_per_million) + sum by (model) (rate(envoy_llm_output_tokens_total[5m]) * 3600 / 1000000 * $output_price_per_million)",
+            "legendFormat": "{{model}}"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/src/main/java/com/majordomo/adapter/out/llm/AnthropicLlmScoringAdapter.java
+++ b/src/main/java/com/majordomo/adapter/out/llm/AnthropicLlmScoringAdapter.java
@@ -36,12 +36,16 @@ public class AnthropicLlmScoringAdapter implements LlmScoringPort {
     @Override
     public LlmScoreResponse score(JobPosting posting, Rubric rubric) {
         ScoringPrompt prompt = promptBuilder.build(posting, rubric);
-        String json = client.send(prompt.systemPrompt(), prompt.userPrompt());
+        AnthropicMessageClient.MessageResult result =
+                client.sendWithUsage(prompt.systemPrompt(), prompt.userPrompt());
+        LlmScoreResponse parsed;
         try {
-            return mapper.readValue(json, LlmScoreResponse.class);
+            parsed = mapper.readValue(result.text(), LlmScoreResponse.class);
         } catch (Exception e) {
-            throw new LlmScoringException("LLM returned unparseable JSON: " + json, e);
+            throw new LlmScoringException(
+                    "LLM returned unparseable JSON: " + result.text(), e);
         }
+        return result.usage().map(parsed::withUsage).orElse(parsed);
     }
 
     @Override

--- a/src/main/java/com/majordomo/adapter/out/llm/AnthropicMessageClient.java
+++ b/src/main/java/com/majordomo/adapter/out/llm/AnthropicMessageClient.java
@@ -6,11 +6,15 @@ import com.anthropic.models.messages.ContentBlock;
 import com.anthropic.models.messages.Message;
 import com.anthropic.models.messages.MessageCreateParams;
 import com.anthropic.models.messages.TextBlockParam;
+import com.anthropic.models.messages.Usage;
 import com.majordomo.application.envoy.LlmScoringException;
+import com.majordomo.domain.model.envoy.LlmScoreResponse;
 import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
 import io.github.resilience4j.retry.annotation.Retry;
 
 import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Thin wrapper over {@link AnthropicClient}. Applies a Resilience4j circuit breaker
@@ -58,6 +62,23 @@ public class AnthropicMessageClient {
     @CircuitBreaker(name = "envoy-llm")
     @Retry(name = "envoy-llm")
     public String send(String systemPrompt, String userPrompt) {
+        return sendWithUsage(systemPrompt, userPrompt).text();
+    }
+
+    /**
+     * Sends one Messages API call and returns the assistant's first text block
+     * along with usage metadata (token counts and wall-clock latency). Usage is
+     * captured inside the Resilience4j-protected scope so retries are timed
+     * independently — each surviving attempt records its own duration.
+     *
+     * @param systemPrompt rubric-derived instructions (cached)
+     * @param userPrompt   posting body
+     * @return the assistant's first text block plus optional usage data
+     */
+    @CircuitBreaker(name = "envoy-llm")
+    @Retry(name = "envoy-llm")
+    public MessageResult sendWithUsage(String systemPrompt, String userPrompt) {
+        long startNs = System.nanoTime();
         try {
             MessageCreateParams params = MessageCreateParams.builder()
                     .model(model)
@@ -74,14 +95,41 @@ public class AnthropicMessageClient {
             if (blocks == null || blocks.isEmpty()) {
                 throw new LlmScoringException("Anthropic API returned no content");
             }
-            return blocks.get(0).text()
+            String text = blocks.get(0).text()
                     .map(tb -> tb.text())
                     .orElseThrow(() -> new LlmScoringException(
                             "First content block was not text"));
+            long latencyMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNs);
+            return new MessageResult(text, extractUsage(message, latencyMs));
         } catch (LlmScoringException e) {
             throw e;
         } catch (Exception e) {
             throw new LlmScoringException("Anthropic API call failed", e);
         }
     }
+
+    private static Optional<LlmScoreResponse.Usage> extractUsage(Message message, long latencyMs) {
+        try {
+            Usage usage = message.usage();
+            if (usage == null) {
+                return Optional.empty();
+            }
+            return Optional.of(new LlmScoreResponse.Usage(
+                    usage.inputTokens(), usage.outputTokens(), latencyMs));
+        } catch (RuntimeException ignored) {
+            // SDK may surface usage as a JSON-backed lazy struct; on parse failure
+            // we silently drop the usage rather than failing the scoring call.
+            return Optional.empty();
+        }
+    }
+
+    /**
+     * Result of a single Anthropic Messages API call: the assistant's first
+     * text block plus optional usage metadata. Usage is empty when the SDK does
+     * not expose it (e.g. on streaming or when the API omits the field).
+     *
+     * @param text  the assistant's first text block
+     * @param usage usage metadata captured around the SDK call
+     */
+    public record MessageResult(String text, Optional<LlmScoreResponse.Usage> usage) { }
 }

--- a/src/main/java/com/majordomo/application/envoy/JobScorerService.java
+++ b/src/main/java/com/majordomo/application/envoy/JobScorerService.java
@@ -13,21 +13,39 @@ import com.majordomo.domain.port.out.envoy.JobPostingRepository;
 import com.majordomo.domain.port.out.envoy.LlmScoringPort;
 import com.majordomo.domain.port.out.envoy.RubricRepository;
 import com.majordomo.domain.port.out.envoy.ScoreReportRepository;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
 import org.springframework.stereotype.Service;
 
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Orchestrates posting scoring. Java owns all deterministic work: load the
  * posting and active rubric, render the prompt, validate the LLM response via
  * {@link ScoreAssembler}, and persist the report. The LLM makes only the fuzzy
  * interpretive choices.
+ *
+ * <p>Each scoring call also records Prometheus metrics:
+ * <ul>
+ *     <li>{@code envoy_llm_input_tokens_total} (counter, tags: org, model, rubric)</li>
+ *     <li>{@code envoy_llm_output_tokens_total} (counter, tags: org, model, rubric)</li>
+ *     <li>{@code envoy_llm_call_duration} (timer, tags: model, outcome)</li>
+ * </ul>
+ * Token counters are only incremented when the LLM adapter supplies usage data.
+ * The timer is always recorded so that latency is visible even for providers
+ * that omit token counts.
  */
 @Service
 public class JobScorerService implements ScoreJobPostingUseCase {
+
+    private static final String INPUT_TOKENS_METRIC = "envoy_llm_input_tokens_total";
+    private static final String OUTPUT_TOKENS_METRIC = "envoy_llm_output_tokens_total";
+    private static final String CALL_DURATION_METRIC = "envoy_llm_call_duration";
 
     private final RubricRepository rubrics;
     private final JobPostingRepository postings;
@@ -35,6 +53,7 @@ public class JobScorerService implements ScoreJobPostingUseCase {
     private final LlmScoringPort llm;
     private final ScoreAssembler assembler;
     private final EventPublisher eventPublisher;
+    private final MeterRegistry meterRegistry;
 
     /**
      * Constructs the scorer with all required collaborators.
@@ -45,19 +64,22 @@ public class JobScorerService implements ScoreJobPostingUseCase {
      * @param llm            outbound LLM scoring port
      * @param assembler      deterministic LLM-response validator
      * @param eventPublisher domain event publisher
+     * @param meterRegistry  Micrometer registry for token/latency metrics
      */
     public JobScorerService(RubricRepository rubrics,
                             JobPostingRepository postings,
                             ScoreReportRepository reports,
                             LlmScoringPort llm,
                             ScoreAssembler assembler,
-                            EventPublisher eventPublisher) {
+                            EventPublisher eventPublisher,
+                            MeterRegistry meterRegistry) {
         this.rubrics = rubrics;
         this.postings = postings;
         this.reports = reports;
         this.llm = llm;
         this.assembler = assembler;
         this.eventPublisher = eventPublisher;
+        this.meterRegistry = meterRegistry;
     }
 
     @Override
@@ -93,12 +115,54 @@ public class JobScorerService implements ScoreJobPostingUseCase {
     }
 
     private ScoreReport runOne(JobPosting posting, Rubric rubric) {
-        LlmScoreResponse resp = llm.score(posting, rubric);
-        ScoreReport report = assembler.assemble(posting, rubric, resp, llm.modelId());
+        String modelId = llm.modelId();
+        long startNs = System.nanoTime();
+        LlmScoreResponse resp;
+        try {
+            resp = llm.score(posting, rubric);
+        } catch (RuntimeException e) {
+            recordTimer(modelId, "error", System.nanoTime() - startNs);
+            throw e;
+        }
+        recordTimer(modelId, "success", System.nanoTime() - startNs);
+        recordTokenUsage(resp, posting.getOrganizationId(), modelId, rubric.name());
+
+        ScoreReport report = assembler.assemble(posting, rubric, resp, modelId);
         ScoreReport saved = reports.save(report);
         eventPublisher.publish(new JobPostingScored(
                 saved.id(), saved.organizationId(), saved.postingId(),
                 saved.finalScore(), saved.recommendation(), Instant.now()));
         return saved;
+    }
+
+    private void recordTimer(String modelId, String outcome, long elapsedNs) {
+        Timer.builder(CALL_DURATION_METRIC)
+                .description("Wall-clock duration of envoy LLM scoring calls")
+                .tag("model", modelId)
+                .tag("outcome", outcome)
+                .register(meterRegistry)
+                .record(elapsedNs, TimeUnit.NANOSECONDS);
+    }
+
+    private void recordTokenUsage(LlmScoreResponse resp,
+                                  UUID organizationId,
+                                  String modelId,
+                                  String rubricName) {
+        resp.usage().ifPresent(usage -> {
+            Counter.builder(INPUT_TOKENS_METRIC)
+                    .description("Prompt tokens consumed by envoy LLM scoring calls")
+                    .tag("org", organizationId.toString())
+                    .tag("model", modelId)
+                    .tag("rubric", rubricName)
+                    .register(meterRegistry)
+                    .increment(usage.inputTokens());
+            Counter.builder(OUTPUT_TOKENS_METRIC)
+                    .description("Completion tokens produced by envoy LLM scoring calls")
+                    .tag("org", organizationId.toString())
+                    .tag("model", modelId)
+                    .tag("rubric", rubricName)
+                    .register(meterRegistry)
+                    .increment(usage.outputTokens());
+        });
     }
 }

--- a/src/main/java/com/majordomo/domain/model/envoy/LlmScoreResponse.java
+++ b/src/main/java/com/majordomo/domain/model/envoy/LlmScoreResponse.java
@@ -15,12 +15,54 @@ import java.util.Optional;
  *                         {@link Disqualifier#key()} in the active rubric
  * @param categoryVerdicts one entry per category in the rubric (LLM must cover all)
  * @param flagHits         zero or more flags the LLM judged to have fired
+ * @param usage            optional usage metadata captured by the adapter
+ *                         (token counts, wall-clock latency); empty when the
+ *                         provider does not supply it
  */
 public record LlmScoreResponse(
         Optional<String> disqualifierKey,
         List<CategoryVerdict> categoryVerdicts,
-        List<FlagFinding> flagHits
+        List<FlagFinding> flagHits,
+        Optional<Usage> usage
 ) {
+
+    /**
+     * Convenience constructor for callers that have not yet adopted the
+     * {@code usage} field. Equivalent to supplying {@link Optional#empty()}.
+     *
+     * @param disqualifierKey  see {@link #disqualifierKey()}
+     * @param categoryVerdicts see {@link #categoryVerdicts()}
+     * @param flagHits         see {@link #flagHits()}
+     */
+    public LlmScoreResponse(Optional<String> disqualifierKey,
+                            List<CategoryVerdict> categoryVerdicts,
+                            List<FlagFinding> flagHits) {
+        this(disqualifierKey, categoryVerdicts, flagHits, Optional.empty());
+    }
+
+    /**
+     * Returns a copy with the supplied usage metadata attached.
+     *
+     * @param newUsage usage metadata captured by the adapter
+     * @return a new {@code LlmScoreResponse} with all other fields unchanged
+     */
+    public LlmScoreResponse withUsage(Usage newUsage) {
+        return new LlmScoreResponse(
+                disqualifierKey, categoryVerdicts, flagHits, Optional.ofNullable(newUsage));
+    }
+
+    /**
+     * Provider-supplied call metadata captured by the adapter. All fields are
+     * non-negative; latency is wall-clock around the SDK call (not just network
+     * time). Used for observability metrics — never persisted on the score
+     * report (yet) and never returned to the LLM.
+     *
+     * @param inputTokens  prompt tokens consumed (including cached system prompt)
+     * @param outputTokens completion tokens produced
+     * @param latencyMs    wall-clock duration of the SDK call in milliseconds
+     */
+    public record Usage(long inputTokens, long outputTokens, long latencyMs) { }
+
     /**
      * A single category verdict returned by the LLM.
      *
@@ -98,6 +140,7 @@ public record LlmScoreResponse(
         return new LlmScoreResponse(
                 Optional.ofNullable(disqualifierKey),
                 categoryVerdicts == null ? List.of() : categoryVerdicts,
-                flagHits == null ? List.of() : flagHits);
+                flagHits == null ? List.of() : flagHits,
+                Optional.empty());
     }
 }

--- a/src/test/java/com/majordomo/adapter/out/llm/AnthropicLlmScoringAdapterTest.java
+++ b/src/test/java/com/majordomo/adapter/out/llm/AnthropicLlmScoringAdapterTest.java
@@ -93,6 +93,36 @@ class AnthropicLlmScoringAdapterTest {
     }
 
     @Test
+    void populatesUsageFromSdkResponse() {
+        String innerJson = "{\\\"disqualifierKey\\\":null,"
+                + "\\\"categoryVerdicts\\\":[{\\\"categoryKey\\\":\\\"compensation\\\","
+                + "\\\"tierLabel\\\":\\\"Good\\\",\\\"rationale\\\":\\\"listed salary\\\"}],"
+                + "\\\"flagHits\\\":[]}";
+        server.enqueue(new MockResponse()
+                .setHeader("Content-Type", "application/json")
+                .setBody("""
+                        {
+                          "id": "msg_01",
+                          "type": "message",
+                          "role": "assistant",
+                          "model": "claude-sonnet-4-6",
+                          "stop_reason": "end_turn",
+                          "usage": {"input_tokens": 1234, "output_tokens": 56},
+                          "content": [
+                            {"type": "text", "text": "%s"}
+                          ]
+                        }
+                        """.formatted(innerJson)));
+
+        LlmScoreResponse resp = adapter.score(posting(), rubric());
+
+        assertThat(resp.usage()).isPresent();
+        assertThat(resp.usage().get().inputTokens()).isEqualTo(1234L);
+        assertThat(resp.usage().get().outputTokens()).isEqualTo(56L);
+        assertThat(resp.usage().get().latencyMs()).isGreaterThanOrEqualTo(0L);
+    }
+
+    @Test
     void throwsOnNon2xx() {
         server.enqueue(new MockResponse().setResponseCode(500).setBody("{}"));
         assertThatThrownBy(() -> adapter.score(posting(), rubric()))

--- a/src/test/java/com/majordomo/application/envoy/JobScorerServiceTest.java
+++ b/src/test/java/com/majordomo/application/envoy/JobScorerServiceTest.java
@@ -16,6 +16,8 @@ import com.majordomo.domain.port.out.envoy.JobPostingRepository;
 import com.majordomo.domain.port.out.envoy.LlmScoringPort;
 import com.majordomo.domain.port.out.envoy.RubricRepository;
 import com.majordomo.domain.port.out.envoy.ScoreReportRepository;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -46,6 +48,7 @@ class JobScorerServiceTest {
     @Mock EventPublisher eventPublisher;
 
     private JobScorerService scorer;
+    private MeterRegistry meterRegistry;
     private final UUID orgId = UuidFactory.newId();
 
     private Rubric rubric;
@@ -53,8 +56,10 @@ class JobScorerServiceTest {
 
     @BeforeEach
     void setUp() {
+        meterRegistry = new SimpleMeterRegistry();
         scorer = new JobScorerService(
-                rubrics, postings, reports, llm, new ScoreAssembler(), eventPublisher);
+                rubrics, postings, reports, llm, new ScoreAssembler(),
+                eventPublisher, meterRegistry);
         rubric = new Rubric(UuidFactory.newId(), Optional.empty(), 1, "default",
                 List.of(),
                 List.of(new Category("compensation", "pay", 20,
@@ -162,6 +167,87 @@ class JobScorerServiceTest {
                 .isInstanceOf(IllegalArgumentException.class);
         verify(reports, never()).save(any());
         verify(eventPublisher, never()).publish(any());
+    }
+
+    @Test
+    void recordsTokenAndLatencyMetricsWhenLlmReturnsUsage() {
+        when(postings.findById(posting.getId(), orgId)).thenReturn(Optional.of(posting));
+        when(rubrics.findActiveByName("default", orgId)).thenReturn(Optional.of(rubric));
+        when(llm.score(any(), any())).thenReturn(new LlmScoreResponse(
+                Optional.empty(),
+                List.of(new LlmScoreResponse.CategoryVerdict("compensation", "Good", "listed")),
+                List.of(),
+                Optional.of(new LlmScoreResponse.Usage(123L, 45L, 200L))));
+        when(llm.modelId()).thenReturn("claude-sonnet-4-6");
+        when(reports.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        scorer.score(posting.getId(), "default", orgId);
+
+        double inputTokens = meterRegistry.get("envoy_llm_input_tokens_total")
+                .tag("org", orgId.toString())
+                .tag("model", "claude-sonnet-4-6")
+                .tag("rubric", "default")
+                .counter().count();
+        double outputTokens = meterRegistry.get("envoy_llm_output_tokens_total")
+                .tag("org", orgId.toString())
+                .tag("model", "claude-sonnet-4-6")
+                .tag("rubric", "default")
+                .counter().count();
+        long timerCount = meterRegistry.get("envoy_llm_call_duration")
+                .tag("model", "claude-sonnet-4-6")
+                .tag("outcome", "success")
+                .timer().count();
+
+        assertThat(inputTokens).isEqualTo(123.0);
+        assertThat(outputTokens).isEqualTo(45.0);
+        assertThat(timerCount).isEqualTo(1L);
+    }
+
+    @Test
+    void doesNotIncrementTokenCountersWhenLlmReturnsNoUsage() {
+        when(postings.findById(posting.getId(), orgId)).thenReturn(Optional.of(posting));
+        when(rubrics.findActiveByName("default", orgId)).thenReturn(Optional.of(rubric));
+        when(llm.score(any(), any())).thenReturn(LlmScoreResponse.of(null,
+                List.of(new LlmScoreResponse.CategoryVerdict("compensation", "Good", "listed")),
+                List.of()));
+        when(llm.modelId()).thenReturn("claude-sonnet-4-6");
+        when(reports.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        ScoreReport r = scorer.score(posting.getId(), "default", orgId);
+
+        assertThat(r).isNotNull();
+        // Counters were never registered, so finding them should produce no meter.
+        assertThat(meterRegistry.find("envoy_llm_input_tokens_total").counter()).isNull();
+        assertThat(meterRegistry.find("envoy_llm_output_tokens_total").counter()).isNull();
+        // Timer is always recorded so latency is observable even without token data.
+        long timerCount = meterRegistry.get("envoy_llm_call_duration")
+                .tag("model", "claude-sonnet-4-6")
+                .tag("outcome", "success")
+                .timer().count();
+        assertThat(timerCount).isEqualTo(1L);
+    }
+
+    @Test
+    void recordsErrorOutcomeOnTimerWhenLlmThrows() {
+        when(postings.findById(posting.getId(), orgId)).thenReturn(Optional.of(posting));
+        when(rubrics.findActiveByName("default", orgId)).thenReturn(Optional.of(rubric));
+        when(llm.modelId()).thenReturn("claude-sonnet-4-6");
+        when(llm.score(any(), any())).thenThrow(new LlmScoringException("boom"));
+
+        assertThatThrownBy(() -> scorer.score(posting.getId(), "default", orgId))
+                .isInstanceOf(LlmScoringException.class);
+
+        long errorCount = meterRegistry.get("envoy_llm_call_duration")
+                .tag("model", "claude-sonnet-4-6")
+                .tag("outcome", "error")
+                .timer().count();
+        assertThat(errorCount).isEqualTo(1L);
+        // No success timer was recorded.
+        assertThat(meterRegistry.find("envoy_llm_call_duration")
+                .tag("outcome", "success").timer()).isNull();
+        // No token counters either, since the call never produced a usage payload.
+        assertThat(meterRegistry.find("envoy_llm_input_tokens_total").counter()).isNull();
+        assertThat(meterRegistry.find("envoy_llm_output_tokens_total").counter()).isNull();
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Adds Micrometer counters/timer to `JobScorerService`:
  - `envoy_llm_input_tokens_total{org,model,rubric}`
  - `envoy_llm_output_tokens_total{org,model,rubric}`
  - `envoy_llm_call_duration{model,outcome}`
- Anthropic adapter reads `Usage` from the SDK response and wraps the call in a wall-clock latency measurement, all inside the existing Resilience4j `envoy-llm` circuit-breaker/retry scope.
- Ships a Grafana dashboard at `infra/grafana/dashboards/envoy-llm.json` (tokens/min, p95 latency, spend/hour with configurable per-million prices).

## Scope reduction

The optional persistence/Flyway part of #161 (storing per-report token usage in `envoy_score_report`) is **deferred to a follow-up** — leaving the issue open. This PR uses `Refs #161` for that reason.

## Test Plan

- [x] `JobScorerServiceTest.recordsTokenAndLatencyMetricsWhenLlmReturnsUsage` — counters + timer with correct values + tags via `SimpleMeterRegistry`
- [x] `JobScorerServiceTest.doesNotIncrementTokenCountersWhenLlmReturnsNoUsage`
- [x] `JobScorerServiceTest.recordsErrorOutcomeOnTimerWhenLlmThrows`
- [x] `AnthropicLlmScoringAdapterTest.populatesUsageFromSdkResponse`
- [x] `./mvnw verify` — BUILD SUCCESS, 289 tests, 0 failures, 0 Checkstyle violations

A `@SpringBootTest` integration check against `/actuator/prometheus` was prototyped but dropped: the `RANDOM_PORT` test profile doesn't expose the prometheus endpoint and getting it to do so would have required test-profile config changes outside this PR's scope. The `SimpleMeterRegistry` unit tests already verify metric names, values, and tags directly.

Refs #161

🤖 Generated with [Claude Code](https://claude.com/claude-code)