### PR TITLE
chore: bump testcontainers to 1.21.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
             <dependency>
                 <groupId>org.testcontainers</groupId>
                 <artifactId>testcontainers-bom</artifactId>
-                <version>1.21.3</version>
+                <version>1.21.4</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
## Summary

- Bumps `testcontainers-bom` from `1.21.3` to `1.21.4` in `pom.xml`'s `<dependencyManagement>`.
- Per the [1.21.4 release notes](https://github.com/testcontainers/testcontainers-java/releases/tag/1.21.4): "This release makes version 1.21.x works with recent Docker Engine changes." This restores Docker Desktop 4.6x compatibility on macOS, where `EnvironmentAndSystemPropertyClientProviderStrategy`, `UnixSocketClientProviderStrategy`, and `DockerDesktopClientProviderStrategy` were all returning empty-body `400` from the Docker Desktop CLI-proxy socket.
- Stays on the 1.21.x line rather than jumping to 2.0.x to keep the change minimal and avoid potential breaking changes from the major version bump.

## Test plan

- [x] `./mvnw verify` passes locally (312 tests, 0 failures) — JDK 25 / Temurin
- [x] `./mvnw verify -P integration-tests` passes locally with Docker Desktop running (315 tests, 0 failures — adds `FlywayMigrationIntegrationTest` and `SeedUserIntegrationTest`)
- [x] No `Could not find a valid Docker environment` errors in test output, satisfying issue #124's acceptance criteria
- [ ] CI green on `./mvnw verify` (default profile, no Testcontainers)

Closes #124

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>