### PR TITLE
test(envoy): ArchUnit fitness function for /envoy authorization (closes #174)

### DIFF
--- a/src/test/java/com/majordomo/architecture/EnvoyAuthorizationArchitectureTest.java
+++ b/src/test/java/com/majordomo/architecture/EnvoyAuthorizationArchitectureTest.java
@@ -1,0 +1,159 @@
+package com.majordomo.architecture;
+
+import com.tngtech.archunit.base.DescribedPredicate;
+import com.tngtech.archunit.core.domain.JavaClass;
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.domain.JavaField;
+import com.tngtech.archunit.core.domain.JavaMethod;
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.lang.ArchCondition;
+import com.tngtech.archunit.lang.ArchRule;
+import com.tngtech.archunit.lang.ConditionEvents;
+import com.tngtech.archunit.lang.SimpleConditionEvent;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.methods;
+
+/**
+ * ArchUnit fitness function gating new {@code /envoy} controller routes (issue #174).
+ *
+ * <p>Every HTTP-mapped method on a {@code @Controller} or {@code @RestController}
+ * residing under {@code com.majordomo.adapter.in.web.envoy..} must satisfy at least
+ * one of:
+ *
+ * <ul>
+ *   <li>The owning class declares a field of type
+ *       {@link com.majordomo.application.identity.OrganizationAccessService}.</li>
+ *   <li>The method takes a parameter annotated
+ *       {@code @org.springframework.security.core.annotation.AuthenticationPrincipal}.</li>
+ * </ul>
+ *
+ * <p>HTTP-mapped means annotated with {@code @RequestMapping},
+ * {@code @GetMapping}, {@code @PostMapping}, {@code @PutMapping},
+ * {@code @PatchMapping}, or {@code @DeleteMapping}.
+ *
+ * <p>This rule does <em>not</em> verify the implementation actually calls
+ * {@code verifyAccess} or actually uses the principal &mdash; that is a code
+ * review concern. What it does prevent is silently shipping a new {@code /envoy}
+ * route that has neither hook in place at all.
+ *
+ * <p>Uses plain JUnit Jupiter {@code @Test} methods rather than ArchUnit's
+ * {@code @ArchTest} static-field discovery, which Surefire was silently
+ * skipping (see issue #122).
+ */
+class EnvoyAuthorizationArchitectureTest {
+
+    private static final String CONTROLLER_ANNOTATION =
+            "org.springframework.stereotype.Controller";
+    private static final String REST_CONTROLLER_ANNOTATION =
+            "org.springframework.web.bind.annotation.RestController";
+
+    private static final String AUTHENTICATION_PRINCIPAL_ANNOTATION =
+            "org.springframework.security.core.annotation.AuthenticationPrincipal";
+
+    private static final String ORG_ACCESS_SERVICE =
+            "com.majordomo.application.identity.OrganizationAccessService";
+
+    private static final Set<String> HTTP_MAPPING_ANNOTATIONS = Set.of(
+            "org.springframework.web.bind.annotation.RequestMapping",
+            "org.springframework.web.bind.annotation.GetMapping",
+            "org.springframework.web.bind.annotation.PostMapping",
+            "org.springframework.web.bind.annotation.PutMapping",
+            "org.springframework.web.bind.annotation.PatchMapping",
+            "org.springframework.web.bind.annotation.DeleteMapping");
+
+    private static JavaClasses classes;
+
+    @BeforeAll
+    static void importClasses() {
+        classes = new ClassFileImporter()
+                .withImportOption(new ImportOption.DoNotIncludeTests())
+                .importPackages("com.majordomo");
+    }
+
+    /**
+     * Every HTTP-mapped method on an /envoy controller must be gated by
+     * {@code OrganizationAccessService} on the owning class or
+     * {@code @AuthenticationPrincipal} on the method.
+     */
+    @Test
+    void everyEnvoyControllerRouteIsAuthorized() {
+        ArchRule rule = methods()
+                .that(areDeclaredInEnvoyController())
+                .and(areHttpMapped())
+                .should(beGatedByOrgAccessOrAuthenticationPrincipal());
+
+        rule.check(classes);
+    }
+
+    private static DescribedPredicate<JavaMethod> areDeclaredInEnvoyController() {
+        return new DescribedPredicate<>(
+                "declared in an envoy @Controller or @RestController") {
+            @Override
+            public boolean test(JavaMethod method) {
+                JavaClass owner = method.getOwner();
+                if (!owner.getPackageName()
+                        .startsWith("com.majordomo.adapter.in.web.envoy")) {
+                    return false;
+                }
+                return owner.isAnnotatedWith(CONTROLLER_ANNOTATION)
+                        || owner.isAnnotatedWith(REST_CONTROLLER_ANNOTATION);
+            }
+        };
+    }
+
+    private static DescribedPredicate<JavaMethod> areHttpMapped() {
+        return new DescribedPredicate<>("annotated with a Spring HTTP mapping") {
+            @Override
+            public boolean test(JavaMethod method) {
+                return method.getAnnotations().stream()
+                        .anyMatch(a -> HTTP_MAPPING_ANNOTATIONS.contains(
+                                a.getRawType().getFullName()));
+            }
+        };
+    }
+
+    private static ArchCondition<JavaMethod> beGatedByOrgAccessOrAuthenticationPrincipal() {
+        return new ArchCondition<>(
+                "have an OrganizationAccessService field on the owner OR an "
+                        + "@AuthenticationPrincipal parameter") {
+            @Override
+            public void check(JavaMethod method, ConditionEvents events) {
+                boolean ownerHasOrgAccess = ownerHasOrgAccessField(method.getOwner());
+                boolean methodHasPrincipal = methodHasAuthenticationPrincipalParam(method);
+
+                if (ownerHasOrgAccess || methodHasPrincipal) {
+                    return;
+                }
+
+                String message = String.format(
+                        "Method %s.%s on /envoy controller is not gated: "
+                                + "owner has no OrganizationAccessService field "
+                                + "and method has no @AuthenticationPrincipal "
+                                + "parameter (declared in %s)",
+                        method.getOwner().getSimpleName(),
+                        method.getName(),
+                        method.getSourceCodeLocation());
+                events.add(SimpleConditionEvent.violated(method, message));
+            }
+        };
+    }
+
+    private static boolean ownerHasOrgAccessField(JavaClass owner) {
+        for (JavaField field : owner.getAllFields()) {
+            if (field.getRawType().getFullName().equals(ORG_ACCESS_SERVICE)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean methodHasAuthenticationPrincipalParam(JavaMethod method) {
+        return method.getParameters().stream()
+                .anyMatch(p -> p.isAnnotatedWith(AUTHENTICATION_PRINCIPAL_ANNOTATION));
+    }
+}


### PR DESCRIPTION
Closes #174.

## Summary

- Audited every controller under `com.majordomo.adapter.in.web.envoy..` (7 classes, 14 HTTP-mapped routes).
- **No vulnerabilities found.** All routes are scoped to the authenticated user's organization either via `OrganizationAccessService.verifyAccess(organizationId)` (REST controllers under `/api/envoy/**`) or via an `@AuthenticationPrincipal UserDetails` parameter that resolves the user's first organization and uses it to scope every downstream repository / use case call (Thymeleaf controllers under `/envoy/**`).
- `SecurityConfig` ends in `.anyRequest().authenticated()` and contains no `/envoy` paths in the `permitAll()` allowlist, so anonymous access is impossible.
- Added an ArchUnit fitness function so any new `/envoy` route that bypasses both gates fails the build.

## Route inventory

| Controller | Method | Verb | Path | User identification | Authz mechanism |
|---|---|---|---|---|---|
| `EnvoyComparatorController` | `compare` | GET | `/envoy/compare` | `@AuthenticationPrincipal UserDetails` | `resolveContext(principal)` resolves org from membership; rubric, postings, reports all looked up by `(id, orgId)` so no cross-org leakage |
| `EnvoyPageController` | `envoy` | GET | `/envoy` | `@AuthenticationPrincipal UserDetails` | `resolveContext`; reports listed via `query(orgId, ...)` |
| `EnvoyPageController` | `submitIngest` | POST | `/envoy` | `@AuthenticationPrincipal UserDetails` | `resolveContext`; ingest + score scoped to `orgId` |
| `EnvoyPageController` | `getReport` | GET | `/envoy/reports/{id}` | `@AuthenticationPrincipal UserDetails` | `resolveContext`; `findById(id, orgId)` returns 404 across orgs |
| `RubricAuthorController` | `list` | GET | `/envoy/rubrics` | `@AuthenticationPrincipal UserDetails` | `resolveContext`; `findActiveRubricsForOrg(orgId)` |
| `RubricAuthorController` | `editForm` | GET | `/envoy/rubrics/{name}/edit` | `@AuthenticationPrincipal UserDetails` | `resolveContext`; `findActiveByName(name, orgId)` |
| `RubricAuthorController` | `submit` | POST | `/envoy/rubrics/{name}` | `@AuthenticationPrincipal UserDetails` | `resolveContext`; `saveNewVersion(name, rubric, orgId)` |
| `PostingController` | `ingest` | POST | `/api/envoy/postings` | `OrganizationAccessService` | `verifyAccess(organizationId)` before mutation |
| `PostingController` | `score` | POST | `/api/envoy/postings/{id}/score` | `OrganizationAccessService` | `verifyAccess` + `score(id, rubric, orgId)` |
| `PostingController` | `scoreAll` | POST | `/api/envoy/postings/{id}/score-all` | `OrganizationAccessService` | `verifyAccess` + `scoreAll(id, rubrics, orgId)` |
| `PostingController` | `rescoreAll` | POST | `/api/envoy/postings/rescore` | `OrganizationAccessService` | `verifyAccess` + `findAllByOrganizationId(orgId)` |
| `ReportController` | `list` | GET | `/api/envoy/reports` | `OrganizationAccessService` | `verifyAccess` + `query(orgId, ...)` |
| `ReportController` | `getById` | GET | `/api/envoy/reports/{id}` | `OrganizationAccessService` | `verifyAccess` + `findById(id, orgId)` (404 across orgs) |
| `RubricController` | `putRubric` | PUT | `/api/envoy/rubrics/{name}` | `OrganizationAccessService` | `verifyAccess` + `saveNewVersion(name, rubric, orgId)` |

## Findings

**No vulnerabilities; all routes scoped to authenticated user via `OrganizationAccessService` or `@AuthenticationPrincipal`.**

- No anonymous endpoints. `SecurityConfig.authorizeHttpRequests` permits `/`, `/login`, static assets, Swagger, and selected actuator endpoints; everything else (including all `/envoy/**` and `/api/envoy/**`) hits `.anyRequest().authenticated()`.
- All read endpoints scope by `organizationId`: per-row repository calls use the `(id, orgId)` overload so a report belonging to another org returns `Optional.empty()` (rendered as 404 by the controller, not silently leaked).
- All write endpoints validate ownership before mutating: REST controllers call `organizationAccessService.verifyAccess(organizationId)` first; Thymeleaf controllers derive the org from the principal's membership and never accept an org id from the request.
- No fixes required.

## Fitness function

`src/test/java/com/majordomo/architecture/EnvoyAuthorizationArchitectureTest.java`

Rule: every HTTP-mapped method (`@RequestMapping`, `@GetMapping`, `@PostMapping`, `@PutMapping`, `@PatchMapping`, `@DeleteMapping`) on a class under `com.majordomo.adapter.in.web.envoy..` annotated `@Controller` or `@RestController` must satisfy at least one of:

- the owning class declares a field of type `com.majordomo.application.identity.OrganizationAccessService`, OR
- the method has a parameter annotated `@AuthenticationPrincipal`.

This is a structural check, not a behavioural one — it does not verify the implementation actually calls `verifyAccess` or actually uses the principal (that remains a code-review concern). What it does prevent is silently shipping a new `/envoy` route that has neither hook in place at all. Passes against the current code with no violations.

## Test plan

- [x] `./mvnw test -Dtest=EnvoyAuthorizationArchitectureTest` — green
- [x] `./mvnw test -Dtest=EnvoyAuthorizationArchitectureTest,HexagonalArchitectureTest,NamingConventionTest` — green (all three architecture tests)
- [x] `./mvnw verify` — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)