### PR TITLE
feat(dashboard): surface Envoy APPLY_NOW postings (closes #173)

### DIFF
--- a/src/main/java/com/majordomo/adapter/in/event/CacheEvictionListener.java
+++ b/src/main/java/com/majordomo/adapter/in/event/CacheEvictionListener.java
@@ -1,5 +1,6 @@
 package com.majordomo.adapter.in.event;
 
+import com.majordomo.domain.model.event.JobPostingScored;
 import com.majordomo.domain.model.event.ServiceRecordCreated;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -35,6 +36,18 @@ public class CacheEvictionListener {
     public void onServiceRecordCreated(ServiceRecordCreated event) {
         LOG.debug("Evicting spend cache after service record created");
         evict("spend");
+    }
+
+    /**
+     * Evicts the APPLY_NOW dashboard cache after a posting is scored, so
+     * newly-scored APPLY_NOW postings appear promptly on the dashboard panel.
+     *
+     * @param event the scoring event
+     */
+    @EventListener
+    public void onJobPostingScored(JobPostingScored event) {
+        LOG.debug("Evicting envoy-apply-now cache after posting scored");
+        evict("envoy-apply-now");
     }
 
     private void evict(String cacheName) {

--- a/src/main/java/com/majordomo/adapter/in/web/DashboardPageController.java
+++ b/src/main/java/com/majordomo/adapter/in/web/DashboardPageController.java
@@ -1,6 +1,7 @@
 package com.majordomo.adapter.in.web;
 
 import com.majordomo.domain.port.in.DashboardUseCase;
+import com.majordomo.domain.port.in.envoy.GetRecentApplyNowPostingsUseCase;
 import com.majordomo.domain.port.out.identity.MembershipRepository;
 import com.majordomo.domain.port.out.identity.UserRepository;
 
@@ -16,23 +17,29 @@ import org.springframework.web.bind.annotation.GetMapping;
 @Controller
 public class DashboardPageController {
 
+    private static final int APPLY_NOW_PANEL_LIMIT = 5;
+
     private final DashboardUseCase dashboardUseCase;
     private final UserRepository userRepository;
     private final MembershipRepository membershipRepository;
+    private final GetRecentApplyNowPostingsUseCase recentApplyNowUseCase;
 
     /**
      * Constructs the dashboard page controller.
      *
-     * @param dashboardUseCase     the inbound port for dashboard data retrieval
-     * @param userRepository       the outbound port for user lookups
-     * @param membershipRepository the outbound port for membership lookups
+     * @param dashboardUseCase      the inbound port for dashboard data retrieval
+     * @param userRepository        the outbound port for user lookups
+     * @param membershipRepository  the outbound port for membership lookups
+     * @param recentApplyNowUseCase inbound port for recent APPLY_NOW postings
      */
     public DashboardPageController(DashboardUseCase dashboardUseCase,
                                    UserRepository userRepository,
-                                   MembershipRepository membershipRepository) {
+                                   MembershipRepository membershipRepository,
+                                   GetRecentApplyNowPostingsUseCase recentApplyNowUseCase) {
         this.dashboardUseCase = dashboardUseCase;
         this.userRepository = userRepository;
         this.membershipRepository = membershipRepository;
+        this.recentApplyNowUseCase = recentApplyNowUseCase;
     }
 
     /**
@@ -53,6 +60,8 @@ public class DashboardPageController {
         var summary = dashboardUseCase.getSummary(orgId);
         model.addAttribute("summary", summary);
         model.addAttribute("username", user.getUsername());
+        model.addAttribute("applyNowPostings",
+                recentApplyNowUseCase.getRecentApplyNow(orgId, APPLY_NOW_PANEL_LIMIT));
         return "dashboard";
     }
 }

--- a/src/main/java/com/majordomo/application/envoy/RecentApplyNowQueryService.java
+++ b/src/main/java/com/majordomo/application/envoy/RecentApplyNowQueryService.java
@@ -1,0 +1,57 @@
+package com.majordomo.application.envoy;
+
+import com.majordomo.domain.model.envoy.ApplyNowPosting;
+import com.majordomo.domain.model.envoy.JobPosting;
+import com.majordomo.domain.model.envoy.Recommendation;
+import com.majordomo.domain.model.envoy.ScoreReport;
+import com.majordomo.domain.port.in.envoy.GetRecentApplyNowPostingsUseCase;
+import com.majordomo.domain.port.out.envoy.JobPostingRepository;
+import com.majordomo.domain.port.out.envoy.ScoreReportRepository;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Lists recent APPLY_NOW reports enriched with posting metadata for summary surfaces.
+ * Cached in {@code envoy-apply-now} (5-minute TTL via {@link com.majordomo.adapter.in.web.config.CacheConfig});
+ * the cache is evicted on {@link com.majordomo.domain.model.event.JobPostingScored} so newly-scored APPLY_NOW
+ * postings appear promptly on the dashboard.
+ */
+@Service
+public class RecentApplyNowQueryService implements GetRecentApplyNowPostingsUseCase {
+
+    private final ScoreReportRepository reports;
+    private final JobPostingRepository postings;
+
+    /**
+     * Constructs the service.
+     *
+     * @param reports outbound port for score reports
+     * @param postings outbound port for postings (used to enrich each report)
+     */
+    public RecentApplyNowQueryService(ScoreReportRepository reports, JobPostingRepository postings) {
+        this.reports = reports;
+        this.postings = postings;
+    }
+
+    @Override
+    @Cacheable(value = "envoy-apply-now", key = "#organizationId + ':' + #limit")
+    public List<ApplyNowPosting> getRecentApplyNow(UUID organizationId, int limit) {
+        int clamped = Math.max(1, Math.min(limit, 100));
+        var page = reports.query(organizationId, null, Recommendation.APPLY_NOW, null, clamped);
+        return page.items().stream().map(report -> enrich(report, organizationId)).toList();
+    }
+
+    private ApplyNowPosting enrich(ScoreReport report, UUID organizationId) {
+        JobPosting posting = postings.findById(report.postingId(), organizationId).orElse(null);
+        return new ApplyNowPosting(
+                report.id(),
+                report.postingId(),
+                posting != null ? posting.getCompany() : null,
+                posting != null ? posting.getTitle() : null,
+                posting != null ? posting.getLocation() : null,
+                report.finalScore());
+    }
+}

--- a/src/main/java/com/majordomo/domain/model/envoy/ApplyNowPosting.java
+++ b/src/main/java/com/majordomo/domain/model/envoy/ApplyNowPosting.java
@@ -1,0 +1,22 @@
+package com.majordomo.domain.model.envoy;
+
+import java.util.UUID;
+
+/**
+ * Read-model projection of an APPLY_NOW score report enriched with posting metadata,
+ * for surfaces (e.g. dashboard) that need a flat row without re-joining the posting.
+ *
+ * @param reportId   the underlying {@link ScoreReport} id (target of any link to detail)
+ * @param postingId  the {@link JobPosting} id
+ * @param company    posting company (may be {@code null} if the posting omitted it)
+ * @param title      posting title (may be {@code null})
+ * @param location   posting location (may be {@code null})
+ * @param finalScore the report's final score
+ */
+public record ApplyNowPosting(
+        UUID reportId,
+        UUID postingId,
+        String company,
+        String title,
+        String location,
+        int finalScore) { }

--- a/src/main/java/com/majordomo/domain/port/in/envoy/GetRecentApplyNowPostingsUseCase.java
+++ b/src/main/java/com/majordomo/domain/port/in/envoy/GetRecentApplyNowPostingsUseCase.java
@@ -1,0 +1,23 @@
+package com.majordomo.domain.port.in.envoy;
+
+import com.majordomo.domain.model.envoy.ApplyNowPosting;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Inbound port: list the most recent APPLY_NOW score reports for an organization,
+ * enriched with posting metadata for display on summary surfaces (e.g. the dashboard).
+ */
+public interface GetRecentApplyNowPostingsUseCase {
+
+    /**
+     * Returns the most recent APPLY_NOW reports in the org, newest first, capped at
+     * {@code limit}. Implementations should clamp {@code limit} to a sensible range.
+     *
+     * @param organizationId owning org
+     * @param limit          maximum rows to return
+     * @return list of enriched APPLY_NOW rows (may be empty)
+     */
+    List<ApplyNowPosting> getRecentApplyNow(UUID organizationId, int limit);
+}

--- a/src/main/resources/templates/dashboard.html
+++ b/src/main/resources/templates/dashboard.html
@@ -97,6 +97,36 @@
 
         </div>
 
+        <!-- APPLY_NOW Postings (Envoy) -->
+        <div class="bg-white rounded-lg shadow mb-8">
+            <div class="px-6 py-4 border-b border-gray-200 flex items-center justify-between">
+                <h2 class="text-lg font-semibold text-gray-900">High-priority job postings</h2>
+                <a href="/envoy" class="text-sm text-indigo-600 hover:text-indigo-800">View all &rarr;</a>
+            </div>
+            <div class="p-6">
+                <p th:if="${#lists.isEmpty(applyNowPostings)}" class="text-gray-400 text-sm">
+                    No APPLY_NOW postings yet.
+                </p>
+                <ul class="space-y-3" th:unless="${#lists.isEmpty(applyNowPostings)}">
+                    <li th:each="posting : ${applyNowPostings}"
+                        class="flex items-center justify-between p-3 rounded-md bg-emerald-50 border border-emerald-200">
+                        <div>
+                            <a th:href="@{/envoy/reports/{id}(id=${posting.reportId()})}"
+                               class="font-medium text-gray-800 hover:text-indigo-700"
+                               th:text="${posting.title() != null ? posting.title() : 'Untitled posting'}">Title</a>
+                            <span class="block text-sm text-gray-600">
+                                <span th:text="${posting.company() != null ? posting.company() : '—'}">Company</span>
+                                <span th:if="${posting.location() != null}"
+                                      th:text="' · ' + ${posting.location()}"></span>
+                            </span>
+                        </div>
+                        <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-emerald-100 text-emerald-800"
+                              th:text="${posting.finalScore()} + ' / 100'">90 / 100</span>
+                    </li>
+                </ul>
+            </div>
+        </div>
+
         <!-- Recent Service Records -->
         <div class="bg-white rounded-lg shadow">
             <div class="px-6 py-4 border-b border-gray-200">

--- a/src/test/java/com/majordomo/adapter/in/event/CacheEvictionListenerTest.java
+++ b/src/test/java/com/majordomo/adapter/in/event/CacheEvictionListenerTest.java
@@ -1,5 +1,7 @@
 package com.majordomo.adapter.in.event;
 
+import com.majordomo.domain.model.envoy.Recommendation;
+import com.majordomo.domain.model.event.JobPostingScored;
 import com.majordomo.domain.model.event.ServiceRecordCreated;
 import org.junit.jupiter.api.Test;
 import org.springframework.cache.Cache;
@@ -27,6 +29,21 @@ class CacheEvictionListenerTest {
         var listener = new CacheEvictionListener(cacheManager);
         listener.onServiceRecordCreated(new ServiceRecordCreated(
                 UUID.randomUUID(), UUID.randomUUID(), null, Instant.now()));
+
+        verify(cache).clear();
+    }
+
+    /** APPLY_NOW dashboard cache should be cleared when a posting is scored. */
+    @Test
+    void onJobPostingScoredEvictsApplyNowCache() {
+        var cacheManager = mock(CacheManager.class);
+        var cache = mock(Cache.class);
+        when(cacheManager.getCache("envoy-apply-now")).thenReturn(cache);
+
+        var listener = new CacheEvictionListener(cacheManager);
+        listener.onJobPostingScored(new JobPostingScored(
+                UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID(),
+                85, Recommendation.APPLY_NOW, Instant.now()));
 
         verify(cache).clear();
     }

--- a/src/test/java/com/majordomo/adapter/in/web/DashboardPageControllerTest.java
+++ b/src/test/java/com/majordomo/adapter/in/web/DashboardPageControllerTest.java
@@ -3,10 +3,12 @@ package com.majordomo.adapter.in.web;
 import com.majordomo.adapter.in.web.config.SecurityConfig;
 import com.majordomo.adapter.in.web.config.OAuth2UserService;
 import com.majordomo.domain.model.DashboardSummary;
+import com.majordomo.domain.model.envoy.ApplyNowPosting;
 import com.majordomo.domain.model.identity.Membership;
 import com.majordomo.domain.model.identity.MemberRole;
 import com.majordomo.domain.model.identity.User;
 import com.majordomo.domain.port.in.DashboardUseCase;
+import com.majordomo.domain.port.in.envoy.GetRecentApplyNowPostingsUseCase;
 import com.majordomo.domain.port.out.identity.ApiKeyRepository;
 import com.majordomo.domain.port.out.identity.MembershipRepository;
 import com.majordomo.domain.port.out.identity.UserRepository;
@@ -55,6 +57,9 @@ class DashboardPageControllerTest {
     @MockitoBean
     private OAuth2UserService oAuth2UserService;
 
+    @MockitoBean
+    private GetRecentApplyNowPostingsUseCase recentApplyNowUseCase;
+
     /** Authenticated user with an organization membership sees the dashboard. */
     @Test
     @WithMockUser(username = "testuser")
@@ -67,15 +72,21 @@ class DashboardPageControllerTest {
         DashboardSummary summary = new DashboardSummary(
                 3, 5, List.of(), List.of(), List.of(), new BigDecimal("1200.00"));
 
+        ApplyNowPosting applyNow = new ApplyNowPosting(
+                UUID.randomUUID(), UUID.randomUUID(),
+                "Acme Inc", "Senior Engineer", "Remote", 92);
+
         when(userRepository.findByUsername("testuser")).thenReturn(Optional.of(user));
         when(membershipRepository.findByUserId(userId)).thenReturn(List.of(membership));
         when(dashboardUseCase.getSummary(orgId)).thenReturn(summary);
+        when(recentApplyNowUseCase.getRecentApplyNow(orgId, 5)).thenReturn(List.of(applyNow));
 
         mockMvc.perform(get("/dashboard"))
                 .andExpect(status().isOk())
                 .andExpect(view().name("dashboard"))
                 .andExpect(model().attributeExists("summary"))
-                .andExpect(model().attributeExists("username"));
+                .andExpect(model().attributeExists("username"))
+                .andExpect(model().attributeExists("applyNowPostings"));
     }
 
     /** Unauthenticated access to dashboard redirects to login. */

--- a/src/test/java/com/majordomo/application/envoy/RecentApplyNowQueryServiceTest.java
+++ b/src/test/java/com/majordomo/application/envoy/RecentApplyNowQueryServiceTest.java
@@ -1,0 +1,110 @@
+package com.majordomo.application.envoy;
+
+import com.majordomo.domain.model.Page;
+import com.majordomo.domain.model.envoy.ApplyNowPosting;
+import com.majordomo.domain.model.envoy.JobPosting;
+import com.majordomo.domain.model.envoy.Recommendation;
+import com.majordomo.domain.model.envoy.ScoreReport;
+import com.majordomo.domain.port.out.envoy.JobPostingRepository;
+import com.majordomo.domain.port.out.envoy.ScoreReportRepository;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for {@link RecentApplyNowQueryService}.
+ */
+class RecentApplyNowQueryServiceTest {
+
+    private final ScoreReportRepository reports = mock(ScoreReportRepository.class);
+    private final JobPostingRepository postings = mock(JobPostingRepository.class);
+    private final RecentApplyNowQueryService service = new RecentApplyNowQueryService(reports, postings);
+
+    /** Delegates to the report repo with recommendation = APPLY_NOW and enriches each row from the posting repo. */
+    @Test
+    void enrichesApplyNowReportsWithPostingMetadata() {
+        UUID orgId = UUID.randomUUID();
+        UUID postingId = UUID.randomUUID();
+        UUID reportId = UUID.randomUUID();
+        ScoreReport report = report(reportId, orgId, postingId, 92);
+        when(reports.query(eq(orgId), isNull(), eq(Recommendation.APPLY_NOW), isNull(), eq(5)))
+                .thenReturn(new Page<>(List.of(report), null, false));
+        when(postings.findById(postingId, orgId)).thenReturn(Optional.of(posting(postingId, orgId,
+                "Acme Inc", "Senior Engineer", "Remote")));
+
+        List<ApplyNowPosting> result = service.getRecentApplyNow(orgId, 5);
+
+        assertThat(result).containsExactly(new ApplyNowPosting(
+                reportId, postingId, "Acme Inc", "Senior Engineer", "Remote", 92));
+    }
+
+    /** A missing posting (rare race / hard-deleted) is tolerated: the row still appears with null enrichment. */
+    @Test
+    void tolerantOfMissingPosting() {
+        UUID orgId = UUID.randomUUID();
+        UUID postingId = UUID.randomUUID();
+        UUID reportId = UUID.randomUUID();
+        when(reports.query(eq(orgId), isNull(), eq(Recommendation.APPLY_NOW), isNull(), eq(5)))
+                .thenReturn(new Page<>(List.of(report(reportId, orgId, postingId, 90)), null, false));
+        when(postings.findById(postingId, orgId)).thenReturn(Optional.empty());
+
+        List<ApplyNowPosting> result = service.getRecentApplyNow(orgId, 5);
+
+        assertThat(result).containsExactly(new ApplyNowPosting(
+                reportId, postingId, null, null, null, 90));
+    }
+
+    /** Limit is clamped to [1, 100]. */
+    @Test
+    void clampsLimit() {
+        UUID orgId = UUID.randomUUID();
+        when(reports.query(eq(orgId), isNull(), eq(Recommendation.APPLY_NOW), isNull(), eq(1)))
+                .thenReturn(new Page<>(List.of(), null, false));
+
+        service.getRecentApplyNow(orgId, 0);
+
+        verify(reports).query(eq(orgId), isNull(), eq(Recommendation.APPLY_NOW), isNull(), eq(1));
+    }
+
+    /** Limit above 100 is clamped down. */
+    @Test
+    void clampsHighLimit() {
+        UUID orgId = UUID.randomUUID();
+        when(reports.query(eq(orgId), isNull(), eq(Recommendation.APPLY_NOW), isNull(), eq(100)))
+                .thenReturn(new Page<>(List.of(), null, false));
+
+        service.getRecentApplyNow(orgId, 5000);
+
+        verify(reports).query(eq(orgId), isNull(), eq(Recommendation.APPLY_NOW), isNull(), eq(100));
+    }
+
+    private static ScoreReport report(UUID id, UUID orgId, UUID postingId, int finalScore) {
+        return new ScoreReport(
+                id, orgId, postingId, UUID.randomUUID(), 1,
+                Optional.empty(), List.of(), List.of(),
+                finalScore, finalScore, Recommendation.APPLY_NOW,
+                "claude-test", Instant.parse("2026-04-01T00:00:00Z"));
+    }
+
+    private static JobPosting posting(UUID id, UUID orgId, String company, String title, String location) {
+        JobPosting p = new JobPosting();
+        p.setId(id);
+        p.setOrganizationId(orgId);
+        p.setSource("manual");
+        p.setRawText("body");
+        p.setCompany(company);
+        p.setTitle(title);
+        p.setLocation(location);
+        return p;
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a "High-priority job postings" panel to `/dashboard` listing the top 5 APPLY_NOW score reports for the user's org, linking each to `/envoy/reports/{id}`.
- New read-only use case `GetRecentApplyNowPostingsUseCase` + service `RecentApplyNowQueryService` in `application/envoy/`. Cached in `envoy-apply-now` (Redis, 5-min TTL via existing `CacheConfig`).
- Cache evicted on `JobPostingScored` so newly scored APPLY_NOW postings appear promptly.
- Empty state when there are no APPLY_NOW postings yet.

Out of scope (per issue): filtering out applied/dismissed postings — depends on #170 which is being implemented separately.

Closes #173

## Test plan

- [x] `RecentApplyNowQueryServiceTest` — repo delegation with `Recommendation.APPLY_NOW`, posting enrichment, missing-posting tolerance, limit clamping (low + high).
- [x] `CacheEvictionListenerTest` — new test asserting `JobPostingScored` clears `envoy-apply-now`.
- [x] `DashboardPageControllerTest` — extended to assert `applyNowPostings` model attribute is populated.
- [x] `./mvnw verify` — 331 tests, 0 failures.
- [ ] Manual browser check — not run; safe to verify locally with `docker-compose up -d && ./mvnw spring-boot:run`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)