### PR TITLE
feat(envoy): rubric version A/B comparison (closes #171)

### DIFF
--- a/src/main/java/com/majordomo/adapter/in/web/envoy/RubricComparatorController.java
+++ b/src/main/java/com/majordomo/adapter/in/web/envoy/RubricComparatorController.java
@@ -1,0 +1,99 @@
+package com.majordomo.adapter.in.web.envoy;
+
+import com.majordomo.domain.model.envoy.RubricComparison;
+import com.majordomo.domain.model.identity.User;
+import com.majordomo.domain.port.in.envoy.CompareRubricVersionsUseCase;
+import com.majordomo.domain.port.out.identity.MembershipRepository;
+import com.majordomo.domain.port.out.identity.UserRepository;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.util.UUID;
+
+/**
+ * Renders the rubric A/B comparison page at
+ * {@code /envoy/rubrics/{name}/compare?from=N&to=M&limit=L}. Compares two
+ * versions of the named rubric over the most-recent {@code limit} postings;
+ * results are in-memory only (no live {@code ScoreReport} is overwritten).
+ */
+@Controller
+public class RubricComparatorController {
+
+    /** Default and maximum number of postings to score against each version. */
+    private static final int DEFAULT_LIMIT = 10;
+    private static final int MAX_LIMIT = 50;
+
+    private final CompareRubricVersionsUseCase comparisonUseCase;
+    private final UserRepository userRepository;
+    private final MembershipRepository membershipRepository;
+
+    /** Resolved authentication context. */
+    private record AuthContext(User user, UUID organizationId) { }
+
+    /**
+     * Constructs the controller.
+     *
+     * @param comparisonUseCase    inbound port for rubric comparison
+     * @param userRepository       outbound port for user lookups
+     * @param membershipRepository outbound port for membership lookups
+     */
+    public RubricComparatorController(CompareRubricVersionsUseCase comparisonUseCase,
+                                      UserRepository userRepository,
+                                      MembershipRepository membershipRepository) {
+        this.comparisonUseCase = comparisonUseCase;
+        this.userRepository = userRepository;
+        this.membershipRepository = membershipRepository;
+    }
+
+    /**
+     * Renders the comparison view.
+     *
+     * @param name      rubric name (path variable)
+     * @param from      older version (required)
+     * @param to        newer version (required)
+     * @param limit     posting set size (default 10, capped at 50)
+     * @param principal authenticated user
+     * @param model     Thymeleaf model
+     * @return the {@code rubric-compare} template, or {@code redirect:/} if
+     *         the user has no organization
+     */
+    @GetMapping("/envoy/rubrics/{name}/compare")
+    public String compare(@PathVariable String name,
+                          @RequestParam("from") int from,
+                          @RequestParam("to") int to,
+                          @RequestParam(value = "limit", defaultValue = "" + DEFAULT_LIMIT) int limit,
+                          @AuthenticationPrincipal UserDetails principal,
+                          Model model) {
+        AuthContext ctx = resolveContext(principal);
+        if (ctx.organizationId() == null) {
+            return "redirect:/";
+        }
+        UUID orgId = ctx.organizationId();
+        int clamped = Math.max(1, Math.min(limit, MAX_LIMIT));
+
+        RubricComparison result = comparisonUseCase.compare(name, from, to, clamped, orgId);
+
+        model.addAttribute("rubricName", name);
+        model.addAttribute("fromVersion", from);
+        model.addAttribute("toVersion", to);
+        model.addAttribute("limit", clamped);
+        model.addAttribute("result", result);
+        model.addAttribute("organizationId", orgId);
+        model.addAttribute("username", ctx.user().getUsername());
+        return "rubric-compare";
+    }
+
+    private AuthContext resolveContext(UserDetails principal) {
+        var user = userRepository.findByUsername(principal.getUsername()).orElseThrow();
+        var memberships = membershipRepository.findByUserId(user.getId());
+        if (memberships.isEmpty()) {
+            return new AuthContext(user, null);
+        }
+        return new AuthContext(user, memberships.get(0).getOrganizationId());
+    }
+}

--- a/src/main/java/com/majordomo/adapter/out/persistence/envoy/JobPostingRepositoryAdapter.java
+++ b/src/main/java/com/majordomo/adapter/out/persistence/envoy/JobPostingRepositoryAdapter.java
@@ -2,6 +2,7 @@ package com.majordomo.adapter.out.persistence.envoy;
 
 import com.majordomo.domain.model.envoy.JobPosting;
 import com.majordomo.domain.port.out.envoy.JobPostingRepository;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -44,6 +45,15 @@ public class JobPostingRepositoryAdapter implements JobPostingRepository {
     @Override
     public List<JobPosting> findAllByOrganizationId(UUID organizationId) {
         return jpa.findAllByOrganizationId(organizationId).stream()
+                .map(JobPostingMapper::toDomain)
+                .toList();
+    }
+
+    @Override
+    public List<JobPosting> findRecentByOrganizationId(UUID organizationId, int limit) {
+        int clamped = Math.max(1, Math.min(limit, 100));
+        return jpa.findByOrganizationIdOrderByFetchedAtDesc(organizationId, PageRequest.of(0, clamped))
+                .stream()
                 .map(JobPostingMapper::toDomain)
                 .toList();
     }

--- a/src/main/java/com/majordomo/adapter/out/persistence/envoy/JpaJobPostingRepository.java
+++ b/src/main/java/com/majordomo/adapter/out/persistence/envoy/JpaJobPostingRepository.java
@@ -39,4 +39,15 @@ public interface JpaJobPostingRepository extends JpaRepository<JobPostingEntity,
      * @return every posting in that org (may be empty)
      */
     List<JobPostingEntity> findAllByOrganizationId(UUID organizationId);
+
+    /**
+     * Most-recent postings for an org, ordered by {@code fetched_at} descending.
+     * Used as the default posting set for rubric A/B comparison.
+     *
+     * @param organizationId owning org
+     * @param pageable       page metadata (caller passes a {@code PageRequest.of(0, limit)})
+     * @return matching postings, newest first
+     */
+    List<JobPostingEntity> findByOrganizationIdOrderByFetchedAtDesc(
+            UUID organizationId, org.springframework.data.domain.Pageable pageable);
 }

--- a/src/main/java/com/majordomo/adapter/out/persistence/envoy/JpaRubricRepository.java
+++ b/src/main/java/com/majordomo/adapter/out/persistence/envoy/JpaRubricRepository.java
@@ -54,4 +54,24 @@ public interface JpaRubricRepository extends JpaRepository<RubricEntity, UUID> {
      * @return system-default rows grouped by name with newest version first
      */
     List<RubricEntity> findAllByOrganizationIdIsNullOrderByNameAscVersionDesc();
+
+    /**
+     * Exact-match finder for an org-specific rubric version.
+     *
+     * @param organizationId org scope
+     * @param name           rubric name
+     * @param version        version number
+     * @return the matching org-specific row, if any
+     */
+    Optional<RubricEntity> findByOrganizationIdAndNameAndVersion(
+            UUID organizationId, String name, int version);
+
+    /**
+     * Exact-match finder for a system-default rubric version.
+     *
+     * @param name    rubric name
+     * @param version version number
+     * @return the matching system-default row, if any
+     */
+    Optional<RubricEntity> findByOrganizationIdIsNullAndNameAndVersion(String name, int version);
 }

--- a/src/main/java/com/majordomo/adapter/out/persistence/envoy/RubricRepositoryAdapter.java
+++ b/src/main/java/com/majordomo/adapter/out/persistence/envoy/RubricRepositoryAdapter.java
@@ -74,6 +74,17 @@ public class RubricRepositoryAdapter implements RubricRepository {
     }
 
     @Override
+    public Optional<Rubric> findByOrgNameVersion(String name, int version, UUID organizationId) {
+        Optional<RubricEntity> orgSpecific =
+                jpa.findByOrganizationIdAndNameAndVersion(organizationId, name, version);
+        if (orgSpecific.isPresent()) {
+            return orgSpecific.map(RubricMapper::toDomain);
+        }
+        return jpa.findByOrganizationIdIsNullAndNameAndVersion(name, version)
+                .map(RubricMapper::toDomain);
+    }
+
+    @Override
     public Rubric save(Rubric rubric) {
         return RubricMapper.toDomain(jpa.save(RubricMapper.toEntity(rubric)));
     }

--- a/src/main/java/com/majordomo/application/envoy/RubricComparisonService.java
+++ b/src/main/java/com/majordomo/application/envoy/RubricComparisonService.java
@@ -1,0 +1,119 @@
+package com.majordomo.application.envoy;
+
+import com.majordomo.domain.model.envoy.JobPosting;
+import com.majordomo.domain.model.envoy.LlmScoreResponse;
+import com.majordomo.domain.model.envoy.Recommendation;
+import com.majordomo.domain.model.envoy.Rubric;
+import com.majordomo.domain.model.envoy.RubricComparison;
+import com.majordomo.domain.model.envoy.RubricComparison.PostingComparison;
+import com.majordomo.domain.model.envoy.ScoreReport;
+import com.majordomo.domain.port.in.envoy.CompareRubricVersionsUseCase;
+import com.majordomo.domain.port.out.envoy.JobPostingRepository;
+import com.majordomo.domain.port.out.envoy.LlmScoringPort;
+import com.majordomo.domain.port.out.envoy.RubricRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Runs rubric A/B comparison: re-scores the same posting set against two
+ * versions of a rubric and aggregates the results. Reports produced here are
+ * in-memory only — they do not pass through {@link ScoreReport#id()} assignment
+ * or {@link com.majordomo.domain.port.out.envoy.ScoreReportRepository#save},
+ * so the live report for each posting+rubric pair remains untouched.
+ */
+@Service
+public class RubricComparisonService implements CompareRubricVersionsUseCase {
+
+    /** Hard cap on the posting set; LLM calls are quadratic in (postings × versions). */
+    private static final int MAX_POSTINGS = 50;
+
+    private final RubricRepository rubrics;
+    private final JobPostingRepository postings;
+    private final LlmScoringPort llm;
+    private final ScoreAssembler assembler;
+
+    /**
+     * Constructs the service.
+     *
+     * @param rubrics   outbound port for rubric lookups
+     * @param postings  outbound port for postings
+     * @param llm       outbound LLM scoring port
+     * @param assembler deterministic LLM-response validator
+     */
+    public RubricComparisonService(RubricRepository rubrics,
+                                   JobPostingRepository postings,
+                                   LlmScoringPort llm,
+                                   ScoreAssembler assembler) {
+        this.rubrics = rubrics;
+        this.postings = postings;
+        this.llm = llm;
+        this.assembler = assembler;
+    }
+
+    @Override
+    public RubricComparison compare(String rubricName,
+                                    int fromVersion,
+                                    int toVersion,
+                                    int limit,
+                                    UUID organizationId) {
+        if (fromVersion == toVersion) {
+            throw new IllegalArgumentException(
+                    "fromVersion and toVersion must differ");
+        }
+        Rubric fromRubric = rubrics.findByOrgNameVersion(rubricName, fromVersion, organizationId)
+                .orElseThrow(() -> new IllegalArgumentException(
+                        "Rubric version not found: " + rubricName + " v" + fromVersion));
+        Rubric toRubric = rubrics.findByOrgNameVersion(rubricName, toVersion, organizationId)
+                .orElseThrow(() -> new IllegalArgumentException(
+                        "Rubric version not found: " + rubricName + " v" + toVersion));
+
+        int clampedLimit = Math.max(1, Math.min(limit, MAX_POSTINGS));
+        List<JobPosting> set = postings.findRecentByOrganizationId(organizationId, clampedLimit);
+
+        String modelId = llm.modelId();
+        List<PostingComparison> rows = new ArrayList<>(set.size());
+        Map<Recommendation, Long> fromDist = new EnumMap<>(Recommendation.class);
+        Map<Recommendation, Long> toDist = new EnumMap<>(Recommendation.class);
+        long fromSum = 0;
+        long toSum = 0;
+        long flips = 0;
+
+        for (JobPosting posting : set) {
+            ScoreReport fromReport = scoreFresh(posting, fromRubric, modelId);
+            ScoreReport toReport = scoreFresh(posting, toRubric, modelId);
+            int delta = toReport.finalScore() - fromReport.finalScore();
+            boolean flipped = fromReport.recommendation() != toReport.recommendation();
+            if (flipped) {
+                flips++;
+            }
+            rows.add(new PostingComparison(posting, fromReport, toReport, delta, flipped));
+            fromDist.merge(fromReport.recommendation(), 1L, Long::sum);
+            toDist.merge(toReport.recommendation(), 1L, Long::sum);
+            fromSum += fromReport.finalScore();
+            toSum += toReport.finalScore();
+        }
+
+        double meanFrom = set.isEmpty() ? 0.0 : ((double) fromSum) / set.size();
+        double meanTo = set.isEmpty() ? 0.0 : ((double) toSum) / set.size();
+        return new RubricComparison(
+                rubricName, fromVersion, toVersion, rows,
+                meanFrom, meanTo, fromDist, toDist, flips);
+    }
+
+    /**
+     * Scores a single posting against a rubric and returns an in-memory
+     * {@link ScoreReport} — never persisted, never publishes events, never
+     * touches metrics. Identical assembly path as {@link JobScorerService} so
+     * the resulting fields (categoryScores, finalScore, recommendation) are
+     * directly comparable to live reports.
+     */
+    private ScoreReport scoreFresh(JobPosting posting, Rubric rubric, String modelId) {
+        LlmScoreResponse resp = llm.score(posting, rubric);
+        return assembler.assemble(posting, rubric, resp, modelId);
+    }
+}

--- a/src/main/java/com/majordomo/domain/model/envoy/RubricComparison.java
+++ b/src/main/java/com/majordomo/domain/model/envoy/RubricComparison.java
@@ -1,0 +1,48 @@
+package com.majordomo.domain.model.envoy;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Result of running rubric version A/B comparison: per-posting deltas plus
+ * aggregate stats. Comparison-only — these reports are NOT persisted to
+ * {@code envoy_score_report}; the live report for the current rubric version
+ * remains untouched.
+ *
+ * @param rubricName     the rubric being compared (e.g. "default")
+ * @param fromVersion    the older version number
+ * @param toVersion      the newer version number
+ * @param postings       per-posting comparison rows, in fetched-at-desc order
+ * @param meanFromScore  mean final score across the posting set under {@code fromVersion}
+ * @param meanToScore    mean final score across the posting set under {@code toVersion}
+ * @param fromDistribution recommendation counts under {@code fromVersion}
+ * @param toDistribution   recommendation counts under {@code toVersion}
+ * @param flips          count of postings whose recommendation differed between versions
+ */
+public record RubricComparison(
+        String rubricName,
+        int fromVersion,
+        int toVersion,
+        List<PostingComparison> postings,
+        double meanFromScore,
+        double meanToScore,
+        Map<Recommendation, Long> fromDistribution,
+        Map<Recommendation, Long> toDistribution,
+        long flips) {
+
+    /**
+     * One comparison row: a posting and its (in-memory) score under each rubric version.
+     *
+     * @param posting        the source posting
+     * @param fromReport     score report under {@code fromVersion} (in-memory only, not persisted)
+     * @param toReport       score report under {@code toVersion}   (in-memory only, not persisted)
+     * @param scoreDelta     {@code toReport.finalScore() - fromReport.finalScore()}
+     * @param recommendationFlipped {@code true} when the recommendation differs between versions
+     */
+    public record PostingComparison(
+            JobPosting posting,
+            ScoreReport fromReport,
+            ScoreReport toReport,
+            int scoreDelta,
+            boolean recommendationFlipped) { }
+}

--- a/src/main/java/com/majordomo/domain/port/in/envoy/CompareRubricVersionsUseCase.java
+++ b/src/main/java/com/majordomo/domain/port/in/envoy/CompareRubricVersionsUseCase.java
@@ -1,0 +1,33 @@
+package com.majordomo.domain.port.in.envoy;
+
+import com.majordomo.domain.model.envoy.RubricComparison;
+
+import java.util.UUID;
+
+/**
+ * Inbound port for rubric version A/B comparison. Re-runs scoring against two
+ * arbitrary versions of the same rubric over the most-recent N postings; the
+ * resulting reports are NOT persisted (live {@code ScoreReport} rows are
+ * untouched).
+ */
+public interface CompareRubricVersionsUseCase {
+
+    /**
+     * Compares two versions of {@code rubricName} on the most-recent {@code limit}
+     * postings in {@code organizationId}. Both versions are scored fresh against
+     * each posting; results are aggregated in memory and returned.
+     *
+     * @param rubricName     the rubric to compare (e.g. "default")
+     * @param fromVersion    older version number
+     * @param toVersion      newer version number
+     * @param limit          number of most-recent postings to score (clamped to [1, 50])
+     * @param organizationId owning org
+     * @return aggregated comparison
+     * @throws IllegalArgumentException if either version is missing or {@code from == to}
+     */
+    RubricComparison compare(String rubricName,
+                             int fromVersion,
+                             int toVersion,
+                             int limit,
+                             UUID organizationId);
+}

--- a/src/main/java/com/majordomo/domain/port/out/envoy/JobPostingRepository.java
+++ b/src/main/java/com/majordomo/domain/port/out/envoy/JobPostingRepository.java
@@ -48,4 +48,15 @@ public interface JobPostingRepository {
      * @return every posting in that org (may be empty)
      */
     List<JobPosting> findAllByOrganizationId(UUID organizationId);
+
+    /**
+     * Returns the most recently fetched postings for an organization, newest first,
+     * capped at {@code limit}. Used as a default posting set for rubric A/B
+     * comparison.
+     *
+     * @param organizationId owning org
+     * @param limit          maximum number of postings to return
+     * @return most-recent postings in that org, newest first
+     */
+    List<JobPosting> findRecentByOrganizationId(UUID organizationId, int limit);
 }

--- a/src/main/java/com/majordomo/domain/port/out/envoy/RubricRepository.java
+++ b/src/main/java/com/majordomo/domain/port/out/envoy/RubricRepository.java
@@ -54,6 +54,19 @@ public interface RubricRepository {
     List<Rubric> findActiveRubricsForOrg(UUID organizationId);
 
     /**
+     * Finds a specific rubric version by {@code (organizationId, name, version)}.
+     * Prefers an org-specific row; falls back to the system default
+     * ({@code organization_id IS NULL}) for the same {@code (name, version)}.
+     * Returned rubric retains its true {@code organizationId} (empty for system default).
+     *
+     * @param name           logical rubric name
+     * @param version        version number to fetch
+     * @param organizationId org scope for the lookup
+     * @return the matching rubric, or empty if neither org-specific nor system default exists
+     */
+    Optional<Rubric> findByOrgNameVersion(String name, int version, UUID organizationId);
+
+    /**
      * Persists a rubric. Caller is responsible for setting id, version, and effectiveFrom.
      *
      * @param rubric the rubric to persist

--- a/src/main/resources/templates/rubric-compare.html
+++ b/src/main/resources/templates/rubric-compare.html
@@ -1,0 +1,131 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org"
+      xmlns:sec="http://www.thymeleaf.org/extras/spring-security"
+      lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Rubric compare - Majordomo</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-gray-100 min-h-screen">
+
+    <div th:replace="~{fragments/header :: header}"></div>
+
+    <div class="flex min-h-screen">
+        <div th:replace="~{fragments/sidebar :: sidebar('envoy')}"></div>
+
+        <main class="flex-1 p-6">
+
+            <!-- Breadcrumb -->
+            <nav class="mb-4" aria-label="Breadcrumb">
+                <ol class="flex items-center space-x-2 text-sm text-gray-500">
+                    <li><a th:href="@{/envoy/rubrics}" class="hover:text-indigo-600 transition">Rubrics</a></li>
+                    <li class="flex items-center space-x-2">
+                        <span>&rsaquo;</span>
+                        <span class="text-gray-900 font-medium"
+                              th:text="${rubricName} + ' v' + ${fromVersion} + ' vs v' + ${toVersion}">Compare</span>
+                    </li>
+                </ol>
+            </nav>
+
+            <!-- Header -->
+            <div class="bg-white rounded-lg shadow mb-6 px-6 py-5">
+                <h1 class="text-2xl font-bold text-gray-900"
+                    th:text="'Rubric ' + ${rubricName} + ': v' + ${fromVersion} + ' vs v' + ${toVersion}">
+                    Rubric compare
+                </h1>
+                <p class="mt-1 text-sm text-gray-600"
+                   th:text="'Scored against the ' + ${limit} + ' most recently ingested postings (in-memory only — live reports unchanged).'">
+                    Scoring against last N postings.
+                </p>
+            </div>
+
+            <!-- Aggregate stats -->
+            <div class="grid grid-cols-1 sm:grid-cols-3 gap-6 mb-8">
+                <div class="bg-white rounded-lg shadow p-6">
+                    <div class="text-xs font-medium text-gray-500 uppercase tracking-wide">Mean score</div>
+                    <div class="mt-2 text-2xl font-bold text-indigo-700">
+                        <span th:text="${#numbers.formatDecimal(result.meanFromScore(), 1, 1)}">0.0</span>
+                        <span class="mx-2 text-gray-400">&rarr;</span>
+                        <span th:text="${#numbers.formatDecimal(result.meanToScore(), 1, 1)}">0.0</span>
+                    </div>
+                    <div class="mt-1 text-xs text-gray-500"
+                         th:text="'v' + ${fromVersion} + ' &rarr; v' + ${toVersion}">v1 -> v2</div>
+                </div>
+                <div class="bg-white rounded-lg shadow p-6">
+                    <div class="text-xs font-medium text-gray-500 uppercase tracking-wide">Recommendation flips</div>
+                    <div class="mt-2 text-3xl font-bold text-amber-700"
+                         th:text="${result.flips()}">0</div>
+                    <div class="mt-1 text-xs text-gray-500"
+                         th:text="'across ' + ${#lists.size(result.postings())} + ' postings'">across N postings</div>
+                </div>
+                <div class="bg-white rounded-lg shadow p-6">
+                    <div class="text-xs font-medium text-gray-500 uppercase tracking-wide">Distribution shift</div>
+                    <ul class="mt-2 space-y-1 text-sm">
+                        <li th:each="rec : ${T(com.majordomo.domain.model.envoy.Recommendation).values()}">
+                            <span class="font-medium text-gray-700" th:text="${rec}">REC</span>
+                            <span class="text-gray-600"
+                                  th:text="${(result.fromDistribution().get(rec) ?: 0)} + ' &rarr; '
+                                          + ${(result.toDistribution().get(rec) ?: 0)}">0 -> 0</span>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+
+            <!-- Per-posting deltas -->
+            <div class="bg-white rounded-lg shadow">
+                <div class="px-6 py-4 border-b border-gray-200">
+                    <h2 class="text-lg font-semibold text-gray-900">Per-posting deltas</h2>
+                </div>
+                <div class="p-0">
+                    <p th:if="${#lists.isEmpty(result.postings())}" class="p-6 text-gray-400 text-sm">
+                        No postings in the comparison set.
+                    </p>
+                    <table th:unless="${#lists.isEmpty(result.postings())}"
+                           class="min-w-full divide-y divide-gray-200">
+                        <thead class="bg-gray-50">
+                            <tr>
+                                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Posting</th>
+                                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+                                    th:text="'v' + ${fromVersion}">v1</th>
+                                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+                                    th:text="'v' + ${toVersion}">v2</th>
+                                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">&Delta;</th>
+                                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Recommendation</th>
+                            </tr>
+                        </thead>
+                        <tbody class="bg-white divide-y divide-gray-200">
+                            <tr th:each="row : ${result.postings()}">
+                                <td class="px-6 py-3 text-sm text-gray-700">
+                                    <span class="font-medium"
+                                          th:text="${row.posting().getCompany() != null ? row.posting().getCompany() : '—'}">Company</span>
+                                    <span class="block text-xs text-gray-500"
+                                          th:text="${row.posting().getTitle() != null ? row.posting().getTitle() : '—'}">Title</span>
+                                </td>
+                                <td class="px-6 py-3 text-sm text-gray-700"
+                                    th:text="${row.fromReport().finalScore()} + ' (' + ${row.fromReport().recommendation()} + ')'">0</td>
+                                <td class="px-6 py-3 text-sm text-gray-700"
+                                    th:text="${row.toReport().finalScore()} + ' (' + ${row.toReport().recommendation()} + ')'">0</td>
+                                <td class="px-6 py-3 text-sm font-semibold"
+                                    th:classappend="${row.scoreDelta() > 0} ? 'text-emerald-700' :
+                                                   (${row.scoreDelta() < 0} ? 'text-red-700' : 'text-gray-500')"
+                                    th:text="${row.scoreDelta() > 0 ? '+' + row.scoreDelta() : row.scoreDelta()}">0</td>
+                                <td class="px-6 py-3 text-sm">
+                                    <span th:if="${row.recommendationFlipped()}"
+                                          class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-amber-100 text-amber-800">
+                                        flipped
+                                    </span>
+                                    <span th:unless="${row.recommendationFlipped()}"
+                                          class="text-gray-400 text-xs">unchanged</span>
+                                </td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+
+        </main>
+    </div>
+</body>
+</html>

--- a/src/test/java/com/majordomo/adapter/in/web/envoy/RubricComparatorControllerTest.java
+++ b/src/test/java/com/majordomo/adapter/in/web/envoy/RubricComparatorControllerTest.java
@@ -1,0 +1,119 @@
+package com.majordomo.adapter.in.web.envoy;
+
+import com.majordomo.adapter.in.web.config.OAuth2UserService;
+import com.majordomo.adapter.in.web.config.SecurityConfig;
+import com.majordomo.domain.model.UuidFactory;
+import com.majordomo.domain.model.envoy.Recommendation;
+import com.majordomo.domain.model.envoy.RubricComparison;
+import com.majordomo.domain.model.identity.Membership;
+import com.majordomo.domain.model.identity.User;
+import com.majordomo.domain.port.in.envoy.CompareRubricVersionsUseCase;
+import com.majordomo.domain.port.out.identity.ApiKeyRepository;
+import com.majordomo.domain.port.out.identity.MembershipRepository;
+import com.majordomo.domain.port.out.identity.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.model;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
+
+/**
+ * Tests for {@link RubricComparatorController}.
+ */
+@WebMvcTest(RubricComparatorController.class)
+@Import(SecurityConfig.class)
+class RubricComparatorControllerTest {
+
+    @Autowired MockMvc mvc;
+
+    @MockitoBean CompareRubricVersionsUseCase comparisonUseCase;
+    @MockitoBean UserRepository userRepository;
+    @MockitoBean MembershipRepository membershipRepository;
+    @MockitoBean ApiKeyRepository apiKeyRepository;
+    @MockitoBean OAuth2UserService oAuth2UserService;
+
+    private static final UUID ORG_ID = UuidFactory.newId();
+
+    /** Renders the rubric-compare template populated from the use case result. */
+    @Test
+    @WithMockUser(username = "robsartin")
+    void rendersComparisonPage() throws Exception {
+        var user = new User(UuidFactory.newId(), "robsartin", "rob@example.com");
+        var membership = new Membership();
+        membership.setUserId(user.getId());
+        membership.setOrganizationId(ORG_ID);
+        when(userRepository.findByUsername("robsartin")).thenReturn(Optional.of(user));
+        when(membershipRepository.findByUserId(user.getId())).thenReturn(List.of(membership));
+
+        RubricComparison result = new RubricComparison(
+                "default", 1, 2, List.of(),
+                75.0, 80.0, new EnumMap<>(Recommendation.class), new EnumMap<>(Recommendation.class), 0L);
+        when(comparisonUseCase.compare("default", 1, 2, 10, ORG_ID)).thenReturn(result);
+
+        mvc.perform(get("/envoy/rubrics/{name}/compare", "default")
+                        .param("from", "1")
+                        .param("to", "2"))
+                .andExpect(status().isOk())
+                .andExpect(view().name("rubric-compare"))
+                .andExpect(model().attribute("rubricName", "default"))
+                .andExpect(model().attribute("fromVersion", 1))
+                .andExpect(model().attribute("toVersion", 2))
+                .andExpect(model().attribute("limit", 10))
+                .andExpect(model().attribute("result", result));
+
+        verify(comparisonUseCase).compare("default", 1, 2, 10, ORG_ID);
+    }
+
+    /** Limit query parameter is clamped to 50 max. */
+    @Test
+    @WithMockUser(username = "robsartin")
+    void clampsLimitParameter() throws Exception {
+        var user = new User(UuidFactory.newId(), "robsartin", "rob@example.com");
+        var membership = new Membership();
+        membership.setUserId(user.getId());
+        membership.setOrganizationId(ORG_ID);
+        when(userRepository.findByUsername("robsartin")).thenReturn(Optional.of(user));
+        when(membershipRepository.findByUserId(user.getId())).thenReturn(List.of(membership));
+
+        RubricComparison result = new RubricComparison(
+                "default", 1, 2, List.of(),
+                0.0, 0.0, new EnumMap<>(Recommendation.class), new EnumMap<>(Recommendation.class), 0L);
+        when(comparisonUseCase.compare(eq("default"), eq(1), eq(2), eq(50), eq(ORG_ID))).thenReturn(result);
+
+        mvc.perform(get("/envoy/rubrics/{name}/compare", "default")
+                        .param("from", "1").param("to", "2").param("limit", "9999"))
+                .andExpect(status().isOk());
+
+        verify(comparisonUseCase).compare("default", 1, 2, 50, ORG_ID);
+    }
+
+    /** Unauthenticated request redirects to login. */
+    @Test
+    void requiresAuthentication() throws Exception {
+        mvc.perform(get("/envoy/rubrics/{name}/compare", "default")
+                        .param("from", "1").param("to", "2"))
+                .andExpect(status().is3xxRedirection());
+        verify(comparisonUseCase, never()).compare(
+                org.mockito.ArgumentMatchers.any(),
+                org.mockito.ArgumentMatchers.anyInt(),
+                org.mockito.ArgumentMatchers.anyInt(),
+                org.mockito.ArgumentMatchers.anyInt(),
+                org.mockito.ArgumentMatchers.any());
+    }
+}

--- a/src/test/java/com/majordomo/application/envoy/RubricComparisonServiceTest.java
+++ b/src/test/java/com/majordomo/application/envoy/RubricComparisonServiceTest.java
@@ -1,0 +1,194 @@
+package com.majordomo.application.envoy;
+
+import com.majordomo.domain.model.envoy.JobPosting;
+import com.majordomo.domain.model.envoy.LlmScoreResponse;
+import com.majordomo.domain.model.envoy.Recommendation;
+import com.majordomo.domain.model.envoy.Rubric;
+import com.majordomo.domain.model.envoy.RubricComparison;
+import com.majordomo.domain.model.envoy.ScoreReport;
+import com.majordomo.domain.model.envoy.Thresholds;
+import com.majordomo.domain.port.out.envoy.JobPostingRepository;
+import com.majordomo.domain.port.out.envoy.LlmScoringPort;
+import com.majordomo.domain.port.out.envoy.RubricRepository;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for {@link RubricComparisonService}.
+ */
+class RubricComparisonServiceTest {
+
+    private static final String RUBRIC_NAME = "default";
+    private static final UUID ORG_ID = UUID.randomUUID();
+
+    private final RubricRepository rubrics = mock(RubricRepository.class);
+    private final JobPostingRepository postings = mock(JobPostingRepository.class);
+    private final LlmScoringPort llm = mock(LlmScoringPort.class);
+    private final ScoreAssembler assembler = mock(ScoreAssembler.class);
+    private final RubricComparisonService service =
+            new RubricComparisonService(rubrics, postings, llm, assembler);
+
+    /** Happy path: two postings, two rubric versions, deltas + aggregates computed correctly. */
+    @Test
+    void comparesTwoVersionsAcrossPostingSet() {
+        Rubric v1 = rubric(1);
+        Rubric v2 = rubric(2);
+        when(rubrics.findByOrgNameVersion(RUBRIC_NAME, 1, ORG_ID)).thenReturn(Optional.of(v1));
+        when(rubrics.findByOrgNameVersion(RUBRIC_NAME, 2, ORG_ID)).thenReturn(Optional.of(v2));
+
+        JobPosting p1 = posting();
+        JobPosting p2 = posting();
+        when(postings.findRecentByOrganizationId(ORG_ID, 50)).thenReturn(List.of(p1, p2));
+        when(llm.modelId()).thenReturn("claude-test");
+        when(llm.score(any(), any())).thenReturn(mock(LlmScoreResponse.class));
+
+        // p1: 60 -> 80 (CONSIDER -> APPLY) = flip
+        // p2: 90 -> 70 (APPLY_NOW -> APPLY)  = flip
+        ScoreReport p1v1 = score(p1, v1, 60, Recommendation.CONSIDER);
+        ScoreReport p1v2 = score(p1, v2, 80, Recommendation.APPLY);
+        ScoreReport p2v1 = score(p2, v1, 90, Recommendation.APPLY_NOW);
+        ScoreReport p2v2 = score(p2, v2, 70, Recommendation.APPLY);
+        when(assembler.assemble(eq(p1), eq(v1), any(), any())).thenReturn(p1v1);
+        when(assembler.assemble(eq(p1), eq(v2), any(), any())).thenReturn(p1v2);
+        when(assembler.assemble(eq(p2), eq(v1), any(), any())).thenReturn(p2v1);
+        when(assembler.assemble(eq(p2), eq(v2), any(), any())).thenReturn(p2v2);
+
+        RubricComparison result = service.compare(RUBRIC_NAME, 1, 2, 50, ORG_ID);
+
+        assertThat(result.rubricName()).isEqualTo(RUBRIC_NAME);
+        assertThat(result.fromVersion()).isEqualTo(1);
+        assertThat(result.toVersion()).isEqualTo(2);
+        assertThat(result.postings()).hasSize(2);
+        assertThat(result.postings().get(0).scoreDelta()).isEqualTo(20);
+        assertThat(result.postings().get(0).recommendationFlipped()).isTrue();
+        assertThat(result.postings().get(1).scoreDelta()).isEqualTo(-20);
+        assertThat(result.postings().get(1).recommendationFlipped()).isTrue();
+        assertThat(result.flips()).isEqualTo(2);
+        assertThat(result.meanFromScore()).isEqualTo(75.0);
+        assertThat(result.meanToScore()).isEqualTo(75.0);
+        assertThat(result.fromDistribution()).containsEntry(Recommendation.CONSIDER, 1L)
+                .containsEntry(Recommendation.APPLY_NOW, 1L);
+        assertThat(result.toDistribution()).containsEntry(Recommendation.APPLY, 2L);
+    }
+
+    /** Live ScoreReport persistence is never invoked — comparison is in-memory only. */
+    @Test
+    void doesNotPersistReports() {
+        Rubric v1 = rubric(1);
+        Rubric v2 = rubric(2);
+        when(rubrics.findByOrgNameVersion(RUBRIC_NAME, 1, ORG_ID)).thenReturn(Optional.of(v1));
+        when(rubrics.findByOrgNameVersion(RUBRIC_NAME, 2, ORG_ID)).thenReturn(Optional.of(v2));
+        when(postings.findRecentByOrganizationId(any(), any(Integer.class))).thenReturn(List.of());
+        when(llm.modelId()).thenReturn("claude-test");
+
+        service.compare(RUBRIC_NAME, 1, 2, 50, ORG_ID);
+
+        // No save methods on these mocks should ever be called.
+        verify(postings, never()).save(any());
+        verify(rubrics, never()).save(any());
+    }
+
+    /** Missing fromVersion throws IllegalArgumentException. */
+    @Test
+    void throwsWhenFromVersionMissing() {
+        when(rubrics.findByOrgNameVersion(RUBRIC_NAME, 1, ORG_ID)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.compare(RUBRIC_NAME, 1, 2, 50, ORG_ID))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("v1");
+    }
+
+    /** Missing toVersion throws IllegalArgumentException. */
+    @Test
+    void throwsWhenToVersionMissing() {
+        when(rubrics.findByOrgNameVersion(RUBRIC_NAME, 1, ORG_ID)).thenReturn(Optional.of(rubric(1)));
+        when(rubrics.findByOrgNameVersion(RUBRIC_NAME, 2, ORG_ID)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.compare(RUBRIC_NAME, 1, 2, 50, ORG_ID))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("v2");
+    }
+
+    /** Comparing a version against itself is rejected. */
+    @Test
+    void throwsWhenVersionsAreEqual() {
+        assertThatThrownBy(() -> service.compare(RUBRIC_NAME, 3, 3, 50, ORG_ID))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    /** Limit is clamped to [1, 50]. */
+    @Test
+    void clampsLimit() {
+        Rubric v1 = rubric(1);
+        Rubric v2 = rubric(2);
+        when(rubrics.findByOrgNameVersion(RUBRIC_NAME, 1, ORG_ID)).thenReturn(Optional.of(v1));
+        when(rubrics.findByOrgNameVersion(RUBRIC_NAME, 2, ORG_ID)).thenReturn(Optional.of(v2));
+        when(postings.findRecentByOrganizationId(eq(ORG_ID), eq(50))).thenReturn(List.of());
+        when(llm.modelId()).thenReturn("claude-test");
+
+        service.compare(RUBRIC_NAME, 1, 2, 9999, ORG_ID);
+
+        verify(postings).findRecentByOrganizationId(ORG_ID, 50);
+    }
+
+    /** Empty posting set returns zero-state aggregates without calling the LLM. */
+    @Test
+    void emptyPostingSetReturnsZeroState() {
+        Rubric v1 = rubric(1);
+        Rubric v2 = rubric(2);
+        when(rubrics.findByOrgNameVersion(RUBRIC_NAME, 1, ORG_ID)).thenReturn(Optional.of(v1));
+        when(rubrics.findByOrgNameVersion(RUBRIC_NAME, 2, ORG_ID)).thenReturn(Optional.of(v2));
+        when(postings.findRecentByOrganizationId(any(), any(Integer.class))).thenReturn(List.of());
+        when(llm.modelId()).thenReturn("claude-test");
+
+        RubricComparison result = service.compare(RUBRIC_NAME, 1, 2, 10, ORG_ID);
+
+        assertThat(result.postings()).isEmpty();
+        assertThat(result.flips()).isZero();
+        assertThat(result.meanFromScore()).isZero();
+        assertThat(result.meanToScore()).isZero();
+        verify(llm, never()).score(any(), any());
+    }
+
+    private static Rubric rubric(int version) {
+        return new Rubric(
+                UUID.randomUUID(),
+                Optional.of(ORG_ID),
+                version,
+                RUBRIC_NAME,
+                List.of(),
+                List.of(),
+                List.of(),
+                new Thresholds(85, 70, 50),
+                Instant.parse("2026-01-01T00:00:00Z"));
+    }
+
+    private static JobPosting posting() {
+        JobPosting p = new JobPosting();
+        p.setId(UUID.randomUUID());
+        p.setOrganizationId(ORG_ID);
+        p.setSource("manual");
+        p.setRawText("body");
+        return p;
+    }
+
+    private static ScoreReport score(JobPosting p, Rubric r, int finalScore, Recommendation rec) {
+        return new ScoreReport(
+                UUID.randomUUID(), ORG_ID, p.getId(), r.id(), r.version(),
+                Optional.empty(), List.of(), List.of(),
+                finalScore, finalScore, rec, "claude-test", Instant.now());
+    }
+}


### PR DESCRIPTION
## Summary

Adds `/envoy/rubrics/{name}/compare?from=N&to=M&limit=L`: re-scores the most-recent L postings against two versions of the named rubric and surfaces per-posting deltas, mean score, recommendation distribution, and recommendation flip count. Comparison is in-memory only — live `ScoreReport` rows for the current version are untouched.

The append-only `envoy_rubric` table (V14) already preserves version history; the new finder `RubricRepository.findByOrgNameVersion` resolves an org-specific row when present and falls back to the system default for the same `(name, version)`. The current rubric author UI's auto-activate-latest behavior is preserved.

Posting set: most-recent L (default 10, capped at 50). Saved sets are out of scope; followup will be filed if needed.

Closes #171

## What changed

- **Domain**: new `RubricComparison` (record) + nested `PostingComparison` row.
- **Ports**: `RubricRepository.findByOrgNameVersion(...)` and `JobPostingRepository.findRecentByOrganizationId(...)`.
- **Application**: `RubricComparisonService` (implements `CompareRubricVersionsUseCase`), reusing `LlmScoringPort` + `ScoreAssembler` so produced rows are directly comparable to live reports.
- **Web**: `RubricComparatorController` + `rubric-compare.html` (Tailwind, mirrors structure of `EnvoyComparatorController`).

## Test plan

- [x] `RubricComparisonServiceTest` (7 tests): per-posting deltas, aggregate stats, no persistence, missing-version errors, equal-version rejection, limit clamping (high), empty posting set.
- [x] `RubricComparatorControllerTest` (3 tests): renders template with model, clamps `limit` query param, requires authentication.
- [x] `./mvnw verify` — 352 tests, 0 failures.
- [ ] Manual browser check — not run; verify locally with `docker-compose up -d && ./mvnw spring-boot:run`.

## Notes

- Comparison runs `2 × L` LLM calls. Default L=10 keeps a typical run cheap; cap of 50 prevents accidental cost blowups. No metrics tag this volume — the use case is human-triggered and rare, and the existing `envoy_llm_*` token counters already cover token cost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)