### PR TITLE
chore: cleanup pass — resolve stale TODO reference (closes #179)

### DIFF
--- a/src/main/java/com/majordomo/adapter/in/web/herald/ScheduleController.java
+++ b/src/main/java/com/majordomo/adapter/in/web/herald/ScheduleController.java
@@ -35,7 +35,7 @@ import java.util.UUID;
  *
  * <p>TODO: Schedules are scoped by propertyId, not organizationId directly. Organization-level
  * access control should be enforced by resolving the property's organization and verifying
- * membership. See GitHub issue #55.</p>
+ * membership. Tracked in issue #184.</p>
  */
 @RestController
 @RequestMapping("/api/schedules")


### PR DESCRIPTION
## Summary

Cleanup inspection pass per #179. The codebase is in good shape — the existing toolchain (Checkstyle for unused imports, visibility, and length; ArchUnit for layer boundaries) already covers most of what the issue's checklist would catch.

**What I found:**

| Check | Result |
|---|---|
| Stale TODOs / FIXMEs | **1** (only in `ScheduleController.java`) |
| Commented-out code blocks | None |
| Wildcard imports | None |
| Unused `@SuppressWarnings` | The one in `LocalFileStorageAdapter` is a Resilience4j fallback method (called via reflection) — legitimate |
| `mvn dependency:analyze` | Plugin can't read Java 25 bytecode (major version 69); skipped |

**What this PR does:**

- The TODO in `ScheduleController` referenced closed issue #55, which was scoped broadly and didn't actually fix the Herald API's org-scoping gap. Filed a fresh narrow issue (**#184**) and updated the in-code reference so a reader can find live tracking.

**What I deliberately did not bundle:**

- Fixing the Herald org-scoping gap itself (it's a real auth issue — belongs in #184, not in a "cleanup" PR per the issue's guidance: "If a finding requires meaningful design change, file a follow-up instead of bundling.").
- Any visibility tightening or method removal — Checkstyle is already enforcing.

Closes #179

## Test plan

- [x] `./mvnw validate` — green (Checkstyle clean).
- [x] No production code or behavior changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)