### PR TITLE
chore(coverage): add JaCoCo + baseline (closes #177)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,9 +78,11 @@ JSON under `/api/envoy`.
 ./mvnw validate          # Checkstyle only
 ./mvnw compile           # Compile
 ./mvnw test              # Run tests
-./mvnw verify            # Full build (compile + checkstyle + test)
+./mvnw verify            # Full build (compile + checkstyle + test + JaCoCo report)
 ./mvnw spring-boot:run   # Start app (requires PostgreSQL + Redis)
 ```
+
+JaCoCo writes a coverage report to `target/site/jacoco/index.html` after `verify`. Integration tests (`*IntegrationTest.java`) are excluded from the default Surefire run, so persistence-adapter coverage in the report under-represents what is actually tested — see issue #189 to merge integration-test data into the report.
 
 ## Known Trade-offs
 

--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,7 @@
         <java.version>25</java.version>
         <springdoc.version>2.8.6</springdoc.version>
         <checkstyle.version>10.21.4</checkstyle.version>
+        <jacoco.version>0.8.13</jacoco.version>
     </properties>
 
     <dependencyManagement>
@@ -195,6 +196,26 @@
                         <exclude>**/*IntegrationTest.java</exclude>
                     </excludes>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>${jacoco.version}</version>
+                <executions>
+                    <execution>
+                        <id>jacoco-prepare</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>jacoco-report</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
## Summary

Adds JaCoCo to the Maven build. `./mvnw verify` now produces an HTML coverage report at `target/site/jacoco/index.html` (and a CSV at `target/site/jacoco/jacoco.csv`). No threshold is enforced — first-pass goal is just to establish a baseline so gaps are visible.

CLAUDE.md updated with the report path and the integration-test caveat.

Closes #177

## Baseline (overall: 66.9% line coverage)

**Highest coverage** — domain models and application services already at 90%+:
- `domain.model` — 97.2%
- `application.steward` — 96.4%
- `application` — 96.2%
- `adapter.in.web.envoy` — 94.2%
- `application.herald` — 92.8%
- `domain.model.concierge` — 92.5%
- `adapter.in.event` — 92.2%

**Real gaps (web slice tests missing):**
- `adapter.in.web.herald` — 13.0% → filed **#186**
- `adapter.in.web.identity` — 21.9% → filed **#187**
- `adapter.in.web.ledger` — 38.5% → filed **#188** (jointly with concierge)
- `adapter.in.web.concierge` — 52.2% → filed **#188**

**Artifact of integration-test exclusion** (filed **#189** to merge integration coverage):
- `adapter.out.persistence.concierge` — 2.5%
- `adapter.out.persistence.steward` — 4.1%
- `adapter.out.persistence.attachment` — 4.2%
- `adapter.out.persistence.herald` — 4.4%
- `adapter.out.persistence.identity` — 7.6%

These persistence adapters are exercised by Testcontainers `*IntegrationTest.java` files, which Surefire excludes by default. The numbers will look very different once #189 lands.

## Test plan

- [x] `./mvnw verify` — 352 tests, 0 failures, JaCoCo report generated.
- [x] `target/site/jacoco/` confirmed populated (HTML + CSV + exec).
- [x] Reviewed per-package CSV for the 5 worst non-artifact gaps; filed targeted follow-ups (#186, #187, #188, #189).

🤖 Generated with [Claude Code](https://claude.com/claude-code)