### PR TITLE
refactor(envoy): Recommendation.fromScore on the enum (closes #198)

### DIFF
--- a/src/main/java/com/majordomo/application/envoy/ScoreAssembler.java
+++ b/src/main/java/com/majordomo/application/envoy/ScoreAssembler.java
@@ -10,7 +10,6 @@ import com.majordomo.domain.model.envoy.LlmScoreResponse;
 import com.majordomo.domain.model.envoy.Recommendation;
 import com.majordomo.domain.model.envoy.Rubric;
 import com.majordomo.domain.model.envoy.ScoreReport;
-import com.majordomo.domain.model.envoy.Thresholds;
 import com.majordomo.domain.model.envoy.Tier;
 import org.springframework.stereotype.Component;
 
@@ -82,7 +81,7 @@ public class ScoreAssembler {
         }
 
         int finalScore = Math.max(0, rawScore - totalPenalty);
-        Recommendation recommendation = deriveRecommendation(finalScore, rubric.thresholds());
+        Recommendation recommendation = Recommendation.fromScore(finalScore, rubric.thresholds());
 
         return new ScoreReport(
                 UuidFactory.newId(),
@@ -143,16 +142,4 @@ public class ScoreAssembler {
         }
     }
 
-    private Recommendation deriveRecommendation(int finalScore, Thresholds t) {
-        if (finalScore >= t.applyImmediately()) {
-            return Recommendation.APPLY_NOW;
-        }
-        if (finalScore >= t.apply()) {
-            return Recommendation.APPLY;
-        }
-        if (finalScore >= t.considerOnly()) {
-            return Recommendation.CONSIDER;
-        }
-        return Recommendation.SKIP;
-    }
 }

--- a/src/main/java/com/majordomo/domain/model/envoy/Recommendation.java
+++ b/src/main/java/com/majordomo/domain/model/envoy/Recommendation.java
@@ -11,5 +11,27 @@ public enum Recommendation {
     /** Score meets the considerOnly threshold but not apply. */
     CONSIDER,
     /** Score is below considerOnly, or a disqualifier was hit. */
-    SKIP
+    SKIP;
+
+    /**
+     * Maps a final score against rubric thresholds to a {@link Recommendation}.
+     * Disqualifier hits do not pass through this method — callers force
+     * {@link #SKIP} directly when a disqualifier fires.
+     *
+     * @param finalScore the final (post-flag) score
+     * @param thresholds the rubric's score cutoffs
+     * @return the recommendation tier the score falls into
+     */
+    public static Recommendation fromScore(int finalScore, Thresholds thresholds) {
+        if (finalScore >= thresholds.applyImmediately()) {
+            return APPLY_NOW;
+        }
+        if (finalScore >= thresholds.apply()) {
+            return APPLY;
+        }
+        if (finalScore >= thresholds.considerOnly()) {
+            return CONSIDER;
+        }
+        return SKIP;
+    }
 }

--- a/src/test/java/com/majordomo/domain/model/envoy/RecommendationTest.java
+++ b/src/test/java/com/majordomo/domain/model/envoy/RecommendationTest.java
@@ -1,0 +1,43 @@
+package com.majordomo.domain.model.envoy;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link Recommendation#fromScore(int, Thresholds)} — the static factory
+ * that maps a final score against thresholds. Boundary conditions are exhaustive
+ * because the ladder is otherwise easy to off-by-one.
+ */
+class RecommendationTest {
+
+    private static final Thresholds T = new Thresholds(85, 70, 50);
+
+    /** A score at or above applyImmediately is APPLY_NOW. */
+    @Test
+    void applyNowAtOrAboveApplyImmediatelyThreshold() {
+        assertThat(Recommendation.fromScore(85, T)).isEqualTo(Recommendation.APPLY_NOW);
+        assertThat(Recommendation.fromScore(100, T)).isEqualTo(Recommendation.APPLY_NOW);
+    }
+
+    /** A score in [apply, applyImmediately) is APPLY. */
+    @Test
+    void applyBetweenApplyAndApplyImmediately() {
+        assertThat(Recommendation.fromScore(70, T)).isEqualTo(Recommendation.APPLY);
+        assertThat(Recommendation.fromScore(84, T)).isEqualTo(Recommendation.APPLY);
+    }
+
+    /** A score in [considerOnly, apply) is CONSIDER. */
+    @Test
+    void considerBetweenConsiderOnlyAndApply() {
+        assertThat(Recommendation.fromScore(50, T)).isEqualTo(Recommendation.CONSIDER);
+        assertThat(Recommendation.fromScore(69, T)).isEqualTo(Recommendation.CONSIDER);
+    }
+
+    /** A score below considerOnly is SKIP. */
+    @Test
+    void skipBelowConsiderOnly() {
+        assertThat(Recommendation.fromScore(49, T)).isEqualTo(Recommendation.SKIP);
+        assertThat(Recommendation.fromScore(0, T)).isEqualTo(Recommendation.SKIP);
+    }
+}


### PR DESCRIPTION
## Summary

Moves the score → tier mapping from `ScoreAssembler.deriveRecommendation` onto `Recommendation.fromScore(int finalScore, Thresholds thresholds)`. Behavior identical; the logic now lives next to the enum it returns.

Closes #198

## Test plan

- [x] New `RecommendationTest` (4 tests) covering each tier boundary (APPLY_NOW / APPLY / CONSIDER / SKIP).
- [x] `./mvnw verify` — 356 tests, 0 failures.
- [x] No behavior change; existing assembler/scoring tests stay green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)