### PR TITLE
refactor: extract CurrentOrganizationResolver (closes #191)

### DIFF
--- a/src/main/java/com/majordomo/adapter/in/web/DashboardPageController.java
+++ b/src/main/java/com/majordomo/adapter/in/web/DashboardPageController.java
@@ -1,9 +1,8 @@
 package com.majordomo.adapter.in.web;
 
+import com.majordomo.application.identity.CurrentOrganizationResolver;
 import com.majordomo.domain.port.in.DashboardUseCase;
 import com.majordomo.domain.port.in.envoy.GetRecentApplyNowPostingsUseCase;
-import com.majordomo.domain.port.out.identity.MembershipRepository;
-import com.majordomo.domain.port.out.identity.UserRepository;
 
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -20,25 +19,21 @@ public class DashboardPageController {
     private static final int APPLY_NOW_PANEL_LIMIT = 5;
 
     private final DashboardUseCase dashboardUseCase;
-    private final UserRepository userRepository;
-    private final MembershipRepository membershipRepository;
+    private final CurrentOrganizationResolver currentOrg;
     private final GetRecentApplyNowPostingsUseCase recentApplyNowUseCase;
 
     /**
      * Constructs the dashboard page controller.
      *
      * @param dashboardUseCase      the inbound port for dashboard data retrieval
-     * @param userRepository        the outbound port for user lookups
-     * @param membershipRepository  the outbound port for membership lookups
+     * @param currentOrg            resolves the authenticated user's first organization
      * @param recentApplyNowUseCase inbound port for recent APPLY_NOW postings
      */
     public DashboardPageController(DashboardUseCase dashboardUseCase,
-                                   UserRepository userRepository,
-                                   MembershipRepository membershipRepository,
+                                   CurrentOrganizationResolver currentOrg,
                                    GetRecentApplyNowPostingsUseCase recentApplyNowUseCase) {
         this.dashboardUseCase = dashboardUseCase;
-        this.userRepository = userRepository;
-        this.membershipRepository = membershipRepository;
+        this.currentOrg = currentOrg;
         this.recentApplyNowUseCase = recentApplyNowUseCase;
     }
 
@@ -51,15 +46,14 @@ public class DashboardPageController {
      */
     @GetMapping("/dashboard")
     public String dashboard(@AuthenticationPrincipal UserDetails principal, Model model) {
-        var user = userRepository.findByUsername(principal.getUsername()).orElseThrow();
-        var memberships = membershipRepository.findByUserId(user.getId());
-        if (memberships.isEmpty()) {
+        var resolved = currentOrg.resolve(principal);
+        if (resolved.organizationId() == null) {
             return "redirect:/";
         }
-        var orgId = memberships.get(0).getOrganizationId();
+        var orgId = resolved.organizationId();
         var summary = dashboardUseCase.getSummary(orgId);
         model.addAttribute("summary", summary);
-        model.addAttribute("username", user.getUsername());
+        model.addAttribute("username", resolved.user().getUsername());
         model.addAttribute("applyNowPostings",
                 recentApplyNowUseCase.getRecentApplyNow(orgId, APPLY_NOW_PANEL_LIMIT));
         return "dashboard";

--- a/src/main/java/com/majordomo/adapter/in/web/envoy/EnvoyComparatorController.java
+++ b/src/main/java/com/majordomo/adapter/in/web/envoy/EnvoyComparatorController.java
@@ -1,16 +1,14 @@
 package com.majordomo.adapter.in.web.envoy;
 
+import com.majordomo.application.identity.CurrentOrganizationResolver;
 import com.majordomo.domain.model.envoy.Category;
 import com.majordomo.domain.model.envoy.CategoryScore;
 import com.majordomo.domain.model.envoy.JobPosting;
 import com.majordomo.domain.model.envoy.Rubric;
 import com.majordomo.domain.model.envoy.ScoreReport;
-import com.majordomo.domain.model.identity.User;
 import com.majordomo.domain.port.in.envoy.QueryScoreReportsUseCase;
 import com.majordomo.domain.port.out.envoy.JobPostingRepository;
 import com.majordomo.domain.port.out.envoy.RubricRepository;
-import com.majordomo.domain.port.out.identity.MembershipRepository;
-import com.majordomo.domain.port.out.identity.UserRepository;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Controller;
@@ -44,8 +42,7 @@ public class EnvoyComparatorController {
     private final QueryScoreReportsUseCase reports;
     private final RubricRepository rubricRepository;
     private final JobPostingRepository jobPostingRepository;
-    private final UserRepository userRepository;
-    private final MembershipRepository membershipRepository;
+    private final CurrentOrganizationResolver currentOrg;
 
     /**
      * One column in the comparator table — a posting plus (optionally) the
@@ -90,28 +87,22 @@ public class EnvoyComparatorController {
      */
     public record Row(String categoryKey, List<Cell> cells) { }
 
-    /** Resolved authentication context. */
-    private record AuthContext(User user, UUID organizationId) { }
-
     /**
      * Constructs the controller.
      *
      * @param reports              inbound port for report queries
      * @param rubricRepository     outbound port for rubric lookups
      * @param jobPostingRepository outbound port for posting lookups
-     * @param userRepository       outbound port for user lookups
-     * @param membershipRepository outbound port for membership lookups
+     * @param currentOrg           resolves the authenticated user's first organization
      */
     public EnvoyComparatorController(QueryScoreReportsUseCase reports,
                                      RubricRepository rubricRepository,
                                      JobPostingRepository jobPostingRepository,
-                                     UserRepository userRepository,
-                                     MembershipRepository membershipRepository) {
+                                     CurrentOrganizationResolver currentOrg) {
         this.reports = reports;
         this.rubricRepository = rubricRepository;
         this.jobPostingRepository = jobPostingRepository;
-        this.userRepository = userRepository;
-        this.membershipRepository = membershipRepository;
+        this.currentOrg = currentOrg;
     }
 
     /**
@@ -144,7 +135,7 @@ public class EnvoyComparatorController {
                           Model model) {
         List<UUID> ids = parseIds(idsParam);
 
-        AuthContext ctx = resolveContext(principal);
+        var ctx = currentOrg.resolve(principal);
         if (ctx.organizationId() == null) {
             return "redirect:/";
         }
@@ -258,12 +249,4 @@ public class EnvoyComparatorController {
         return rows;
     }
 
-    private AuthContext resolveContext(UserDetails principal) {
-        var user = userRepository.findByUsername(principal.getUsername()).orElseThrow();
-        var memberships = membershipRepository.findByUserId(user.getId());
-        if (memberships.isEmpty()) {
-            return new AuthContext(user, null);
-        }
-        return new AuthContext(user, memberships.get(0).getOrganizationId());
-    }
 }

--- a/src/main/java/com/majordomo/adapter/in/web/envoy/EnvoyPageController.java
+++ b/src/main/java/com/majordomo/adapter/in/web/envoy/EnvoyPageController.java
@@ -1,18 +1,16 @@
 package com.majordomo.adapter.in.web.envoy;
 
 import com.majordomo.application.envoy.LlmScoringException;
+import com.majordomo.application.identity.CurrentOrganizationResolver;
 import com.majordomo.domain.model.envoy.JobPosting;
 import com.majordomo.domain.model.envoy.JobSourceRequest;
 import com.majordomo.domain.model.envoy.Recommendation;
 import com.majordomo.domain.model.envoy.ScoreReport;
-import com.majordomo.domain.model.identity.User;
 import com.majordomo.domain.port.in.envoy.IngestJobPostingUseCase;
 import com.majordomo.domain.port.in.envoy.MarkPostingConversionUseCase;
 import com.majordomo.domain.port.in.envoy.QueryScoreReportsUseCase;
 import com.majordomo.domain.port.in.envoy.ScoreJobPostingUseCase;
 import com.majordomo.domain.port.out.envoy.JobPostingRepository;
-import com.majordomo.domain.port.out.identity.MembershipRepository;
-import com.majordomo.domain.port.out.identity.UserRepository;
 import jakarta.servlet.http.HttpServletResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -52,8 +50,7 @@ public class EnvoyPageController {
     private final ScoreJobPostingUseCase scoreUseCase;
     private final MarkPostingConversionUseCase conversionUseCase;
     private final JobPostingRepository jobPostingRepository;
-    private final UserRepository userRepository;
-    private final MembershipRepository membershipRepository;
+    private final CurrentOrganizationResolver currentOrg;
 
     /**
      * View-model row binding a {@link ScoreReport} to its source {@link JobPosting}.
@@ -66,16 +63,6 @@ public class EnvoyPageController {
     public record ScoreReportRow(ScoreReport report, JobPosting posting) { }
 
     /**
-     * Resolved authentication context: the user, plus the first org they
-     * belong to. {@code organizationId} is {@code null} if the user has no
-     * memberships, in which case the caller should redirect home.
-     *
-     * @param user           the authenticated user
-     * @param organizationId the user's first organization id, or {@code null}
-     */
-    private record AuthContext(User user, UUID organizationId) { }
-
-    /**
      * Constructs the controller.
      *
      * @param reports              inbound port for report queries
@@ -83,23 +70,20 @@ public class EnvoyPageController {
      * @param scoreUseCase         inbound port for scoring an ingested posting
      * @param conversionUseCase    inbound port for marking APPLY_NOW conversion outcome
      * @param jobPostingRepository outbound port for posting lookups
-     * @param userRepository       outbound port for user lookups
-     * @param membershipRepository outbound port for membership lookups
+     * @param currentOrg           resolves the authenticated user's first organization
      */
     public EnvoyPageController(QueryScoreReportsUseCase reports,
                                IngestJobPostingUseCase ingestUseCase,
                                ScoreJobPostingUseCase scoreUseCase,
                                MarkPostingConversionUseCase conversionUseCase,
                                JobPostingRepository jobPostingRepository,
-                               UserRepository userRepository,
-                               MembershipRepository membershipRepository) {
+                               CurrentOrganizationResolver currentOrg) {
         this.reports = reports;
         this.ingestUseCase = ingestUseCase;
         this.scoreUseCase = scoreUseCase;
         this.conversionUseCase = conversionUseCase;
         this.jobPostingRepository = jobPostingRepository;
-        this.userRepository = userRepository;
-        this.membershipRepository = membershipRepository;
+        this.currentOrg = currentOrg;
     }
 
     /**
@@ -129,7 +113,7 @@ public class EnvoyPageController {
                         @RequestParam(required = false) Recommendation recommendation,
                         @AuthenticationPrincipal UserDetails principal,
                         Model model) {
-        AuthContext ctx = resolveContext(principal);
+        var ctx = currentOrg.resolve(principal);
         if (ctx.organizationId() == null) {
             return "redirect:/";
         }
@@ -174,7 +158,7 @@ public class EnvoyPageController {
                                @RequestParam(required = false) String location,
                                @AuthenticationPrincipal UserDetails principal,
                                Model model) {
-        AuthContext ctx = resolveContext(principal);
+        var ctx = currentOrg.resolve(principal);
         if (ctx.organizationId() == null) {
             return "redirect:/";
         }
@@ -207,7 +191,7 @@ public class EnvoyPageController {
      * (rows, filter echo values, org id, username). Shared between the GET
      * handler and the POST handler's error path.
      */
-    private void renderEnvoyPage(AuthContext ctx,
+    private void renderEnvoyPage(CurrentOrganizationResolver.Resolved ctx,
                                  Integer minFinalScore,
                                  Recommendation recommendation,
                                  Model model) {
@@ -275,7 +259,7 @@ public class EnvoyPageController {
     @PostMapping("/envoy/postings/{postingId}/applied")
     public String markPostingApplied(@PathVariable UUID postingId,
                                      @AuthenticationPrincipal UserDetails principal) {
-        AuthContext ctx = resolveContext(principal);
+        var ctx = currentOrg.resolve(principal);
         if (ctx.organizationId() == null) {
             return "redirect:/";
         }
@@ -298,7 +282,7 @@ public class EnvoyPageController {
     @PostMapping("/envoy/postings/{postingId}/dismissed")
     public String dismissPosting(@PathVariable UUID postingId,
                                  @AuthenticationPrincipal UserDetails principal) {
-        AuthContext ctx = resolveContext(principal);
+        var ctx = currentOrg.resolve(principal);
         if (ctx.organizationId() == null) {
             return "redirect:/";
         }
@@ -333,7 +317,7 @@ public class EnvoyPageController {
                             @AuthenticationPrincipal UserDetails principal,
                             Model model,
                             HttpServletResponse response) {
-        AuthContext ctx = resolveContext(principal);
+        var ctx = currentOrg.resolve(principal);
         if (ctx.organizationId() == null) {
             return "redirect:/";
         }
@@ -356,17 +340,4 @@ public class EnvoyPageController {
         return "envoy-report";
     }
 
-    /**
-     * Resolves the authenticated user's first organization. Returns an
-     * {@link AuthContext} whose {@code organizationId} is {@code null} when
-     * the user has no membership; callers should redirect home in that case.
-     */
-    private AuthContext resolveContext(UserDetails principal) {
-        var user = userRepository.findByUsername(principal.getUsername()).orElseThrow();
-        var memberships = membershipRepository.findByUserId(user.getId());
-        if (memberships.isEmpty()) {
-            return new AuthContext(user, null);
-        }
-        return new AuthContext(user, memberships.get(0).getOrganizationId());
-    }
 }

--- a/src/main/java/com/majordomo/adapter/in/web/envoy/RubricAuthorController.java
+++ b/src/main/java/com/majordomo/adapter/in/web/envoy/RubricAuthorController.java
@@ -1,15 +1,13 @@
 package com.majordomo.adapter.in.web.envoy;
 
+import com.majordomo.application.identity.CurrentOrganizationResolver;
 import com.majordomo.domain.model.UuidFactory;
 import com.majordomo.domain.model.envoy.Category;
 import com.majordomo.domain.model.envoy.Rubric;
 import com.majordomo.domain.model.envoy.Thresholds;
 import com.majordomo.domain.model.envoy.Tier;
-import com.majordomo.domain.model.identity.User;
 import com.majordomo.domain.port.in.envoy.ManageRubricUseCase;
 import com.majordomo.domain.port.out.envoy.RubricRepository;
-import com.majordomo.domain.port.out.identity.MembershipRepository;
-import com.majordomo.domain.port.out.identity.UserRepository;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Controller;
@@ -43,35 +41,21 @@ public class RubricAuthorController {
 
     private final ManageRubricUseCase rubrics;
     private final RubricRepository rubricRepository;
-    private final UserRepository userRepository;
-    private final MembershipRepository membershipRepository;
-
-    /**
-     * Resolved authentication context: the user, plus the first org they belong
-     * to. {@code organizationId} is {@code null} if the user has no memberships,
-     * in which case callers should redirect home.
-     *
-     * @param user           the authenticated user
-     * @param organizationId the user's first organization id, or {@code null}
-     */
-    private record AuthContext(User user, UUID organizationId) { }
+    private final CurrentOrganizationResolver currentOrg;
 
     /**
      * Constructs the controller.
      *
-     * @param rubrics              inbound port for rubric authoring
-     * @param rubricRepository     outbound port for rubric reads
-     * @param userRepository       outbound port for user lookups
-     * @param membershipRepository outbound port for membership lookups
+     * @param rubrics          inbound port for rubric authoring
+     * @param rubricRepository outbound port for rubric reads
+     * @param currentOrg       resolves the authenticated user's first organization
      */
     public RubricAuthorController(ManageRubricUseCase rubrics,
                                   RubricRepository rubricRepository,
-                                  UserRepository userRepository,
-                                  MembershipRepository membershipRepository) {
+                                  CurrentOrganizationResolver currentOrg) {
         this.rubrics = rubrics;
         this.rubricRepository = rubricRepository;
-        this.userRepository = userRepository;
-        this.membershipRepository = membershipRepository;
+        this.currentOrg = currentOrg;
     }
 
     /**
@@ -86,7 +70,7 @@ public class RubricAuthorController {
      */
     @GetMapping("/envoy/rubrics")
     public String list(@AuthenticationPrincipal UserDetails principal, Model model) {
-        AuthContext ctx = resolveContext(principal);
+        var ctx = currentOrg.resolve(principal);
         if (ctx.organizationId() == null) {
             return "redirect:/";
         }
@@ -113,7 +97,7 @@ public class RubricAuthorController {
     public String editForm(@PathVariable String name,
                            @AuthenticationPrincipal UserDetails principal,
                            Model model) {
-        AuthContext ctx = resolveContext(principal);
+        var ctx = currentOrg.resolve(principal);
         if (ctx.organizationId() == null) {
             return "redirect:/";
         }
@@ -152,7 +136,7 @@ public class RubricAuthorController {
                          @AuthenticationPrincipal UserDetails principal,
                          Model model,
                          RedirectAttributes redirect) {
-        AuthContext ctx = resolveContext(principal);
+        var ctx = currentOrg.resolve(principal);
         if (ctx.organizationId() == null) {
             return "redirect:/";
         }
@@ -284,12 +268,4 @@ public class RubricAuthorController {
                 Instant.now());
     }
 
-    private AuthContext resolveContext(UserDetails principal) {
-        var user = userRepository.findByUsername(principal.getUsername()).orElseThrow();
-        var memberships = membershipRepository.findByUserId(user.getId());
-        if (memberships.isEmpty()) {
-            return new AuthContext(user, null);
-        }
-        return new AuthContext(user, memberships.get(0).getOrganizationId());
-    }
 }

--- a/src/main/java/com/majordomo/adapter/in/web/envoy/RubricComparatorController.java
+++ b/src/main/java/com/majordomo/adapter/in/web/envoy/RubricComparatorController.java
@@ -1,10 +1,8 @@
 package com.majordomo.adapter.in.web.envoy;
 
+import com.majordomo.application.identity.CurrentOrganizationResolver;
 import com.majordomo.domain.model.envoy.RubricComparison;
-import com.majordomo.domain.model.identity.User;
 import com.majordomo.domain.port.in.envoy.CompareRubricVersionsUseCase;
-import com.majordomo.domain.port.out.identity.MembershipRepository;
-import com.majordomo.domain.port.out.identity.UserRepository;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Controller;
@@ -29,25 +27,18 @@ public class RubricComparatorController {
     private static final int MAX_LIMIT = 50;
 
     private final CompareRubricVersionsUseCase comparisonUseCase;
-    private final UserRepository userRepository;
-    private final MembershipRepository membershipRepository;
-
-    /** Resolved authentication context. */
-    private record AuthContext(User user, UUID organizationId) { }
+    private final CurrentOrganizationResolver currentOrg;
 
     /**
      * Constructs the controller.
      *
-     * @param comparisonUseCase    inbound port for rubric comparison
-     * @param userRepository       outbound port for user lookups
-     * @param membershipRepository outbound port for membership lookups
+     * @param comparisonUseCase inbound port for rubric comparison
+     * @param currentOrg        resolves the authenticated user's first organization
      */
     public RubricComparatorController(CompareRubricVersionsUseCase comparisonUseCase,
-                                      UserRepository userRepository,
-                                      MembershipRepository membershipRepository) {
+                                      CurrentOrganizationResolver currentOrg) {
         this.comparisonUseCase = comparisonUseCase;
-        this.userRepository = userRepository;
-        this.membershipRepository = membershipRepository;
+        this.currentOrg = currentOrg;
     }
 
     /**
@@ -69,7 +60,7 @@ public class RubricComparatorController {
                           @RequestParam(value = "limit", defaultValue = "" + DEFAULT_LIMIT) int limit,
                           @AuthenticationPrincipal UserDetails principal,
                           Model model) {
-        AuthContext ctx = resolveContext(principal);
+        var ctx = currentOrg.resolve(principal);
         if (ctx.organizationId() == null) {
             return "redirect:/";
         }
@@ -86,14 +77,5 @@ public class RubricComparatorController {
         model.addAttribute("organizationId", orgId);
         model.addAttribute("username", ctx.user().getUsername());
         return "rubric-compare";
-    }
-
-    private AuthContext resolveContext(UserDetails principal) {
-        var user = userRepository.findByUsername(principal.getUsername()).orElseThrow();
-        var memberships = membershipRepository.findByUserId(user.getId());
-        if (memberships.isEmpty()) {
-            return new AuthContext(user, null);
-        }
-        return new AuthContext(user, memberships.get(0).getOrganizationId());
     }
 }

--- a/src/main/java/com/majordomo/application/identity/CurrentOrganizationResolver.java
+++ b/src/main/java/com/majordomo/application/identity/CurrentOrganizationResolver.java
@@ -1,0 +1,66 @@
+package com.majordomo.application.identity;
+
+import com.majordomo.domain.model.identity.User;
+import com.majordomo.domain.port.out.identity.MembershipRepository;
+import com.majordomo.domain.port.out.identity.UserRepository;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+
+import java.util.UUID;
+
+/**
+ * Resolves the authenticated user's identity plus the {@code organizationId} of
+ * the first organization they belong to. Centralizes the membership-resolution
+ * policy that was duplicated across five controllers (dashboard + the envoy
+ * Thymeleaf controllers).
+ *
+ * <p>Returning a present {@link Resolved} with {@code organizationId == null}
+ * (rather than throwing) preserves the existing controller idiom of redirecting
+ * home when the user has no memberships. Callers that want a hard auth check
+ * should use {@link OrganizationAccessService#verifyAccess(UUID)} instead.</p>
+ */
+@Component
+public class CurrentOrganizationResolver {
+
+    private final UserRepository users;
+    private final MembershipRepository memberships;
+
+    /**
+     * Resolved authentication context returned by {@link #resolve(UserDetails)}.
+     *
+     * @param user           the authenticated user
+     * @param organizationId the user's first organization id, or {@code null}
+     *                       if the user has no memberships
+     */
+    public record Resolved(User user, UUID organizationId) { }
+
+    /**
+     * Constructs the resolver.
+     *
+     * @param users       outbound port for user lookups
+     * @param memberships outbound port for membership lookups
+     */
+    public CurrentOrganizationResolver(UserRepository users, MembershipRepository memberships) {
+        this.users = users;
+        this.memberships = memberships;
+    }
+
+    /**
+     * Resolves the authenticated principal to a user + first-org pairing.
+     *
+     * @param principal the Spring Security {@code UserDetails} for the request
+     * @return the resolved user (always present) and their first {@code organizationId}
+     *         (or {@code null} if they have no memberships)
+     * @throws java.util.NoSuchElementException if the user is not found in the
+     *         {@link UserRepository} (should not happen in practice — Spring
+     *         Security has already authenticated them)
+     */
+    public Resolved resolve(UserDetails principal) {
+        User user = users.findByUsername(principal.getUsername()).orElseThrow();
+        var allMemberships = memberships.findByUserId(user.getId());
+        if (allMemberships.isEmpty()) {
+            return new Resolved(user, null);
+        }
+        return new Resolved(user, allMemberships.get(0).getOrganizationId());
+    }
+}

--- a/src/test/java/com/majordomo/adapter/in/web/DashboardPageControllerTest.java
+++ b/src/test/java/com/majordomo/adapter/in/web/DashboardPageControllerTest.java
@@ -2,30 +2,28 @@ package com.majordomo.adapter.in.web;
 
 import com.majordomo.adapter.in.web.config.SecurityConfig;
 import com.majordomo.adapter.in.web.config.OAuth2UserService;
+import com.majordomo.application.identity.CurrentOrganizationResolver;
 import com.majordomo.domain.model.DashboardSummary;
 import com.majordomo.domain.model.envoy.ApplyNowPosting;
-import com.majordomo.domain.model.identity.Membership;
-import com.majordomo.domain.model.identity.MemberRole;
 import com.majordomo.domain.model.identity.User;
 import com.majordomo.domain.port.in.DashboardUseCase;
 import com.majordomo.domain.port.in.envoy.GetRecentApplyNowPostingsUseCase;
 import com.majordomo.domain.port.out.identity.ApiKeyRepository;
-import com.majordomo.domain.port.out.identity.MembershipRepository;
-import com.majordomo.domain.port.out.identity.UserRepository;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.math.BigDecimal;
 import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.model;
@@ -46,10 +44,7 @@ class DashboardPageControllerTest {
     private DashboardUseCase dashboardUseCase;
 
     @MockitoBean
-    private UserRepository userRepository;
-
-    @MockitoBean
-    private MembershipRepository membershipRepository;
+    private CurrentOrganizationResolver currentOrg;
 
     @MockitoBean
     private ApiKeyRepository apiKeyRepository;
@@ -68,7 +63,6 @@ class DashboardPageControllerTest {
         UUID orgId = UUID.randomUUID();
 
         User user = new User(userId, "testuser", "test@example.com");
-        Membership membership = new Membership(UUID.randomUUID(), userId, orgId, MemberRole.OWNER);
         DashboardSummary summary = new DashboardSummary(
                 3, 5, List.of(), List.of(), List.of(), new BigDecimal("1200.00"));
 
@@ -76,8 +70,8 @@ class DashboardPageControllerTest {
                 UUID.randomUUID(), UUID.randomUUID(),
                 "Acme Inc", "Senior Engineer", "Remote", 92);
 
-        when(userRepository.findByUsername("testuser")).thenReturn(Optional.of(user));
-        when(membershipRepository.findByUserId(userId)).thenReturn(List.of(membership));
+        when(currentOrg.resolve(any(UserDetails.class)))
+                .thenReturn(new CurrentOrganizationResolver.Resolved(user, orgId));
         when(dashboardUseCase.getSummary(orgId)).thenReturn(summary);
         when(recentApplyNowUseCase.getRecentApplyNow(orgId, 5)).thenReturn(List.of(applyNow));
 
@@ -103,8 +97,8 @@ class DashboardPageControllerTest {
         UUID userId = UUID.randomUUID();
         User user = new User(userId, "nomember", "nomember@example.com");
 
-        when(userRepository.findByUsername("nomember")).thenReturn(Optional.of(user));
-        when(membershipRepository.findByUserId(userId)).thenReturn(List.of());
+        when(currentOrg.resolve(any(UserDetails.class)))
+                .thenReturn(new CurrentOrganizationResolver.Resolved(user, null));
 
         mockMvc.perform(get("/dashboard"))
                 .andExpect(status().is3xxRedirection());

--- a/src/test/java/com/majordomo/adapter/in/web/envoy/EnvoyComparatorControllerTest.java
+++ b/src/test/java/com/majordomo/adapter/in/web/envoy/EnvoyComparatorControllerTest.java
@@ -17,10 +17,10 @@ import com.majordomo.domain.port.in.envoy.QueryScoreReportsUseCase;
 import com.majordomo.domain.port.out.envoy.JobPostingRepository;
 import com.majordomo.domain.port.out.envoy.RubricRepository;
 import com.majordomo.domain.port.out.identity.ApiKeyRepository;
-import com.majordomo.domain.port.out.identity.MembershipRepository;
-import com.majordomo.domain.port.out.identity.UserRepository;
+import com.majordomo.application.identity.CurrentOrganizationResolver;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.security.test.context.support.WithMockUser;
@@ -35,6 +35,7 @@ import java.util.UUID;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.model;
@@ -50,8 +51,7 @@ class EnvoyComparatorControllerTest {
     @MockitoBean QueryScoreReportsUseCase reports;
     @MockitoBean RubricRepository rubricRepository;
     @MockitoBean JobPostingRepository jobPostingRepository;
-    @MockitoBean UserRepository userRepository;
-    @MockitoBean MembershipRepository membershipRepository;
+    @MockitoBean CurrentOrganizationResolver currentOrg;
     @MockitoBean ApiKeyRepository apiKeyRepository;
     @MockitoBean OAuth2UserService oAuth2UserService;
 
@@ -98,8 +98,9 @@ class EnvoyComparatorControllerTest {
         var membership = new Membership();
         membership.setUserId(user.getId());
         membership.setOrganizationId(ORG_ID);
-        when(userRepository.findByUsername("robsartin")).thenReturn(Optional.of(user));
-        when(membershipRepository.findByUserId(user.getId())).thenReturn(List.of(membership));
+        when(currentOrg.resolve(any(UserDetails.class)))
+
+                .thenReturn(new CurrentOrganizationResolver.Resolved(user, ORG_ID));
     }
 
     @Test
@@ -237,8 +238,9 @@ class EnvoyComparatorControllerTest {
     @WithMockUser(username = "robsartin")
     void redirectsHomeWhenUserHasNoMembership() throws Exception {
         var user = new User(UuidFactory.newId(), "robsartin", "rob@example.com");
-        when(userRepository.findByUsername("robsartin")).thenReturn(Optional.of(user));
-        when(membershipRepository.findByUserId(user.getId())).thenReturn(List.of());
+        when(currentOrg.resolve(any(UserDetails.class)))
+
+                .thenReturn(new CurrentOrganizationResolver.Resolved(user, null));
 
         mvc.perform(get("/envoy/compare")
                         .param("ids", UuidFactory.newId() + "," + UuidFactory.newId()))

--- a/src/test/java/com/majordomo/adapter/in/web/envoy/EnvoyPageControllerConversionTest.java
+++ b/src/test/java/com/majordomo/adapter/in/web/envoy/EnvoyPageControllerConversionTest.java
@@ -11,18 +11,16 @@ import com.majordomo.domain.port.in.envoy.QueryScoreReportsUseCase;
 import com.majordomo.domain.port.in.envoy.ScoreJobPostingUseCase;
 import com.majordomo.domain.port.out.envoy.JobPostingRepository;
 import com.majordomo.domain.port.out.identity.ApiKeyRepository;
-import com.majordomo.domain.port.out.identity.MembershipRepository;
-import com.majordomo.domain.port.out.identity.UserRepository;
+import com.majordomo.application.identity.CurrentOrganizationResolver;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
-import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -47,8 +45,7 @@ class EnvoyPageControllerConversionTest {
     @MockitoBean IngestJobPostingUseCase ingestUseCase;
     @MockitoBean ScoreJobPostingUseCase scoreUseCase;
     @MockitoBean MarkPostingConversionUseCase conversionUseCase;
-    @MockitoBean UserRepository userRepository;
-    @MockitoBean MembershipRepository membershipRepository;
+    @MockitoBean CurrentOrganizationResolver currentOrg;
     @MockitoBean JobPostingRepository jobPostingRepository;
     @MockitoBean ApiKeyRepository apiKeyRepository;
     @MockitoBean OAuth2UserService oAuth2UserService;
@@ -64,8 +61,9 @@ class EnvoyPageControllerConversionTest {
         membership.setUserId(user.getId());
         membership.setOrganizationId(ORG_ID);
         UUID postingId = UuidFactory.newId();
-        when(userRepository.findByUsername("robsartin")).thenReturn(Optional.of(user));
-        when(membershipRepository.findByUserId(user.getId())).thenReturn(List.of(membership));
+        when(currentOrg.resolve(any(UserDetails.class)))
+
+                .thenReturn(new CurrentOrganizationResolver.Resolved(user, ORG_ID));
 
         mvc.perform(post("/envoy/postings/{id}/applied", postingId).with(csrf()))
                 .andExpect(status().is3xxRedirection())
@@ -83,8 +81,9 @@ class EnvoyPageControllerConversionTest {
         membership.setUserId(user.getId());
         membership.setOrganizationId(ORG_ID);
         UUID postingId = UuidFactory.newId();
-        when(userRepository.findByUsername("robsartin")).thenReturn(Optional.of(user));
-        when(membershipRepository.findByUserId(user.getId())).thenReturn(List.of(membership));
+        when(currentOrg.resolve(any(UserDetails.class)))
+
+                .thenReturn(new CurrentOrganizationResolver.Resolved(user, ORG_ID));
 
         mvc.perform(post("/envoy/postings/{id}/dismissed", postingId).with(csrf()))
                 .andExpect(status().is3xxRedirection())

--- a/src/test/java/com/majordomo/adapter/in/web/envoy/EnvoyPageControllerTest.java
+++ b/src/test/java/com/majordomo/adapter/in/web/envoy/EnvoyPageControllerTest.java
@@ -18,10 +18,10 @@ import com.majordomo.domain.port.in.envoy.QueryScoreReportsUseCase;
 import com.majordomo.domain.port.in.envoy.ScoreJobPostingUseCase;
 import com.majordomo.domain.port.out.envoy.JobPostingRepository;
 import com.majordomo.domain.port.out.identity.ApiKeyRepository;
-import com.majordomo.domain.port.out.identity.MembershipRepository;
-import com.majordomo.domain.port.out.identity.UserRepository;
+import com.majordomo.application.identity.CurrentOrganizationResolver;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.security.test.context.support.WithMockUser;
@@ -58,8 +58,7 @@ class EnvoyPageControllerTest {
     @MockitoBean IngestJobPostingUseCase ingestUseCase;
     @MockitoBean ScoreJobPostingUseCase scoreUseCase;
     @MockitoBean MarkPostingConversionUseCase conversionUseCase;
-    @MockitoBean UserRepository userRepository;
-    @MockitoBean MembershipRepository membershipRepository;
+    @MockitoBean CurrentOrganizationResolver currentOrg;
     @MockitoBean JobPostingRepository jobPostingRepository;
     @MockitoBean ApiKeyRepository apiKeyRepository;
     @MockitoBean OAuth2UserService oAuth2UserService;
@@ -87,8 +86,8 @@ class EnvoyPageControllerTest {
         posting.setTitle("Senior Backend Engineer");
         posting.setLocation("Remote (US)");
 
-        when(userRepository.findByUsername("robsartin")).thenReturn(Optional.of(user));
-        when(membershipRepository.findByUserId(user.getId())).thenReturn(List.of(membership));
+        when(currentOrg.resolve(any(UserDetails.class)))
+                .thenReturn(new CurrentOrganizationResolver.Resolved(user, ORG_ID));
         when(reports.query(eq(ORG_ID), any(), any(), any(), any(Integer.class)))
                 .thenReturn(new Page<>(List.of(report), null, false));
         when(jobPostingRepository.findById(postingId, ORG_ID)).thenReturn(Optional.of(posting));
@@ -135,8 +134,8 @@ class EnvoyPageControllerTest {
         posting.setTitle("Software Engineer");
         posting.setLocation(null);
 
-        when(userRepository.findByUsername("robsartin")).thenReturn(Optional.of(user));
-        when(membershipRepository.findByUserId(user.getId())).thenReturn(List.of(membership));
+        when(currentOrg.resolve(any(UserDetails.class)))
+                .thenReturn(new CurrentOrganizationResolver.Resolved(user, ORG_ID));
         when(reports.query(eq(ORG_ID), any(), any(), any(), any(Integer.class)))
                 .thenReturn(new Page<>(List.of(report), null, false));
         when(jobPostingRepository.findById(postingId, ORG_ID)).thenReturn(Optional.of(posting));
@@ -170,8 +169,8 @@ class EnvoyPageControllerTest {
                 List.of(), List.of(), 70, 70, Recommendation.APPLY,
                 "claude-sonnet-4-6", Instant.now());
 
-        when(userRepository.findByUsername("robsartin")).thenReturn(Optional.of(user));
-        when(membershipRepository.findByUserId(user.getId())).thenReturn(List.of(membership));
+        when(currentOrg.resolve(any(UserDetails.class)))
+                .thenReturn(new CurrentOrganizationResolver.Resolved(user, ORG_ID));
         when(reports.query(eq(ORG_ID), any(), any(), any(), any(Integer.class)))
                 .thenReturn(new Page<>(List.of(report), null, false));
         when(jobPostingRepository.findById(postingId, ORG_ID)).thenReturn(Optional.empty());
@@ -194,8 +193,8 @@ class EnvoyPageControllerTest {
     @WithMockUser(username = "robsartin")
     void redirectsHomeWhenUserHasNoMembership() throws Exception {
         var user = new User(UuidFactory.newId(), "robsartin", "rob@example.com");
-        when(userRepository.findByUsername("robsartin")).thenReturn(Optional.of(user));
-        when(membershipRepository.findByUserId(user.getId())).thenReturn(List.of());
+        when(currentOrg.resolve(any(UserDetails.class)))
+                .thenReturn(new CurrentOrganizationResolver.Resolved(user, null));
 
         mvc.perform(get("/envoy"))
                 .andExpect(status().is3xxRedirection())
@@ -218,8 +217,8 @@ class EnvoyPageControllerTest {
         membership.setUserId(user.getId());
         membership.setOrganizationId(ORG_ID);
 
-        when(userRepository.findByUsername("robsartin")).thenReturn(Optional.of(user));
-        when(membershipRepository.findByUserId(user.getId())).thenReturn(List.of(membership));
+        when(currentOrg.resolve(any(UserDetails.class)))
+                .thenReturn(new CurrentOrganizationResolver.Resolved(user, ORG_ID));
         when(reports.query(eq(ORG_ID), any(), any(), any(), any(Integer.class)))
                 .thenReturn(new Page<>(List.of(), null, false));
 
@@ -239,8 +238,8 @@ class EnvoyPageControllerTest {
         membership.setUserId(user.getId());
         membership.setOrganizationId(ORG_ID);
 
-        when(userRepository.findByUsername("robsartin")).thenReturn(Optional.of(user));
-        when(membershipRepository.findByUserId(user.getId())).thenReturn(List.of(membership));
+        when(currentOrg.resolve(any(UserDetails.class)))
+                .thenReturn(new CurrentOrganizationResolver.Resolved(user, ORG_ID));
         when(reports.query(eq(ORG_ID), any(), any(), any(), any(Integer.class)))
                 .thenReturn(new Page<>(List.of(), null, false));
 
@@ -261,8 +260,8 @@ class EnvoyPageControllerTest {
         membership.setUserId(user.getId());
         membership.setOrganizationId(ORG_ID);
 
-        when(userRepository.findByUsername("robsartin")).thenReturn(Optional.of(user));
-        when(membershipRepository.findByUserId(user.getId())).thenReturn(List.of(membership));
+        when(currentOrg.resolve(any(UserDetails.class)))
+                .thenReturn(new CurrentOrganizationResolver.Resolved(user, ORG_ID));
         when(reports.query(eq(ORG_ID), any(), any(), any(), any(Integer.class)))
                 .thenReturn(new Page<>(List.of(), null, false));
 
@@ -282,8 +281,8 @@ class EnvoyPageControllerTest {
         membership.setUserId(user.getId());
         membership.setOrganizationId(ORG_ID);
 
-        when(userRepository.findByUsername("robsartin")).thenReturn(Optional.of(user));
-        when(membershipRepository.findByUserId(user.getId())).thenReturn(List.of(membership));
+        when(currentOrg.resolve(any(UserDetails.class)))
+                .thenReturn(new CurrentOrganizationResolver.Resolved(user, ORG_ID));
         when(reports.query(eq(ORG_ID), any(), any(), any(), any(Integer.class)))
                 .thenReturn(new Page<>(List.of(), null, false));
 
@@ -306,8 +305,8 @@ class EnvoyPageControllerTest {
         membership.setUserId(user.getId());
         membership.setOrganizationId(ORG_ID);
 
-        when(userRepository.findByUsername("robsartin")).thenReturn(Optional.of(user));
-        when(membershipRepository.findByUserId(user.getId())).thenReturn(List.of(membership));
+        when(currentOrg.resolve(any(UserDetails.class)))
+                .thenReturn(new CurrentOrganizationResolver.Resolved(user, ORG_ID));
         when(reports.query(eq(ORG_ID), any(), any(), any(), any(Integer.class)))
                 .thenReturn(new Page<>(List.of(), null, false));
 
@@ -360,8 +359,8 @@ class EnvoyPageControllerTest {
         posting.setLocation("Remote (US)");
         posting.setRawText("Full posting body goes here.");
 
-        when(userRepository.findByUsername("robsartin")).thenReturn(Optional.of(user));
-        when(membershipRepository.findByUserId(user.getId())).thenReturn(List.of(membership));
+        when(currentOrg.resolve(any(UserDetails.class)))
+                .thenReturn(new CurrentOrganizationResolver.Resolved(user, ORG_ID));
         when(reports.findById(reportId, ORG_ID)).thenReturn(Optional.of(report));
         when(jobPostingRepository.findById(postingId, ORG_ID)).thenReturn(Optional.of(posting));
 
@@ -412,8 +411,8 @@ class EnvoyPageControllerTest {
         posting.setLocation("San Francisco, CA");
         posting.setRawText("Body.");
 
-        when(userRepository.findByUsername("robsartin")).thenReturn(Optional.of(user));
-        when(membershipRepository.findByUserId(user.getId())).thenReturn(List.of(membership));
+        when(currentOrg.resolve(any(UserDetails.class)))
+                .thenReturn(new CurrentOrganizationResolver.Resolved(user, ORG_ID));
         when(reports.findById(reportId, ORG_ID)).thenReturn(Optional.of(report));
         when(jobPostingRepository.findById(postingId, ORG_ID)).thenReturn(Optional.of(posting));
 
@@ -441,8 +440,8 @@ class EnvoyPageControllerTest {
                 List.of(), List.of(), 60, 60,
                 Recommendation.CONSIDER, "claude-sonnet-4-6", Instant.now());
 
-        when(userRepository.findByUsername("robsartin")).thenReturn(Optional.of(user));
-        when(membershipRepository.findByUserId(user.getId())).thenReturn(List.of(membership));
+        when(currentOrg.resolve(any(UserDetails.class)))
+                .thenReturn(new CurrentOrganizationResolver.Resolved(user, ORG_ID));
         when(reports.findById(reportId, ORG_ID)).thenReturn(Optional.of(report));
         when(jobPostingRepository.findById(postingId, ORG_ID)).thenReturn(Optional.empty());
 
@@ -463,8 +462,8 @@ class EnvoyPageControllerTest {
 
         UUID reportId = UuidFactory.newId();
 
-        when(userRepository.findByUsername("robsartin")).thenReturn(Optional.of(user));
-        when(membershipRepository.findByUserId(user.getId())).thenReturn(List.of(membership));
+        when(currentOrg.resolve(any(UserDetails.class)))
+                .thenReturn(new CurrentOrganizationResolver.Resolved(user, ORG_ID));
         when(reports.findById(reportId, ORG_ID)).thenReturn(Optional.empty());
 
         mvc.perform(get("/envoy/reports/{id}", reportId))
@@ -475,8 +474,8 @@ class EnvoyPageControllerTest {
     @WithMockUser(username = "robsartin")
     void getReport_redirectsHomeWhenUserHasNoMembership() throws Exception {
         var user = new User(UuidFactory.newId(), "robsartin", "rob@example.com");
-        when(userRepository.findByUsername("robsartin")).thenReturn(Optional.of(user));
-        when(membershipRepository.findByUserId(user.getId())).thenReturn(List.of());
+        when(currentOrg.resolve(any(UserDetails.class)))
+                .thenReturn(new CurrentOrganizationResolver.Resolved(user, null));
 
         mvc.perform(get("/envoy/reports/{id}", UuidFactory.newId()))
                 .andExpect(status().is3xxRedirection())

--- a/src/test/java/com/majordomo/adapter/in/web/envoy/EnvoyPageIngestFormTest.java
+++ b/src/test/java/com/majordomo/adapter/in/web/envoy/EnvoyPageIngestFormTest.java
@@ -17,11 +17,11 @@ import com.majordomo.domain.port.in.envoy.QueryScoreReportsUseCase;
 import com.majordomo.domain.port.in.envoy.ScoreJobPostingUseCase;
 import com.majordomo.domain.port.out.envoy.JobPostingRepository;
 import com.majordomo.domain.port.out.identity.ApiKeyRepository;
-import com.majordomo.domain.port.out.identity.MembershipRepository;
-import com.majordomo.domain.port.out.identity.UserRepository;
+import com.majordomo.application.identity.CurrentOrganizationResolver;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.security.test.context.support.WithMockUser;
@@ -57,8 +57,7 @@ class EnvoyPageIngestFormTest {
     @MockitoBean IngestJobPostingUseCase ingestUseCase;
     @MockitoBean ScoreJobPostingUseCase scoreUseCase;
     @MockitoBean MarkPostingConversionUseCase conversionUseCase;
-    @MockitoBean UserRepository userRepository;
-    @MockitoBean MembershipRepository membershipRepository;
+    @MockitoBean CurrentOrganizationResolver currentOrg;
     @MockitoBean JobPostingRepository jobPostingRepository;
     @MockitoBean ApiKeyRepository apiKeyRepository;
     @MockitoBean OAuth2UserService oAuth2UserService;
@@ -83,8 +82,10 @@ class EnvoyPageIngestFormTest {
                 List.of(), List.of(), 90, 90, Recommendation.APPLY_NOW,
                 "claude-sonnet-4-6", Instant.now());
 
-        when(userRepository.findByUsername("robsartin")).thenReturn(Optional.of(user));
-        when(membershipRepository.findByUserId(user.getId())).thenReturn(List.of(membership));
+        when(currentOrg.resolve(any(UserDetails.class)))
+
+
+                .thenReturn(new CurrentOrganizationResolver.Resolved(user, ORG_ID));
         when(ingestUseCase.ingest(any(JobSourceRequest.class), eq(ORG_ID))).thenReturn(saved);
         when(scoreUseCase.score(eq(postingId), eq("default"), eq(ORG_ID))).thenReturn(report);
 
@@ -128,8 +129,10 @@ class EnvoyPageIngestFormTest {
                 List.of(), List.of(), 50, 50, Recommendation.CONSIDER,
                 "claude-sonnet-4-6", Instant.now());
 
-        when(userRepository.findByUsername("robsartin")).thenReturn(Optional.of(user));
-        when(membershipRepository.findByUserId(user.getId())).thenReturn(List.of(membership));
+        when(currentOrg.resolve(any(UserDetails.class)))
+
+
+                .thenReturn(new CurrentOrganizationResolver.Resolved(user, ORG_ID));
         when(ingestUseCase.ingest(any(JobSourceRequest.class), eq(ORG_ID))).thenReturn(saved);
         when(scoreUseCase.score(eq(postingId), eq("default"), eq(ORG_ID))).thenReturn(report);
 
@@ -156,8 +159,10 @@ class EnvoyPageIngestFormTest {
         membership.setUserId(user.getId());
         membership.setOrganizationId(ORG_ID);
 
-        when(userRepository.findByUsername("robsartin")).thenReturn(Optional.of(user));
-        when(membershipRepository.findByUserId(user.getId())).thenReturn(List.of(membership));
+        when(currentOrg.resolve(any(UserDetails.class)))
+
+
+                .thenReturn(new CurrentOrganizationResolver.Resolved(user, ORG_ID));
         when(ingestUseCase.ingest(any(JobSourceRequest.class), eq(ORG_ID)))
                 .thenThrow(new IllegalArgumentException("no JobSource supports type: bogus"));
         when(reports.query(eq(ORG_ID), any(), any(), any(), any(Integer.class)))
@@ -188,8 +193,10 @@ class EnvoyPageIngestFormTest {
         saved.setId(postingId);
         saved.setOrganizationId(ORG_ID);
 
-        when(userRepository.findByUsername("robsartin")).thenReturn(Optional.of(user));
-        when(membershipRepository.findByUserId(user.getId())).thenReturn(List.of(membership));
+        when(currentOrg.resolve(any(UserDetails.class)))
+
+
+                .thenReturn(new CurrentOrganizationResolver.Resolved(user, ORG_ID));
         when(ingestUseCase.ingest(any(JobSourceRequest.class), eq(ORG_ID))).thenReturn(saved);
         when(scoreUseCase.score(eq(postingId), eq("default"), eq(ORG_ID)))
                 .thenThrow(new LlmScoringException("LLM returned malformed JSON"));
@@ -219,8 +226,9 @@ class EnvoyPageIngestFormTest {
     @WithMockUser(username = "robsartin")
     void postEnvoy_redirectsHomeWhenUserHasNoMembership() throws Exception {
         var user = new User(UuidFactory.newId(), "robsartin", "rob@example.com");
-        when(userRepository.findByUsername("robsartin")).thenReturn(Optional.of(user));
-        when(membershipRepository.findByUserId(user.getId())).thenReturn(List.of());
+        when(currentOrg.resolve(any(UserDetails.class)))
+
+                .thenReturn(new CurrentOrganizationResolver.Resolved(user, null));
 
         mvc.perform(post("/envoy")
                         .with(csrf())
@@ -252,8 +260,10 @@ class EnvoyPageIngestFormTest {
         membership.setUserId(user.getId());
         membership.setOrganizationId(ORG_ID);
 
-        when(userRepository.findByUsername("robsartin")).thenReturn(Optional.of(user));
-        when(membershipRepository.findByUserId(user.getId())).thenReturn(List.of(membership));
+        when(currentOrg.resolve(any(UserDetails.class)))
+
+
+                .thenReturn(new CurrentOrganizationResolver.Resolved(user, ORG_ID));
         when(reports.query(eq(ORG_ID), any(), any(), any(), any(Integer.class)))
                 .thenReturn(new Page<>(List.of(), null, false));
 

--- a/src/test/java/com/majordomo/adapter/in/web/envoy/RubricAuthorControllerTest.java
+++ b/src/test/java/com/majordomo/adapter/in/web/envoy/RubricAuthorControllerTest.java
@@ -7,18 +7,17 @@ import com.majordomo.domain.model.envoy.Category;
 import com.majordomo.domain.model.envoy.Rubric;
 import com.majordomo.domain.model.envoy.Thresholds;
 import com.majordomo.domain.model.envoy.Tier;
-import com.majordomo.domain.model.identity.Membership;
 import com.majordomo.domain.model.identity.User;
 import com.majordomo.domain.port.in.envoy.ManageRubricUseCase;
 import com.majordomo.domain.port.out.envoy.RubricRepository;
 import com.majordomo.domain.port.out.identity.ApiKeyRepository;
-import com.majordomo.domain.port.out.identity.MembershipRepository;
-import com.majordomo.domain.port.out.identity.UserRepository;
+import com.majordomo.application.identity.CurrentOrganizationResolver;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
@@ -52,8 +51,7 @@ class RubricAuthorControllerTest {
 
     @MockitoBean ManageRubricUseCase rubrics;
     @MockitoBean RubricRepository rubricRepository;
-    @MockitoBean UserRepository userRepository;
-    @MockitoBean MembershipRepository membershipRepository;
+    @MockitoBean CurrentOrganizationResolver currentOrg;
     @MockitoBean ApiKeyRepository apiKeyRepository;
     @MockitoBean OAuth2UserService oAuth2UserService;
 
@@ -61,11 +59,8 @@ class RubricAuthorControllerTest {
 
     private void stubMembership(String username) {
         var user = new User(UuidFactory.newId(), username, username + "@example.com");
-        var membership = new Membership();
-        membership.setUserId(user.getId());
-        membership.setOrganizationId(ORG_ID);
-        when(userRepository.findByUsername(username)).thenReturn(Optional.of(user));
-        when(membershipRepository.findByUserId(user.getId())).thenReturn(List.of(membership));
+        when(currentOrg.resolve(any(UserDetails.class)))
+                .thenReturn(new CurrentOrganizationResolver.Resolved(user, ORG_ID));
     }
 
     private static Rubric sampleRubric(String name, int version) {

--- a/src/test/java/com/majordomo/adapter/in/web/envoy/RubricComparatorControllerTest.java
+++ b/src/test/java/com/majordomo/adapter/in/web/envoy/RubricComparatorControllerTest.java
@@ -9,10 +9,10 @@ import com.majordomo.domain.model.identity.Membership;
 import com.majordomo.domain.model.identity.User;
 import com.majordomo.domain.port.in.envoy.CompareRubricVersionsUseCase;
 import com.majordomo.domain.port.out.identity.ApiKeyRepository;
-import com.majordomo.domain.port.out.identity.MembershipRepository;
-import com.majordomo.domain.port.out.identity.UserRepository;
+import com.majordomo.application.identity.CurrentOrganizationResolver;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.security.test.context.support.WithMockUser;
@@ -21,12 +21,12 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.EnumMap;
 import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
 
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.model;
@@ -43,8 +43,7 @@ class RubricComparatorControllerTest {
     @Autowired MockMvc mvc;
 
     @MockitoBean CompareRubricVersionsUseCase comparisonUseCase;
-    @MockitoBean UserRepository userRepository;
-    @MockitoBean MembershipRepository membershipRepository;
+    @MockitoBean CurrentOrganizationResolver currentOrg;
     @MockitoBean ApiKeyRepository apiKeyRepository;
     @MockitoBean OAuth2UserService oAuth2UserService;
 
@@ -58,8 +57,9 @@ class RubricComparatorControllerTest {
         var membership = new Membership();
         membership.setUserId(user.getId());
         membership.setOrganizationId(ORG_ID);
-        when(userRepository.findByUsername("robsartin")).thenReturn(Optional.of(user));
-        when(membershipRepository.findByUserId(user.getId())).thenReturn(List.of(membership));
+        when(currentOrg.resolve(any(UserDetails.class)))
+
+                .thenReturn(new CurrentOrganizationResolver.Resolved(user, ORG_ID));
 
         RubricComparison result = new RubricComparison(
                 "default", 1, 2, List.of(),
@@ -88,8 +88,9 @@ class RubricComparatorControllerTest {
         var membership = new Membership();
         membership.setUserId(user.getId());
         membership.setOrganizationId(ORG_ID);
-        when(userRepository.findByUsername("robsartin")).thenReturn(Optional.of(user));
-        when(membershipRepository.findByUserId(user.getId())).thenReturn(List.of(membership));
+        when(currentOrg.resolve(any(UserDetails.class)))
+
+                .thenReturn(new CurrentOrganizationResolver.Resolved(user, ORG_ID));
 
         RubricComparison result = new RubricComparison(
                 "default", 1, 2, List.of(),

--- a/src/test/java/com/majordomo/application/identity/CurrentOrganizationResolverTest.java
+++ b/src/test/java/com/majordomo/application/identity/CurrentOrganizationResolverTest.java
@@ -1,0 +1,90 @@
+package com.majordomo.application.identity;
+
+import com.majordomo.domain.model.identity.MemberRole;
+import com.majordomo.domain.model.identity.Membership;
+import com.majordomo.domain.model.identity.User;
+import com.majordomo.domain.port.out.identity.MembershipRepository;
+import com.majordomo.domain.port.out.identity.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for {@link CurrentOrganizationResolver}.
+ */
+class CurrentOrganizationResolverTest {
+
+    private final UserRepository users = mock(UserRepository.class);
+    private final MembershipRepository memberships = mock(MembershipRepository.class);
+    private final CurrentOrganizationResolver resolver =
+            new CurrentOrganizationResolver(users, memberships);
+
+    /** Resolves user with a single membership to (user, that org's id). */
+    @Test
+    void singleMembershipReturnsThatOrg() {
+        UUID userId = UUID.randomUUID();
+        UUID orgId = UUID.randomUUID();
+        User user = new User(userId, "robsartin", "rob@example.com");
+        when(users.findByUsername("robsartin")).thenReturn(Optional.of(user));
+        when(memberships.findByUserId(userId)).thenReturn(List.of(
+                new Membership(UUID.randomUUID(), userId, orgId, MemberRole.OWNER)));
+
+        var result = resolver.resolve(userDetails("robsartin"));
+
+        assertThat(result.user()).isEqualTo(user);
+        assertThat(result.organizationId()).isEqualTo(orgId);
+    }
+
+    /** Selects the first membership when the user belongs to multiple orgs. */
+    @Test
+    void multipleMembershipsReturnsFirst() {
+        UUID userId = UUID.randomUUID();
+        UUID first = UUID.randomUUID();
+        UUID second = UUID.randomUUID();
+        User user = new User(userId, "user", "u@example.com");
+        when(users.findByUsername("user")).thenReturn(Optional.of(user));
+        when(memberships.findByUserId(userId)).thenReturn(List.of(
+                new Membership(UUID.randomUUID(), userId, first, MemberRole.OWNER),
+                new Membership(UUID.randomUUID(), userId, second, MemberRole.OWNER)));
+
+        var result = resolver.resolve(userDetails("user"));
+
+        assertThat(result.organizationId()).isEqualTo(first);
+    }
+
+    /** Returns user with null organizationId when the user has no memberships. */
+    @Test
+    void noMembershipsReturnsNullOrgId() {
+        UUID userId = UUID.randomUUID();
+        User user = new User(userId, "lonely", "l@example.com");
+        when(users.findByUsername("lonely")).thenReturn(Optional.of(user));
+        when(memberships.findByUserId(userId)).thenReturn(List.of());
+
+        var result = resolver.resolve(userDetails("lonely"));
+
+        assertThat(result.user()).isEqualTo(user);
+        assertThat(result.organizationId()).isNull();
+    }
+
+    /** Throws when the user is not found in the repository. */
+    @Test
+    void unknownUserThrows() {
+        when(users.findByUsername("ghost")).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> resolver.resolve(userDetails("ghost")))
+                .isInstanceOf(java.util.NoSuchElementException.class);
+    }
+
+    private static UserDetails userDetails(String username) {
+        return org.springframework.security.core.userdetails.User
+                .withUsername(username).password("x").authorities("USER").build();
+    }
+}


### PR DESCRIPTION
## Summary

Replaces 5 copies of `AuthContext` + `resolveContext(UserDetails)` with a single `CurrentOrganizationResolver` Spring component returning a `Resolved(user, organizationId)` record. No behavior change.

Affected controllers:
- `DashboardPageController`
- `EnvoyPageController`
- `EnvoyComparatorController`
- `RubricComparatorController`
- `RubricAuthorController`

The resolver is `@Component` (not `@Service` — the naming-convention ArchUnit rule reserves `*Service` for application services, and this is an authentication-layer helper).

Closes #191

## Why

From the DRY/SOLID review (#178, finding H1): every controller that wanted the user's org carried the same 6-line "load user → load memberships → take the first one" body. That's both DRY (5 copies) and SRP (each controller knew the membership-resolution policy). One central seam now exists for future evolution: header-based org switching, OAuth-claim-driven scoping, or audit attribution.

## Test plan

- [x] New `CurrentOrganizationResolverTest` (4 tests): single membership, multiple memberships (asserts first), no memberships, unknown user.
- [x] All 5 controller test files updated to `@MockitoBean CurrentOrganizationResolver currentOrg` and stub `currentOrg.resolve(any(UserDetails.class))` instead of stubbing `userRepository` + `membershipRepository` independently.
- [x] `./mvnw verify` — 356 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)