### PR TITLE
refactor(envoy): move APPLY_NOW conversion stat to application layer (closes #192)

### DIFF
--- a/src/main/java/com/majordomo/adapter/in/event/CacheEvictionListener.java
+++ b/src/main/java/com/majordomo/adapter/in/event/CacheEvictionListener.java
@@ -1,6 +1,8 @@
 package com.majordomo.adapter.in.event;
 
 import com.majordomo.domain.model.event.JobPostingScored;
+import com.majordomo.domain.model.event.PostingDismissed;
+import com.majordomo.domain.model.event.PostingMarkedApplied;
 import com.majordomo.domain.model.event.ServiceRecordCreated;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -15,6 +17,9 @@ import org.springframework.stereotype.Component;
 public class CacheEvictionListener {
 
     private static final Logger LOG = LoggerFactory.getLogger(CacheEvictionListener.class);
+
+    private static final String APPLY_NOW_CACHE = "envoy-apply-now";
+    private static final String APPLY_NOW_STAT_CACHE = "envoy-apply-now-stat";
 
     private final CacheManager cacheManager;
 
@@ -39,15 +44,38 @@ public class CacheEvictionListener {
     }
 
     /**
-     * Evicts the APPLY_NOW dashboard cache after a posting is scored, so
-     * newly-scored APPLY_NOW postings appear promptly on the dashboard panel.
+     * Evicts the APPLY_NOW dashboard caches after a posting is scored, so
+     * newly-scored APPLY_NOW postings appear promptly on summary surfaces.
      *
      * @param event the scoring event
      */
     @EventListener
     public void onJobPostingScored(JobPostingScored event) {
-        LOG.debug("Evicting envoy-apply-now cache after posting scored");
-        evict("envoy-apply-now");
+        LOG.debug("Evicting envoy-apply-now caches after posting scored");
+        evict(APPLY_NOW_CACHE);
+        evict(APPLY_NOW_STAT_CACHE);
+    }
+
+    /**
+     * Evicts the APPLY_NOW conversion stat after a user marks a posting applied.
+     *
+     * @param event the apply event
+     */
+    @EventListener
+    public void onPostingMarkedApplied(PostingMarkedApplied event) {
+        LOG.debug("Evicting envoy-apply-now-stat cache after posting marked applied");
+        evict(APPLY_NOW_STAT_CACHE);
+    }
+
+    /**
+     * Evicts the APPLY_NOW conversion stat after a user dismisses a posting.
+     *
+     * @param event the dismiss event
+     */
+    @EventListener
+    public void onPostingDismissed(PostingDismissed event) {
+        LOG.debug("Evicting envoy-apply-now-stat cache after posting dismissed");
+        evict(APPLY_NOW_STAT_CACHE);
     }
 
     private void evict(String cacheName) {

--- a/src/main/java/com/majordomo/adapter/in/web/envoy/EnvoyPageController.java
+++ b/src/main/java/com/majordomo/adapter/in/web/envoy/EnvoyPageController.java
@@ -6,6 +6,7 @@ import com.majordomo.domain.model.envoy.JobPosting;
 import com.majordomo.domain.model.envoy.JobSourceRequest;
 import com.majordomo.domain.model.envoy.Recommendation;
 import com.majordomo.domain.model.envoy.ScoreReport;
+import com.majordomo.domain.port.in.envoy.GetApplyNowConversionStatUseCase;
 import com.majordomo.domain.port.in.envoy.IngestJobPostingUseCase;
 import com.majordomo.domain.port.in.envoy.MarkPostingConversionUseCase;
 import com.majordomo.domain.port.in.envoy.QueryScoreReportsUseCase;
@@ -49,6 +50,7 @@ public class EnvoyPageController {
     private final IngestJobPostingUseCase ingestUseCase;
     private final ScoreJobPostingUseCase scoreUseCase;
     private final MarkPostingConversionUseCase conversionUseCase;
+    private final GetApplyNowConversionStatUseCase conversionStatUseCase;
     private final JobPostingRepository jobPostingRepository;
     private final CurrentOrganizationResolver currentOrg;
 
@@ -65,23 +67,26 @@ public class EnvoyPageController {
     /**
      * Constructs the controller.
      *
-     * @param reports              inbound port for report queries
-     * @param ingestUseCase        inbound port for ingesting a posting from any source
-     * @param scoreUseCase         inbound port for scoring an ingested posting
-     * @param conversionUseCase    inbound port for marking APPLY_NOW conversion outcome
-     * @param jobPostingRepository outbound port for posting lookups
-     * @param currentOrg           resolves the authenticated user's first organization
+     * @param reports               inbound port for report queries
+     * @param ingestUseCase         inbound port for ingesting a posting from any source
+     * @param scoreUseCase          inbound port for scoring an ingested posting
+     * @param conversionUseCase     inbound port for marking APPLY_NOW conversion outcome
+     * @param conversionStatUseCase inbound port for the APPLY_NOW conversion rollup
+     * @param jobPostingRepository  outbound port for posting lookups
+     * @param currentOrg            resolves the authenticated user's first organization
      */
     public EnvoyPageController(QueryScoreReportsUseCase reports,
                                IngestJobPostingUseCase ingestUseCase,
                                ScoreJobPostingUseCase scoreUseCase,
                                MarkPostingConversionUseCase conversionUseCase,
+                               GetApplyNowConversionStatUseCase conversionStatUseCase,
                                JobPostingRepository jobPostingRepository,
                                CurrentOrganizationResolver currentOrg) {
         this.reports = reports;
         this.ingestUseCase = ingestUseCase;
         this.scoreUseCase = scoreUseCase;
         this.conversionUseCase = conversionUseCase;
+        this.conversionStatUseCase = conversionStatUseCase;
         this.jobPostingRepository = jobPostingRepository;
         this.currentOrg = currentOrg;
     }
@@ -206,26 +211,15 @@ public class EnvoyPageController {
                         jobPostingRepository.findById(r.postingId(), orgId).orElse(null)))
                 .toList();
 
-        // Conversion stat: of the user's APPLY_NOW reports, how many of the
-        // *underlying postings* have been marked applied? Counted off the same
-        // /envoy fetch when the user is already filtered to APPLY_NOW; otherwise
-        // a separate small query runs.
-        List<ScoreReport> applyNowReports = recommendation == Recommendation.APPLY_NOW
-                ? recent
-                : reports.query(orgId, null, Recommendation.APPLY_NOW, null, DEFAULT_LIMIT).items();
-        long applyNowTotal = applyNowReports.size();
-        long applyNowApplied = applyNowReports.stream()
-                .map(r -> jobPostingRepository.findById(r.postingId(), orgId).orElse(null))
-                .filter(p -> p != null && p.getAppliedAt() != null)
-                .count();
+        var stat = conversionStatUseCase.getStat(orgId);
 
         model.addAttribute("rows", rows);
         model.addAttribute("minFinalScore", minFinalScore);
         model.addAttribute("recommendation", recommendation);
         model.addAttribute("organizationId", orgId);
         model.addAttribute("username", ctx.user().getUsername());
-        model.addAttribute("applyNowTotal", applyNowTotal);
-        model.addAttribute("applyNowApplied", applyNowApplied);
+        model.addAttribute("applyNowTotal", stat.total());
+        model.addAttribute("applyNowApplied", stat.applied());
     }
 
     /**

--- a/src/main/java/com/majordomo/application/envoy/RecentApplyNowQueryService.java
+++ b/src/main/java/com/majordomo/application/envoy/RecentApplyNowQueryService.java
@@ -1,9 +1,11 @@
 package com.majordomo.application.envoy;
 
+import com.majordomo.domain.model.envoy.ApplyNowConversionStat;
 import com.majordomo.domain.model.envoy.ApplyNowPosting;
 import com.majordomo.domain.model.envoy.JobPosting;
 import com.majordomo.domain.model.envoy.Recommendation;
 import com.majordomo.domain.model.envoy.ScoreReport;
+import com.majordomo.domain.port.in.envoy.GetApplyNowConversionStatUseCase;
 import com.majordomo.domain.port.in.envoy.GetRecentApplyNowPostingsUseCase;
 import com.majordomo.domain.port.out.envoy.JobPostingRepository;
 import com.majordomo.domain.port.out.envoy.ScoreReportRepository;
@@ -14,13 +16,20 @@ import java.util.List;
 import java.util.UUID;
 
 /**
- * Lists recent APPLY_NOW reports enriched with posting metadata for summary surfaces.
- * Cached in {@code envoy-apply-now} (5-minute TTL via {@link com.majordomo.adapter.in.web.config.CacheConfig});
- * the cache is evicted on {@link com.majordomo.domain.model.event.JobPostingScored} so newly-scored APPLY_NOW
- * postings appear promptly on the dashboard.
+ * Lists recent APPLY_NOW reports enriched with posting metadata, plus the
+ * "X of Y applied" rollup for the same window. Cached in {@code envoy-apply-now}
+ * (postings) and {@code envoy-apply-now-stat} (rollup); both evicted on
+ * {@link com.majordomo.domain.model.event.JobPostingScored},
+ * {@link com.majordomo.domain.model.event.PostingMarkedApplied}, and
+ * {@link com.majordomo.domain.model.event.PostingDismissed} so newly-scored or
+ * newly-converted postings show up promptly on summary surfaces.
  */
 @Service
-public class RecentApplyNowQueryService implements GetRecentApplyNowPostingsUseCase {
+public class RecentApplyNowQueryService
+        implements GetRecentApplyNowPostingsUseCase, GetApplyNowConversionStatUseCase {
+
+    /** Window used by both the dashboard panel and the /envoy stat. */
+    static final int STAT_WINDOW = 50;
 
     private final ScoreReportRepository reports;
     private final JobPostingRepository postings;
@@ -42,6 +51,21 @@ public class RecentApplyNowQueryService implements GetRecentApplyNowPostingsUseC
         int clamped = Math.max(1, Math.min(limit, 100));
         var page = reports.query(organizationId, null, Recommendation.APPLY_NOW, null, clamped);
         return page.items().stream().map(report -> enrich(report, organizationId)).toList();
+    }
+
+    @Override
+    @Cacheable(value = "envoy-apply-now-stat", key = "#organizationId")
+    public ApplyNowConversionStat getStat(UUID organizationId) {
+        var page = reports.query(organizationId, null, Recommendation.APPLY_NOW, null, STAT_WINDOW);
+        long total = page.items().size();
+        if (total == 0) {
+            return ApplyNowConversionStat.EMPTY;
+        }
+        long applied = page.items().stream()
+                .map(r -> postings.findById(r.postingId(), organizationId).orElse(null))
+                .filter(p -> p != null && p.getAppliedAt() != null)
+                .count();
+        return new ApplyNowConversionStat(total, applied);
     }
 
     private ApplyNowPosting enrich(ScoreReport report, UUID organizationId) {

--- a/src/main/java/com/majordomo/domain/model/envoy/ApplyNowConversionStat.java
+++ b/src/main/java/com/majordomo/domain/model/envoy/ApplyNowConversionStat.java
@@ -1,0 +1,15 @@
+package com.majordomo.domain.model.envoy;
+
+/**
+ * "X of Y APPLY_NOW postings applied" rollup. {@code total} is the count of
+ * recent score reports recommending APPLY_NOW for an organization;
+ * {@code applied} is the subset whose source posting has been marked applied.
+ *
+ * @param total   number of APPLY_NOW reports counted
+ * @param applied number of those whose source posting has appliedAt set
+ */
+public record ApplyNowConversionStat(long total, long applied) {
+
+    /** Empty stat used when an org has no APPLY_NOW reports yet. */
+    public static final ApplyNowConversionStat EMPTY = new ApplyNowConversionStat(0L, 0L);
+}

--- a/src/main/java/com/majordomo/domain/port/in/envoy/GetApplyNowConversionStatUseCase.java
+++ b/src/main/java/com/majordomo/domain/port/in/envoy/GetApplyNowConversionStatUseCase.java
@@ -1,0 +1,23 @@
+package com.majordomo.domain.port.in.envoy;
+
+import com.majordomo.domain.model.envoy.ApplyNowConversionStat;
+
+import java.util.UUID;
+
+/**
+ * Inbound port: returns the "X of Y APPLY_NOW postings applied" rollup for an
+ * organization. Used by the {@code /envoy} list page.
+ */
+public interface GetApplyNowConversionStatUseCase {
+
+    /**
+     * Returns the conversion stat for the most-recent APPLY_NOW reports in
+     * {@code organizationId}. Implementations should bound the result set to a
+     * sensible cap (matching the controller's recent-reports window) so the
+     * computation stays cheap.
+     *
+     * @param organizationId owning org
+     * @return the stat (always non-null; may be {@link ApplyNowConversionStat#EMPTY})
+     */
+    ApplyNowConversionStat getStat(UUID organizationId);
+}

--- a/src/test/java/com/majordomo/adapter/in/event/CacheEvictionListenerTest.java
+++ b/src/test/java/com/majordomo/adapter/in/event/CacheEvictionListenerTest.java
@@ -2,6 +2,8 @@ package com.majordomo.adapter.in.event;
 
 import com.majordomo.domain.model.envoy.Recommendation;
 import com.majordomo.domain.model.event.JobPostingScored;
+import com.majordomo.domain.model.event.PostingDismissed;
+import com.majordomo.domain.model.event.PostingMarkedApplied;
 import com.majordomo.domain.model.event.ServiceRecordCreated;
 import org.junit.jupiter.api.Test;
 import org.springframework.cache.Cache;
@@ -33,18 +35,49 @@ class CacheEvictionListenerTest {
         verify(cache).clear();
     }
 
-    /** APPLY_NOW dashboard cache should be cleared when a posting is scored. */
+    /** APPLY_NOW dashboard caches (postings + stat) should both be cleared when a posting is scored. */
     @Test
-    void onJobPostingScoredEvictsApplyNowCache() {
+    void onJobPostingScoredEvictsApplyNowCaches() {
         var cacheManager = mock(CacheManager.class);
-        var cache = mock(Cache.class);
-        when(cacheManager.getCache("envoy-apply-now")).thenReturn(cache);
+        var postingsCache = mock(Cache.class);
+        var statCache = mock(Cache.class);
+        when(cacheManager.getCache("envoy-apply-now")).thenReturn(postingsCache);
+        when(cacheManager.getCache("envoy-apply-now-stat")).thenReturn(statCache);
 
         var listener = new CacheEvictionListener(cacheManager);
         listener.onJobPostingScored(new JobPostingScored(
                 UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID(),
                 85, Recommendation.APPLY_NOW, Instant.now()));
 
-        verify(cache).clear();
+        verify(postingsCache).clear();
+        verify(statCache).clear();
+    }
+
+    /** PostingMarkedApplied should evict the conversion stat cache. */
+    @Test
+    void onPostingMarkedAppliedEvictsStatCache() {
+        var cacheManager = mock(CacheManager.class);
+        var statCache = mock(Cache.class);
+        when(cacheManager.getCache("envoy-apply-now-stat")).thenReturn(statCache);
+
+        var listener = new CacheEvictionListener(cacheManager);
+        listener.onPostingMarkedApplied(new PostingMarkedApplied(
+                UUID.randomUUID(), UUID.randomUUID(), Instant.now()));
+
+        verify(statCache).clear();
+    }
+
+    /** PostingDismissed should evict the conversion stat cache. */
+    @Test
+    void onPostingDismissedEvictsStatCache() {
+        var cacheManager = mock(CacheManager.class);
+        var statCache = mock(Cache.class);
+        when(cacheManager.getCache("envoy-apply-now-stat")).thenReturn(statCache);
+
+        var listener = new CacheEvictionListener(cacheManager);
+        listener.onPostingDismissed(new PostingDismissed(
+                UUID.randomUUID(), UUID.randomUUID(), Instant.now()));
+
+        verify(statCache).clear();
     }
 }

--- a/src/test/java/com/majordomo/adapter/in/web/envoy/EnvoyPageControllerConversionTest.java
+++ b/src/test/java/com/majordomo/adapter/in/web/envoy/EnvoyPageControllerConversionTest.java
@@ -5,6 +5,8 @@ import com.majordomo.adapter.in.web.config.SecurityConfig;
 import com.majordomo.domain.model.UuidFactory;
 import com.majordomo.domain.model.identity.Membership;
 import com.majordomo.domain.model.identity.User;
+import com.majordomo.domain.model.envoy.ApplyNowConversionStat;
+import com.majordomo.domain.port.in.envoy.GetApplyNowConversionStatUseCase;
 import com.majordomo.domain.port.in.envoy.IngestJobPostingUseCase;
 import com.majordomo.domain.port.in.envoy.MarkPostingConversionUseCase;
 import com.majordomo.domain.port.in.envoy.QueryScoreReportsUseCase;
@@ -12,6 +14,7 @@ import com.majordomo.domain.port.in.envoy.ScoreJobPostingUseCase;
 import com.majordomo.domain.port.out.envoy.JobPostingRepository;
 import com.majordomo.domain.port.out.identity.ApiKeyRepository;
 import com.majordomo.application.identity.CurrentOrganizationResolver;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -45,12 +48,19 @@ class EnvoyPageControllerConversionTest {
     @MockitoBean IngestJobPostingUseCase ingestUseCase;
     @MockitoBean ScoreJobPostingUseCase scoreUseCase;
     @MockitoBean MarkPostingConversionUseCase conversionUseCase;
+    @MockitoBean GetApplyNowConversionStatUseCase conversionStatUseCase;
     @MockitoBean CurrentOrganizationResolver currentOrg;
     @MockitoBean JobPostingRepository jobPostingRepository;
     @MockitoBean ApiKeyRepository apiKeyRepository;
     @MockitoBean OAuth2UserService oAuth2UserService;
 
     private static final UUID ORG_ID = UuidFactory.newId();
+    @BeforeEach
+    void seedConversionStat() {
+        when(conversionStatUseCase.getStat(any(UUID.class)))
+                .thenReturn(ApplyNowConversionStat.EMPTY);
+    }
+
 
     /** POST /envoy/postings/{id}/applied delegates to the use case and redirects. */
     @Test

--- a/src/test/java/com/majordomo/adapter/in/web/envoy/EnvoyPageControllerTest.java
+++ b/src/test/java/com/majordomo/adapter/in/web/envoy/EnvoyPageControllerTest.java
@@ -12,6 +12,8 @@ import com.majordomo.domain.model.envoy.Recommendation;
 import com.majordomo.domain.model.envoy.ScoreReport;
 import com.majordomo.domain.model.identity.Membership;
 import com.majordomo.domain.model.identity.User;
+import com.majordomo.domain.model.envoy.ApplyNowConversionStat;
+import com.majordomo.domain.port.in.envoy.GetApplyNowConversionStatUseCase;
 import com.majordomo.domain.port.in.envoy.IngestJobPostingUseCase;
 import com.majordomo.domain.port.in.envoy.MarkPostingConversionUseCase;
 import com.majordomo.domain.port.in.envoy.QueryScoreReportsUseCase;
@@ -19,6 +21,7 @@ import com.majordomo.domain.port.in.envoy.ScoreJobPostingUseCase;
 import com.majordomo.domain.port.out.envoy.JobPostingRepository;
 import com.majordomo.domain.port.out.identity.ApiKeyRepository;
 import com.majordomo.application.identity.CurrentOrganizationResolver;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -58,12 +61,19 @@ class EnvoyPageControllerTest {
     @MockitoBean IngestJobPostingUseCase ingestUseCase;
     @MockitoBean ScoreJobPostingUseCase scoreUseCase;
     @MockitoBean MarkPostingConversionUseCase conversionUseCase;
+    @MockitoBean GetApplyNowConversionStatUseCase conversionStatUseCase;
     @MockitoBean CurrentOrganizationResolver currentOrg;
     @MockitoBean JobPostingRepository jobPostingRepository;
     @MockitoBean ApiKeyRepository apiKeyRepository;
     @MockitoBean OAuth2UserService oAuth2UserService;
 
     private static final UUID ORG_ID = UuidFactory.newId();
+    @BeforeEach
+    void seedConversionStat() {
+        when(conversionStatUseCase.getStat(any(UUID.class)))
+                .thenReturn(ApplyNowConversionStat.EMPTY);
+    }
+
 
     @Test
     @WithMockUser(username = "robsartin")

--- a/src/test/java/com/majordomo/adapter/in/web/envoy/EnvoyPageIngestFormTest.java
+++ b/src/test/java/com/majordomo/adapter/in/web/envoy/EnvoyPageIngestFormTest.java
@@ -11,6 +11,8 @@ import com.majordomo.domain.model.envoy.Recommendation;
 import com.majordomo.domain.model.envoy.ScoreReport;
 import com.majordomo.domain.model.identity.Membership;
 import com.majordomo.domain.model.identity.User;
+import com.majordomo.domain.model.envoy.ApplyNowConversionStat;
+import com.majordomo.domain.port.in.envoy.GetApplyNowConversionStatUseCase;
 import com.majordomo.domain.port.in.envoy.IngestJobPostingUseCase;
 import com.majordomo.domain.port.in.envoy.MarkPostingConversionUseCase;
 import com.majordomo.domain.port.in.envoy.QueryScoreReportsUseCase;
@@ -18,6 +20,7 @@ import com.majordomo.domain.port.in.envoy.ScoreJobPostingUseCase;
 import com.majordomo.domain.port.out.envoy.JobPostingRepository;
 import com.majordomo.domain.port.out.identity.ApiKeyRepository;
 import com.majordomo.application.identity.CurrentOrganizationResolver;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -57,12 +60,19 @@ class EnvoyPageIngestFormTest {
     @MockitoBean IngestJobPostingUseCase ingestUseCase;
     @MockitoBean ScoreJobPostingUseCase scoreUseCase;
     @MockitoBean MarkPostingConversionUseCase conversionUseCase;
+    @MockitoBean GetApplyNowConversionStatUseCase conversionStatUseCase;
     @MockitoBean CurrentOrganizationResolver currentOrg;
     @MockitoBean JobPostingRepository jobPostingRepository;
     @MockitoBean ApiKeyRepository apiKeyRepository;
     @MockitoBean OAuth2UserService oAuth2UserService;
 
     private static final UUID ORG_ID = UuidFactory.newId();
+    @BeforeEach
+    void seedConversionStat() {
+        when(conversionStatUseCase.getStat(any(UUID.class)))
+                .thenReturn(ApplyNowConversionStat.EMPTY);
+    }
+
 
     @Test
     @WithMockUser(username = "robsartin")

--- a/src/test/java/com/majordomo/application/envoy/RecentApplyNowQueryServiceTest.java
+++ b/src/test/java/com/majordomo/application/envoy/RecentApplyNowQueryServiceTest.java
@@ -88,6 +88,72 @@ class RecentApplyNowQueryServiceTest {
         verify(reports).query(eq(orgId), isNull(), eq(Recommendation.APPLY_NOW), isNull(), eq(100));
     }
 
+    /** getStat counts APPLY_NOW reports and how many of their postings are applied. */
+    @Test
+    void getStatCountsAppliedReports() {
+        UUID orgId = UUID.randomUUID();
+        UUID p1 = UUID.randomUUID();
+        UUID p2 = UUID.randomUUID();
+        UUID p3 = UUID.randomUUID();
+        when(reports.query(eq(orgId), isNull(), eq(Recommendation.APPLY_NOW), isNull(), eq(50)))
+                .thenReturn(new com.majordomo.domain.model.Page<>(List.of(
+                        report(UUID.randomUUID(), orgId, p1, 90),
+                        report(UUID.randomUUID(), orgId, p2, 91),
+                        report(UUID.randomUUID(), orgId, p3, 92)),
+                        null, false));
+        when(postings.findById(p1, orgId)).thenReturn(Optional.of(applied(p1, orgId)));
+        when(postings.findById(p2, orgId)).thenReturn(Optional.of(applied(p2, orgId)));
+        when(postings.findById(p3, orgId)).thenReturn(Optional.of(unapplied(p3, orgId)));
+
+        var stat = service.getStat(orgId);
+
+        assertThat(stat.total()).isEqualTo(3L);
+        assertThat(stat.applied()).isEqualTo(2L);
+    }
+
+    /** getStat returns EMPTY when there are no APPLY_NOW reports. */
+    @Test
+    void getStatEmptyWhenNoReports() {
+        UUID orgId = UUID.randomUUID();
+        when(reports.query(eq(orgId), isNull(), eq(Recommendation.APPLY_NOW), isNull(), eq(50)))
+                .thenReturn(new com.majordomo.domain.model.Page<>(List.of(), null, false));
+
+        var stat = service.getStat(orgId);
+
+        assertThat(stat).isEqualTo(com.majordomo.domain.model.envoy.ApplyNowConversionStat.EMPTY);
+    }
+
+    /** getStat tolerates missing posting (race / hard-deleted) — counts as not-applied. */
+    @Test
+    void getStatTolerantOfMissingPosting() {
+        UUID orgId = UUID.randomUUID();
+        UUID p1 = UUID.randomUUID();
+        when(reports.query(eq(orgId), isNull(), eq(Recommendation.APPLY_NOW), isNull(), eq(50)))
+                .thenReturn(new com.majordomo.domain.model.Page<>(List.of(
+                        report(UUID.randomUUID(), orgId, p1, 90)), null, false));
+        when(postings.findById(p1, orgId)).thenReturn(Optional.empty());
+
+        var stat = service.getStat(orgId);
+
+        assertThat(stat.total()).isEqualTo(1L);
+        assertThat(stat.applied()).isEqualTo(0L);
+    }
+
+    private static JobPosting applied(UUID id, UUID orgId) {
+        JobPosting p = unapplied(id, orgId);
+        p.setAppliedAt(Instant.parse("2026-04-15T00:00:00Z"));
+        return p;
+    }
+
+    private static JobPosting unapplied(UUID id, UUID orgId) {
+        JobPosting p = new JobPosting();
+        p.setId(id);
+        p.setOrganizationId(orgId);
+        p.setSource("manual");
+        p.setRawText("body");
+        return p;
+    }
+
     private static ScoreReport report(UUID id, UUID orgId, UUID postingId, int finalScore) {
         return new ScoreReport(
                 id, orgId, postingId, UUID.randomUUID(), 1,


### PR DESCRIPTION
## Summary

Pulls the "X of Y APPLY_NOW postings applied" computation out of `EnvoyPageController` and into the application layer where it belongs. The controller was running a second `ScoreReportRepository.query` plus an N+1 posting lookup on every `/envoy` request — read-model logic in an inbound adapter, with no caching.

## What changed

- **Domain DTO**: `ApplyNowConversionStat(total, applied)` record + `EMPTY` sentinel.
- **Inbound port**: `GetApplyNowConversionStatUseCase` (separate interface from `GetRecentApplyNowPostingsUseCase` to keep the ports thin).
- **Implementation**: extends `RecentApplyNowQueryService` (same service, same window). Annotated `@Cacheable(value = "envoy-apply-now-stat", key = "#organizationId")`.
- **Eviction**: `CacheEvictionListener` now also evicts `envoy-apply-now-stat` on `JobPostingScored`, `PostingMarkedApplied`, and `PostingDismissed` — all three move the needle on the rollup.
- **Controller**: replaces ~15 lines of inline computation with a single `conversionStatUseCase.getStat(orgId)` call.

Closes #192

## Test plan

- [x] `RecentApplyNowQueryServiceTest` — 3 new tests: counts applied/non-applied, empty when no APPLY_NOW reports, tolerant of missing posting (race).
- [x] `CacheEvictionListenerTest` — extended `JobPostingScored` test asserts both caches clear; new tests for `PostingMarkedApplied` and `PostingDismissed`.
- [x] `EnvoyPageController` test files updated with the new `@MockitoBean GetApplyNowConversionStatUseCase` and a `@BeforeEach` returning `ApplyNowConversionStat.EMPTY`.
- [x] `./mvnw verify` — 373 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)