### PR TITLE
refactor(envoy): centralize Prometheus instrumentation in EnvoyMetrics (closes #193)

### DIFF
--- a/src/main/java/com/majordomo/application/envoy/EnvoyMetrics.java
+++ b/src/main/java/com/majordomo/application/envoy/EnvoyMetrics.java
@@ -1,0 +1,122 @@
+package com.majordomo.application.envoy;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import org.springframework.stereotype.Component;
+
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Owns the metric names, descriptions, and tag conventions for the Envoy
+ * service so {@link JobScorerService} and {@link PostingConversionService}
+ * don't each carry their own {@code Counter.builder(...)} chains. Metric names
+ * and tag keys are intentionally part of this class's public API surface — they
+ * are also part of the dashboard contract.
+ */
+@Component
+public class EnvoyMetrics {
+
+    /** Counter: prompt tokens consumed by Envoy LLM scoring calls. */
+    static final String LLM_INPUT_TOKENS = "envoy_llm_input_tokens_total";
+
+    /** Counter: completion tokens produced by Envoy LLM scoring calls. */
+    static final String LLM_OUTPUT_TOKENS = "envoy_llm_output_tokens_total";
+
+    /** Timer: wall-clock duration of Envoy LLM scoring calls. */
+    static final String LLM_CALL_DURATION = "envoy_llm_call_duration";
+
+    /** Counter: APPLY_NOW conversions, by outcome (applied / dismissed). */
+    static final String APPLY_NOW_CONVERSION = "envoy_apply_now_conversion_total";
+
+    static final String TAG_ORG = "org";
+    static final String TAG_MODEL = "model";
+    static final String TAG_RUBRIC = "rubric";
+    static final String TAG_OUTCOME = "outcome";
+
+    /** Outcome tag values for {@link #APPLY_NOW_CONVERSION}. */
+    public enum ConversionOutcome {
+        APPLIED("applied"),
+        DISMISSED("dismissed");
+
+        private final String tag;
+
+        ConversionOutcome(String tag) {
+            this.tag = tag;
+        }
+
+        String tag() {
+            return tag;
+        }
+    }
+
+    private final MeterRegistry meterRegistry;
+
+    /**
+     * Constructs the helper.
+     *
+     * @param meterRegistry Micrometer registry to record into
+     */
+    public EnvoyMetrics(MeterRegistry meterRegistry) {
+        this.meterRegistry = meterRegistry;
+    }
+
+    /**
+     * Records the wall-clock duration of an LLM scoring call.
+     *
+     * @param modelId   model identifier (e.g. {@code claude-sonnet-4-6})
+     * @param outcome   {@code success} or {@code error}
+     * @param elapsedNs elapsed time in nanoseconds
+     */
+    public void recordLlmCallDuration(String modelId, String outcome, long elapsedNs) {
+        Timer.builder(LLM_CALL_DURATION)
+                .description("Wall-clock duration of envoy LLM scoring calls")
+                .tag(TAG_MODEL, modelId)
+                .tag(TAG_OUTCOME, outcome)
+                .register(meterRegistry)
+                .record(elapsedNs, TimeUnit.NANOSECONDS);
+    }
+
+    /**
+     * Increments the LLM token counters by the per-call usage.
+     *
+     * @param organizationId owning org (used as a tag value)
+     * @param modelId        model identifier
+     * @param rubricName     rubric name used for the call
+     * @param inputTokens    prompt tokens consumed
+     * @param outputTokens   completion tokens produced
+     */
+    public void recordLlmTokenUsage(UUID organizationId, String modelId, String rubricName,
+                                    long inputTokens, long outputTokens) {
+        Counter.builder(LLM_INPUT_TOKENS)
+                .description("Prompt tokens consumed by envoy LLM scoring calls")
+                .tag(TAG_ORG, organizationId.toString())
+                .tag(TAG_MODEL, modelId)
+                .tag(TAG_RUBRIC, rubricName)
+                .register(meterRegistry)
+                .increment(inputTokens);
+        Counter.builder(LLM_OUTPUT_TOKENS)
+                .description("Completion tokens produced by envoy LLM scoring calls")
+                .tag(TAG_ORG, organizationId.toString())
+                .tag(TAG_MODEL, modelId)
+                .tag(TAG_RUBRIC, rubricName)
+                .register(meterRegistry)
+                .increment(outputTokens);
+    }
+
+    /**
+     * Increments the APPLY_NOW conversion counter for the given outcome.
+     *
+     * @param organizationId owning org (used as a tag value)
+     * @param outcome        {@link ConversionOutcome#APPLIED} or {@link ConversionOutcome#DISMISSED}
+     */
+    public void recordApplyNowConversion(UUID organizationId, ConversionOutcome outcome) {
+        Counter.builder(APPLY_NOW_CONVERSION)
+                .description("APPLY_NOW posting conversions, by outcome")
+                .tag(TAG_ORG, organizationId.toString())
+                .tag(TAG_OUTCOME, outcome.tag())
+                .register(meterRegistry)
+                .increment();
+    }
+}

--- a/src/main/java/com/majordomo/application/envoy/JobScorerService.java
+++ b/src/main/java/com/majordomo/application/envoy/JobScorerService.java
@@ -13,16 +13,12 @@ import com.majordomo.domain.port.out.envoy.JobPostingRepository;
 import com.majordomo.domain.port.out.envoy.LlmScoringPort;
 import com.majordomo.domain.port.out.envoy.RubricRepository;
 import com.majordomo.domain.port.out.envoy.ScoreReportRepository;
-import io.micrometer.core.instrument.Counter;
-import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.core.instrument.Timer;
 import org.springframework.stereotype.Service;
 
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
-import java.util.concurrent.TimeUnit;
 
 /**
  * Orchestrates posting scoring. Java owns all deterministic work: load the
@@ -30,22 +26,11 @@ import java.util.concurrent.TimeUnit;
  * {@link ScoreAssembler}, and persist the report. The LLM makes only the fuzzy
  * interpretive choices.
  *
- * <p>Each scoring call also records Prometheus metrics:
- * <ul>
- *     <li>{@code envoy_llm_input_tokens_total} (counter, tags: org, model, rubric)</li>
- *     <li>{@code envoy_llm_output_tokens_total} (counter, tags: org, model, rubric)</li>
- *     <li>{@code envoy_llm_call_duration} (timer, tags: model, outcome)</li>
- * </ul>
- * Token counters are only incremented when the LLM adapter supplies usage data.
- * The timer is always recorded so that latency is visible even for providers
- * that omit token counts.
+ * <p>LLM-call observability (token counters and latency timer) is delegated to
+ * {@link EnvoyMetrics}.</p>
  */
 @Service
 public class JobScorerService implements ScoreJobPostingUseCase {
-
-    private static final String INPUT_TOKENS_METRIC = "envoy_llm_input_tokens_total";
-    private static final String OUTPUT_TOKENS_METRIC = "envoy_llm_output_tokens_total";
-    private static final String CALL_DURATION_METRIC = "envoy_llm_call_duration";
 
     private final RubricRepository rubrics;
     private final JobPostingRepository postings;
@@ -53,7 +38,7 @@ public class JobScorerService implements ScoreJobPostingUseCase {
     private final LlmScoringPort llm;
     private final ScoreAssembler assembler;
     private final EventPublisher eventPublisher;
-    private final MeterRegistry meterRegistry;
+    private final EnvoyMetrics metrics;
 
     /**
      * Constructs the scorer with all required collaborators.
@@ -64,7 +49,7 @@ public class JobScorerService implements ScoreJobPostingUseCase {
      * @param llm            outbound LLM scoring port
      * @param assembler      deterministic LLM-response validator
      * @param eventPublisher domain event publisher
-     * @param meterRegistry  Micrometer registry for token/latency metrics
+     * @param metrics        envoy metrics helper
      */
     public JobScorerService(RubricRepository rubrics,
                             JobPostingRepository postings,
@@ -72,14 +57,14 @@ public class JobScorerService implements ScoreJobPostingUseCase {
                             LlmScoringPort llm,
                             ScoreAssembler assembler,
                             EventPublisher eventPublisher,
-                            MeterRegistry meterRegistry) {
+                            EnvoyMetrics metrics) {
         this.rubrics = rubrics;
         this.postings = postings;
         this.reports = reports;
         this.llm = llm;
         this.assembler = assembler;
         this.eventPublisher = eventPublisher;
-        this.meterRegistry = meterRegistry;
+        this.metrics = metrics;
     }
 
     @Override
@@ -121,11 +106,13 @@ public class JobScorerService implements ScoreJobPostingUseCase {
         try {
             resp = llm.score(posting, rubric);
         } catch (RuntimeException e) {
-            recordTimer(modelId, "error", System.nanoTime() - startNs);
+            metrics.recordLlmCallDuration(modelId, "error", System.nanoTime() - startNs);
             throw e;
         }
-        recordTimer(modelId, "success", System.nanoTime() - startNs);
-        recordTokenUsage(resp, posting.getOrganizationId(), modelId, rubric.name());
+        metrics.recordLlmCallDuration(modelId, "success", System.nanoTime() - startNs);
+        resp.usage().ifPresent(usage -> metrics.recordLlmTokenUsage(
+                posting.getOrganizationId(), modelId, rubric.name(),
+                usage.inputTokens(), usage.outputTokens()));
 
         ScoreReport report = assembler.assemble(posting, rubric, resp, modelId);
         ScoreReport saved = reports.save(report);
@@ -133,36 +120,5 @@ public class JobScorerService implements ScoreJobPostingUseCase {
                 saved.id(), saved.organizationId(), saved.postingId(),
                 saved.finalScore(), saved.recommendation(), Instant.now()));
         return saved;
-    }
-
-    private void recordTimer(String modelId, String outcome, long elapsedNs) {
-        Timer.builder(CALL_DURATION_METRIC)
-                .description("Wall-clock duration of envoy LLM scoring calls")
-                .tag("model", modelId)
-                .tag("outcome", outcome)
-                .register(meterRegistry)
-                .record(elapsedNs, TimeUnit.NANOSECONDS);
-    }
-
-    private void recordTokenUsage(LlmScoreResponse resp,
-                                  UUID organizationId,
-                                  String modelId,
-                                  String rubricName) {
-        resp.usage().ifPresent(usage -> {
-            Counter.builder(INPUT_TOKENS_METRIC)
-                    .description("Prompt tokens consumed by envoy LLM scoring calls")
-                    .tag("org", organizationId.toString())
-                    .tag("model", modelId)
-                    .tag("rubric", rubricName)
-                    .register(meterRegistry)
-                    .increment(usage.inputTokens());
-            Counter.builder(OUTPUT_TOKENS_METRIC)
-                    .description("Completion tokens produced by envoy LLM scoring calls")
-                    .tag("org", organizationId.toString())
-                    .tag("model", modelId)
-                    .tag("rubric", rubricName)
-                    .register(meterRegistry)
-                    .increment(usage.outputTokens());
-        });
     }
 }

--- a/src/main/java/com/majordomo/application/envoy/PostingConversionService.java
+++ b/src/main/java/com/majordomo/application/envoy/PostingConversionService.java
@@ -6,8 +6,6 @@ import com.majordomo.domain.model.event.PostingMarkedApplied;
 import com.majordomo.domain.port.in.envoy.MarkPostingConversionUseCase;
 import com.majordomo.domain.port.out.EventPublisher;
 import com.majordomo.domain.port.out.envoy.JobPostingRepository;
-import io.micrometer.core.instrument.Counter;
-import io.micrometer.core.instrument.MeterRegistry;
 import org.springframework.stereotype.Service;
 
 import java.time.Instant;
@@ -16,32 +14,29 @@ import java.util.UUID;
 /**
  * Records the user's response to an APPLY_NOW recommendation: either applied
  * or dismissed. Both are terminal — re-marking has no effect. Each transition
- * publishes a domain event (consumed by the audit listener) and increments
- * a Prometheus counter so conversion rate is observable.
+ * publishes a domain event (consumed by the audit listener) and delegates to
+ * {@link EnvoyMetrics} for Prometheus instrumentation.
  */
 @Service
 public class PostingConversionService implements MarkPostingConversionUseCase {
 
-    /** Total APPLY_NOW conversions, tagged by org and outcome={applied,dismissed}. */
-    static final String CONVERSION_METRIC = "envoy_apply_now_conversion_total";
-
     private final JobPostingRepository postings;
     private final EventPublisher eventPublisher;
-    private final MeterRegistry meterRegistry;
+    private final EnvoyMetrics metrics;
 
     /**
      * Constructs the service.
      *
      * @param postings       outbound port for postings
      * @param eventPublisher domain event publisher
-     * @param meterRegistry  metrics registry for the conversion counter
+     * @param metrics        envoy metrics helper
      */
     public PostingConversionService(JobPostingRepository postings,
                                     EventPublisher eventPublisher,
-                                    MeterRegistry meterRegistry) {
+                                    EnvoyMetrics metrics) {
         this.postings = postings;
         this.eventPublisher = eventPublisher;
-        this.meterRegistry = meterRegistry;
+        this.metrics = metrics;
     }
 
     @Override
@@ -56,12 +51,7 @@ public class PostingConversionService implements MarkPostingConversionUseCase {
         posting.setAppliedAt(now);
         postings.save(posting);
         eventPublisher.publish(new PostingMarkedApplied(postingId, organizationId, now));
-        Counter.builder(CONVERSION_METRIC)
-                .description("APPLY_NOW posting conversions, by outcome")
-                .tag("org", organizationId.toString())
-                .tag("outcome", "applied")
-                .register(meterRegistry)
-                .increment();
+        metrics.recordApplyNowConversion(organizationId, EnvoyMetrics.ConversionOutcome.APPLIED);
     }
 
     @Override
@@ -76,11 +66,6 @@ public class PostingConversionService implements MarkPostingConversionUseCase {
         posting.setDismissedAt(now);
         postings.save(posting);
         eventPublisher.publish(new PostingDismissed(postingId, organizationId, now));
-        Counter.builder(CONVERSION_METRIC)
-                .description("APPLY_NOW posting conversions, by outcome")
-                .tag("org", organizationId.toString())
-                .tag("outcome", "dismissed")
-                .register(meterRegistry)
-                .increment();
+        metrics.recordApplyNowConversion(organizationId, EnvoyMetrics.ConversionOutcome.DISMISSED);
     }
 }

--- a/src/test/java/com/majordomo/application/envoy/EnvoyMetricsTest.java
+++ b/src/test/java/com/majordomo/application/envoy/EnvoyMetricsTest.java
@@ -1,0 +1,74 @@
+package com.majordomo.application.envoy;
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link EnvoyMetrics}.
+ *
+ * <p>The metric names and tag keys exercised here are part of the dashboard
+ * contract; these assertions exist explicitly to break loudly if a refactor
+ * changes either.</p>
+ */
+class EnvoyMetricsTest {
+
+    private final SimpleMeterRegistry registry = new SimpleMeterRegistry();
+    private final EnvoyMetrics metrics = new EnvoyMetrics(registry);
+
+    /** Token-usage call increments the input + output counters with the expected tag keys. */
+    @Test
+    void recordLlmTokenUsageIncrementsBothCounters() {
+        UUID orgId = UUID.randomUUID();
+
+        metrics.recordLlmTokenUsage(orgId, "claude-sonnet-4-6", "default", 100, 50);
+
+        var input = registry.get("envoy_llm_input_tokens_total")
+                .tag("org", orgId.toString())
+                .tag("model", "claude-sonnet-4-6")
+                .tag("rubric", "default")
+                .counter();
+        var output = registry.get("envoy_llm_output_tokens_total")
+                .tag("org", orgId.toString())
+                .tag("model", "claude-sonnet-4-6")
+                .tag("rubric", "default")
+                .counter();
+        assertThat(input.count()).isEqualTo(100.0);
+        assertThat(output.count()).isEqualTo(50.0);
+    }
+
+    /** LLM call duration timer is recorded under the model + outcome tag pair. */
+    @Test
+    void recordLlmCallDurationRecordsTimer() {
+        metrics.recordLlmCallDuration("claude-sonnet-4-6", "success", 12_345_678L);
+
+        var timer = registry.get("envoy_llm_call_duration")
+                .tag("model", "claude-sonnet-4-6")
+                .tag("outcome", "success")
+                .timer();
+        assertThat(timer.count()).isEqualTo(1L);
+    }
+
+    /** APPLY_NOW conversion counter is tagged by org and outcome={applied,dismissed}. */
+    @Test
+    void recordApplyNowConversionUsesCorrectTags() {
+        UUID orgId = UUID.randomUUID();
+
+        metrics.recordApplyNowConversion(orgId, EnvoyMetrics.ConversionOutcome.APPLIED);
+        metrics.recordApplyNowConversion(orgId, EnvoyMetrics.ConversionOutcome.DISMISSED);
+
+        var applied = registry.get("envoy_apply_now_conversion_total")
+                .tag("org", orgId.toString())
+                .tag("outcome", "applied")
+                .counter();
+        var dismissed = registry.get("envoy_apply_now_conversion_total")
+                .tag("org", orgId.toString())
+                .tag("outcome", "dismissed")
+                .counter();
+        assertThat(applied.count()).isEqualTo(1.0);
+        assertThat(dismissed.count()).isEqualTo(1.0);
+    }
+}

--- a/src/test/java/com/majordomo/application/envoy/JobScorerServiceTest.java
+++ b/src/test/java/com/majordomo/application/envoy/JobScorerServiceTest.java
@@ -59,7 +59,7 @@ class JobScorerServiceTest {
         meterRegistry = new SimpleMeterRegistry();
         scorer = new JobScorerService(
                 rubrics, postings, reports, llm, new ScoreAssembler(),
-                eventPublisher, meterRegistry);
+                eventPublisher, new EnvoyMetrics(meterRegistry));
         rubric = new Rubric(UuidFactory.newId(), Optional.empty(), 1, "default",
                 List.of(),
                 List.of(new Category("compensation", "pay", 20,

--- a/src/test/java/com/majordomo/application/envoy/PostingConversionServiceTest.java
+++ b/src/test/java/com/majordomo/application/envoy/PostingConversionServiceTest.java
@@ -30,8 +30,9 @@ class PostingConversionServiceTest {
     private final JobPostingRepository postings = mock(JobPostingRepository.class);
     private final EventPublisher events = mock(EventPublisher.class);
     private final SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
+    private final EnvoyMetrics metrics = new EnvoyMetrics(meterRegistry);
     private final PostingConversionService service =
-            new PostingConversionService(postings, events, meterRegistry);
+            new PostingConversionService(postings, events, metrics);
 
     /** markApplied stamps appliedAt, persists, publishes the event, and increments the applied counter. */
     @Test
@@ -150,7 +151,7 @@ class PostingConversionServiceTest {
     }
 
     private double counterCount(String outcome, UUID orgId) {
-        var counter = meterRegistry.find(PostingConversionService.CONVERSION_METRIC)
+        var counter = meterRegistry.find(EnvoyMetrics.APPLY_NOW_CONVERSION)
                 .tag("org", orgId.toString())
                 .tag("outcome", outcome)
                 .counter();


### PR DESCRIPTION
## Summary

Pulls Prometheus instrumentation out of `JobScorerService` and `PostingConversionService` into a single `EnvoyMetrics` component that owns metric names, descriptions, and tag conventions. Backward-compatible: metric names, tag keys, and tag values are unchanged.

## What changed

- New `EnvoyMetrics` (`@Component` in `application/envoy/`) with three typed helpers:
  - `recordLlmCallDuration(modelId, outcome, elapsedNs)` → `envoy_llm_call_duration` timer.
  - `recordLlmTokenUsage(orgId, modelId, rubric, in, out)` → `envoy_llm_input_tokens_total` + `envoy_llm_output_tokens_total` counters.
  - `recordApplyNowConversion(orgId, ConversionOutcome)` → `envoy_apply_now_conversion_total` counter.
- `JobScorerService` and `PostingConversionService` now depend on `EnvoyMetrics` instead of `MeterRegistry`. The `runOne` body lost ~10 lines of meter plumbing.
- `ConversionOutcome` enum (APPLIED / DISMISSED) replaces stringly-typed `"applied"` / `"dismissed"` at the call site.

Closes #193

## Test plan

- [x] New `EnvoyMetricsTest` (3 tests) explicitly asserting metric names + tag keys to break loudly if the dashboard contract changes.
- [x] Existing `JobScorerServiceTest` (12 tests) and `PostingConversionServiceTest` (6 tests) updated to construct `EnvoyMetrics` from the test `SimpleMeterRegistry`. Tag-shape assertions retained — they pass unchanged because metric names + tags are identical to the pre-refactor contract.
- [x] `./mvnw verify` — 371 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)