### PR TITLE
refactor(envoy): ScoreReportFilter object replaces 5-param query signature (closes #197)

### DIFF
--- a/src/main/java/com/majordomo/adapter/in/web/envoy/EnvoyPageController.java
+++ b/src/main/java/com/majordomo/adapter/in/web/envoy/EnvoyPageController.java
@@ -6,6 +6,7 @@ import com.majordomo.domain.model.envoy.JobPosting;
 import com.majordomo.domain.model.envoy.JobSourceRequest;
 import com.majordomo.domain.model.envoy.Recommendation;
 import com.majordomo.domain.model.envoy.ScoreReport;
+import com.majordomo.domain.model.envoy.ScoreReportFilter;
 import com.majordomo.domain.port.in.envoy.GetApplyNowConversionStatUseCase;
 import com.majordomo.domain.port.in.envoy.IngestJobPostingUseCase;
 import com.majordomo.domain.port.in.envoy.MarkPostingConversionUseCase;
@@ -202,7 +203,8 @@ public class EnvoyPageController {
                                  Model model) {
         UUID orgId = ctx.organizationId();
         List<ScoreReport> recent = reports
-                .query(orgId, minFinalScore, recommendation, null, DEFAULT_LIMIT)
+                .query(orgId, new ScoreReportFilter(minFinalScore, recommendation),
+                        null, DEFAULT_LIMIT)
                 .items();
 
         List<ScoreReportRow> rows = recent.stream()

--- a/src/main/java/com/majordomo/adapter/in/web/envoy/ReportController.java
+++ b/src/main/java/com/majordomo/adapter/in/web/envoy/ReportController.java
@@ -4,6 +4,7 @@ import com.majordomo.application.identity.OrganizationAccessService;
 import com.majordomo.domain.model.Page;
 import com.majordomo.domain.model.envoy.Recommendation;
 import com.majordomo.domain.model.envoy.ScoreReport;
+import com.majordomo.domain.model.envoy.ScoreReportFilter;
 import com.majordomo.domain.port.in.envoy.QueryScoreReportsUseCase;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
@@ -54,7 +55,8 @@ public class ReportController {
             @RequestParam(required = false) UUID cursor,
             @RequestParam(defaultValue = "20") int limit) {
         organizationAccessService.verifyAccess(organizationId);
-        return query.query(organizationId, minFinalScore, recommendation, cursor, limit);
+        return query.query(organizationId,
+                new ScoreReportFilter(minFinalScore, recommendation), cursor, limit);
     }
 
     /**

--- a/src/main/java/com/majordomo/adapter/out/persistence/envoy/ScoreReportRepositoryAdapter.java
+++ b/src/main/java/com/majordomo/adapter/out/persistence/envoy/ScoreReportRepositoryAdapter.java
@@ -1,8 +1,8 @@
 package com.majordomo.adapter.out.persistence.envoy;
 
 import com.majordomo.domain.model.Page;
-import com.majordomo.domain.model.envoy.Recommendation;
 import com.majordomo.domain.model.envoy.ScoreReport;
+import com.majordomo.domain.model.envoy.ScoreReportFilter;
 import com.majordomo.domain.port.out.envoy.ScoreReportRepository;
 import org.springframework.data.domain.Limit;
 import org.springframework.data.domain.Sort;
@@ -39,13 +39,13 @@ public class ScoreReportRepositoryAdapter implements ScoreReportRepository {
     }
 
     @Override
-    public Page<ScoreReport> query(UUID organizationId, Integer minFinalScore,
-                                   Recommendation recommendation, UUID cursor, int limit) {
+    public Page<ScoreReport> query(UUID organizationId, ScoreReportFilter filter,
+                                   UUID cursor, int limit) {
         int clamped = Math.max(1, Math.min(limit, 100));
         List<ScoreReportEntity> rows = jpa.query(
                 organizationId,
-                minFinalScore,
-                recommendation == null ? null : recommendation.name(),
+                filter.minFinalScore(),
+                filter.recommendation() == null ? null : filter.recommendation().name(),
                 cursor,
                 Sort.by("id").ascending(),
                 Limit.of(clamped + 1));

--- a/src/main/java/com/majordomo/application/envoy/RecentApplyNowQueryService.java
+++ b/src/main/java/com/majordomo/application/envoy/RecentApplyNowQueryService.java
@@ -5,6 +5,7 @@ import com.majordomo.domain.model.envoy.ApplyNowPosting;
 import com.majordomo.domain.model.envoy.JobPosting;
 import com.majordomo.domain.model.envoy.Recommendation;
 import com.majordomo.domain.model.envoy.ScoreReport;
+import com.majordomo.domain.model.envoy.ScoreReportFilter;
 import com.majordomo.domain.port.in.envoy.GetApplyNowConversionStatUseCase;
 import com.majordomo.domain.port.in.envoy.GetRecentApplyNowPostingsUseCase;
 import com.majordomo.domain.port.out.envoy.JobPostingRepository;
@@ -49,14 +50,16 @@ public class RecentApplyNowQueryService
     @Cacheable(value = "envoy-apply-now", key = "#organizationId + ':' + #limit")
     public List<ApplyNowPosting> getRecentApplyNow(UUID organizationId, int limit) {
         int clamped = Math.max(1, Math.min(limit, 100));
-        var page = reports.query(organizationId, null, Recommendation.APPLY_NOW, null, clamped);
+        var page = reports.query(organizationId,
+                ScoreReportFilter.withRecommendation(Recommendation.APPLY_NOW), null, clamped);
         return page.items().stream().map(report -> enrich(report, organizationId)).toList();
     }
 
     @Override
     @Cacheable(value = "envoy-apply-now-stat", key = "#organizationId")
     public ApplyNowConversionStat getStat(UUID organizationId) {
-        var page = reports.query(organizationId, null, Recommendation.APPLY_NOW, null, STAT_WINDOW);
+        var page = reports.query(organizationId,
+                ScoreReportFilter.withRecommendation(Recommendation.APPLY_NOW), null, STAT_WINDOW);
         long total = page.items().size();
         if (total == 0) {
             return ApplyNowConversionStat.EMPTY;

--- a/src/main/java/com/majordomo/application/envoy/ScoreReportQueryService.java
+++ b/src/main/java/com/majordomo/application/envoy/ScoreReportQueryService.java
@@ -1,8 +1,8 @@
 package com.majordomo.application.envoy;
 
 import com.majordomo.domain.model.Page;
-import com.majordomo.domain.model.envoy.Recommendation;
 import com.majordomo.domain.model.envoy.ScoreReport;
+import com.majordomo.domain.model.envoy.ScoreReportFilter;
 import com.majordomo.domain.port.in.envoy.QueryScoreReportsUseCase;
 import com.majordomo.domain.port.out.envoy.ScoreReportRepository;
 import org.springframework.stereotype.Service;
@@ -31,9 +31,9 @@ public class ScoreReportQueryService implements QueryScoreReportsUseCase {
     }
 
     @Override
-    public Page<ScoreReport> query(UUID organizationId, Integer minFinalScore,
-                                   Recommendation recommendation, UUID cursor, int limit) {
+    public Page<ScoreReport> query(UUID organizationId, ScoreReportFilter filter,
+                                   UUID cursor, int limit) {
         int clamped = Math.max(1, Math.min(limit, 100));
-        return repo.query(organizationId, minFinalScore, recommendation, cursor, clamped);
+        return repo.query(organizationId, filter, cursor, clamped);
     }
 }

--- a/src/main/java/com/majordomo/domain/model/envoy/ScoreReportFilter.java
+++ b/src/main/java/com/majordomo/domain/model/envoy/ScoreReportFilter.java
@@ -1,0 +1,35 @@
+package com.majordomo.domain.model.envoy;
+
+/**
+ * Optional filters applied to a {@code ScoreReportRepository.query} call.
+ * Each field is nullable; {@code null} means "no filter on that field".
+ *
+ * <p>Use {@link #none()} for an unfiltered query and the {@code with*}
+ * helpers to build narrower filters fluently.</p>
+ *
+ * @param minFinalScore  include only reports with {@code finalScore >= this} (null = no minimum)
+ * @param recommendation include only reports with this recommendation (null = any)
+ */
+public record ScoreReportFilter(Integer minFinalScore, Recommendation recommendation) {
+
+    private static final ScoreReportFilter NONE = new ScoreReportFilter(null, null);
+
+    /**
+     * Returns the no-op filter.
+     *
+     * @return the singleton "no filter" instance
+     */
+    public static ScoreReportFilter none() {
+        return NONE;
+    }
+
+    /**
+     * Returns a filter narrowed to the given recommendation tier.
+     *
+     * @param recommendation required recommendation tier
+     * @return a filter where only that tier passes
+     */
+    public static ScoreReportFilter withRecommendation(Recommendation recommendation) {
+        return new ScoreReportFilter(null, recommendation);
+    }
+}

--- a/src/main/java/com/majordomo/domain/port/in/envoy/QueryScoreReportsUseCase.java
+++ b/src/main/java/com/majordomo/domain/port/in/envoy/QueryScoreReportsUseCase.java
@@ -1,8 +1,8 @@
 package com.majordomo.domain.port.in.envoy;
 
 import com.majordomo.domain.model.Page;
-import com.majordomo.domain.model.envoy.Recommendation;
 import com.majordomo.domain.model.envoy.ScoreReport;
+import com.majordomo.domain.model.envoy.ScoreReportFilter;
 
 import java.util.Optional;
 import java.util.UUID;
@@ -23,12 +23,10 @@ public interface QueryScoreReportsUseCase {
      * Cursor-paginated, filterable report query within an org.
      *
      * @param organizationId required org scope
-     * @param minFinalScore  optional min score (null = no lower bound)
-     * @param recommendation optional recommendation filter (null = any)
+     * @param filter         optional secondary filters (use {@link ScoreReportFilter#none()})
      * @param cursor         optional cursor (null = first page)
      * @param limit          row cap (clamped to [1, 100])
      * @return page of reports
      */
-    Page<ScoreReport> query(UUID organizationId, Integer minFinalScore,
-                            Recommendation recommendation, UUID cursor, int limit);
+    Page<ScoreReport> query(UUID organizationId, ScoreReportFilter filter, UUID cursor, int limit);
 }

--- a/src/main/java/com/majordomo/domain/port/out/envoy/ScoreReportRepository.java
+++ b/src/main/java/com/majordomo/domain/port/out/envoy/ScoreReportRepository.java
@@ -1,8 +1,8 @@
 package com.majordomo.domain.port.out.envoy;
 
 import com.majordomo.domain.model.Page;
-import com.majordomo.domain.model.envoy.Recommendation;
 import com.majordomo.domain.model.envoy.ScoreReport;
+import com.majordomo.domain.model.envoy.ScoreReportFilter;
 
 import java.util.Optional;
 import java.util.UUID;
@@ -30,16 +30,15 @@ public interface ScoreReportRepository {
     Optional<ScoreReport> findById(UUID id, UUID organizationId);
 
     /**
-     * Cursor-paginated query over reports within an organization, with optional
-     * secondary filters. Null filter values mean "no filter on that field".
+     * Cursor-paginated query over reports within an organization. Optional
+     * filters are bundled into {@link ScoreReportFilter}; pass
+     * {@link ScoreReportFilter#none()} for an unfiltered query.
      *
      * @param organizationId required — reports are always org-scoped
-     * @param minFinalScore  include only reports with finalScore &gt;= this (null = no minimum)
-     * @param recommendation include only reports with this recommendation (null = any)
+     * @param filter         optional secondary filters (never {@code null})
      * @param cursor         next-page cursor (null = first page)
      * @param limit          clamped to [1, 100] by the caller; repository must honour limit+1
-     * @return a page of reports in the given org matching the filters
+     * @return a page of reports in the given org matching the filter
      */
-    Page<ScoreReport> query(UUID organizationId, Integer minFinalScore,
-                            Recommendation recommendation, UUID cursor, int limit);
+    Page<ScoreReport> query(UUID organizationId, ScoreReportFilter filter, UUID cursor, int limit);
 }

--- a/src/test/java/com/majordomo/adapter/in/web/envoy/EnvoyPageControllerTest.java
+++ b/src/test/java/com/majordomo/adapter/in/web/envoy/EnvoyPageControllerTest.java
@@ -10,6 +10,7 @@ import com.majordomo.domain.model.envoy.FlagHit;
 import com.majordomo.domain.model.envoy.JobPosting;
 import com.majordomo.domain.model.envoy.Recommendation;
 import com.majordomo.domain.model.envoy.ScoreReport;
+import com.majordomo.domain.model.envoy.ScoreReportFilter;
 import com.majordomo.domain.model.identity.Membership;
 import com.majordomo.domain.model.identity.User;
 import com.majordomo.domain.model.envoy.ApplyNowConversionStat;
@@ -74,7 +75,6 @@ class EnvoyPageControllerTest {
                 .thenReturn(ApplyNowConversionStat.EMPTY);
     }
 
-
     @Test
     @WithMockUser(username = "robsartin")
     void rendersEnvoyPageWithEnrichedRows() throws Exception {
@@ -98,7 +98,7 @@ class EnvoyPageControllerTest {
 
         when(currentOrg.resolve(any(UserDetails.class)))
                 .thenReturn(new CurrentOrganizationResolver.Resolved(user, ORG_ID));
-        when(reports.query(eq(ORG_ID), any(), any(), any(), any(Integer.class)))
+        when(reports.query(eq(ORG_ID), any(ScoreReportFilter.class), any(), any(Integer.class)))
                 .thenReturn(new Page<>(List.of(report), null, false));
         when(jobPostingRepository.findById(postingId, ORG_ID)).thenReturn(Optional.of(posting));
 
@@ -146,7 +146,7 @@ class EnvoyPageControllerTest {
 
         when(currentOrg.resolve(any(UserDetails.class)))
                 .thenReturn(new CurrentOrganizationResolver.Resolved(user, ORG_ID));
-        when(reports.query(eq(ORG_ID), any(), any(), any(), any(Integer.class)))
+        when(reports.query(eq(ORG_ID), any(ScoreReportFilter.class), any(), any(Integer.class)))
                 .thenReturn(new Page<>(List.of(report), null, false));
         when(jobPostingRepository.findById(postingId, ORG_ID)).thenReturn(Optional.of(posting));
 
@@ -181,7 +181,7 @@ class EnvoyPageControllerTest {
 
         when(currentOrg.resolve(any(UserDetails.class)))
                 .thenReturn(new CurrentOrganizationResolver.Resolved(user, ORG_ID));
-        when(reports.query(eq(ORG_ID), any(), any(), any(), any(Integer.class)))
+        when(reports.query(eq(ORG_ID), any(ScoreReportFilter.class), any(), any(Integer.class)))
                 .thenReturn(new Page<>(List.of(report), null, false));
         when(jobPostingRepository.findById(postingId, ORG_ID)).thenReturn(Optional.empty());
 
@@ -229,7 +229,7 @@ class EnvoyPageControllerTest {
 
         when(currentOrg.resolve(any(UserDetails.class)))
                 .thenReturn(new CurrentOrganizationResolver.Resolved(user, ORG_ID));
-        when(reports.query(eq(ORG_ID), any(), any(), any(), any(Integer.class)))
+        when(reports.query(eq(ORG_ID), any(ScoreReportFilter.class), any(), any(Integer.class)))
                 .thenReturn(new Page<>(List.of(), null, false));
 
         mvc.perform(get("/envoy"))
@@ -237,7 +237,7 @@ class EnvoyPageControllerTest {
                 .andExpect(model().attribute("minFinalScore", (Object) null))
                 .andExpect(model().attribute("recommendation", (Object) null));
 
-        verify(reports).query(eq(ORG_ID), isNull(), isNull(), isNull(), anyInt());
+        verify(reports).query(eq(ORG_ID), eq(ScoreReportFilter.none()), isNull(), anyInt());
     }
 
     @Test
@@ -250,7 +250,7 @@ class EnvoyPageControllerTest {
 
         when(currentOrg.resolve(any(UserDetails.class)))
                 .thenReturn(new CurrentOrganizationResolver.Resolved(user, ORG_ID));
-        when(reports.query(eq(ORG_ID), any(), any(), any(), any(Integer.class)))
+        when(reports.query(eq(ORG_ID), any(ScoreReportFilter.class), any(), any(Integer.class)))
                 .thenReturn(new Page<>(List.of(), null, false));
 
         mvc.perform(get("/envoy").param("recommendation", "APPLY_NOW"))
@@ -258,8 +258,9 @@ class EnvoyPageControllerTest {
                 .andExpect(model().attribute("minFinalScore", (Object) null))
                 .andExpect(model().attribute("recommendation", Recommendation.APPLY_NOW));
 
-        verify(reports).query(eq(ORG_ID), isNull(),
-                eq(Recommendation.APPLY_NOW), isNull(), anyInt());
+        verify(reports).query(eq(ORG_ID),
+                eq(ScoreReportFilter.withRecommendation(Recommendation.APPLY_NOW)),
+                isNull(), anyInt());
     }
 
     @Test
@@ -272,7 +273,7 @@ class EnvoyPageControllerTest {
 
         when(currentOrg.resolve(any(UserDetails.class)))
                 .thenReturn(new CurrentOrganizationResolver.Resolved(user, ORG_ID));
-        when(reports.query(eq(ORG_ID), any(), any(), any(), any(Integer.class)))
+        when(reports.query(eq(ORG_ID), any(ScoreReportFilter.class), any(), any(Integer.class)))
                 .thenReturn(new Page<>(List.of(), null, false));
 
         mvc.perform(get("/envoy").param("minFinalScore", "70"))
@@ -280,7 +281,7 @@ class EnvoyPageControllerTest {
                 .andExpect(model().attribute("minFinalScore", 70))
                 .andExpect(model().attribute("recommendation", (Object) null));
 
-        verify(reports).query(eq(ORG_ID), eq(70), isNull(), isNull(), anyInt());
+        verify(reports).query(eq(ORG_ID), eq(new ScoreReportFilter(70, null)), isNull(), anyInt());
     }
 
     @Test
@@ -293,7 +294,7 @@ class EnvoyPageControllerTest {
 
         when(currentOrg.resolve(any(UserDetails.class)))
                 .thenReturn(new CurrentOrganizationResolver.Resolved(user, ORG_ID));
-        when(reports.query(eq(ORG_ID), any(), any(), any(), any(Integer.class)))
+        when(reports.query(eq(ORG_ID), any(ScoreReportFilter.class), any(), any(Integer.class)))
                 .thenReturn(new Page<>(List.of(), null, false));
 
         mvc.perform(get("/envoy")
@@ -303,8 +304,7 @@ class EnvoyPageControllerTest {
                 .andExpect(model().attribute("minFinalScore", 70))
                 .andExpect(model().attribute("recommendation", Recommendation.APPLY_NOW));
 
-        verify(reports).query(eq(ORG_ID), eq(70),
-                eq(Recommendation.APPLY_NOW), isNull(), anyInt());
+        verify(reports).query(eq(ORG_ID), eq(new ScoreReportFilter(70, Recommendation.APPLY_NOW)), isNull(), anyInt());
     }
 
     @Test
@@ -317,7 +317,7 @@ class EnvoyPageControllerTest {
 
         when(currentOrg.resolve(any(UserDetails.class)))
                 .thenReturn(new CurrentOrganizationResolver.Resolved(user, ORG_ID));
-        when(reports.query(eq(ORG_ID), any(), any(), any(), any(Integer.class)))
+        when(reports.query(eq(ORG_ID), any(ScoreReportFilter.class), any(), any(Integer.class)))
                 .thenReturn(new Page<>(List.of(), null, false));
 
         MvcResult result = mvc.perform(get("/envoy")

--- a/src/test/java/com/majordomo/adapter/in/web/envoy/EnvoyPageIngestFormTest.java
+++ b/src/test/java/com/majordomo/adapter/in/web/envoy/EnvoyPageIngestFormTest.java
@@ -9,6 +9,7 @@ import com.majordomo.domain.model.envoy.JobPosting;
 import com.majordomo.domain.model.envoy.JobSourceRequest;
 import com.majordomo.domain.model.envoy.Recommendation;
 import com.majordomo.domain.model.envoy.ScoreReport;
+import com.majordomo.domain.model.envoy.ScoreReportFilter;
 import com.majordomo.domain.model.identity.Membership;
 import com.majordomo.domain.model.identity.User;
 import com.majordomo.domain.model.envoy.ApplyNowConversionStat;
@@ -175,7 +176,7 @@ class EnvoyPageIngestFormTest {
                 .thenReturn(new CurrentOrganizationResolver.Resolved(user, ORG_ID));
         when(ingestUseCase.ingest(any(JobSourceRequest.class), eq(ORG_ID)))
                 .thenThrow(new IllegalArgumentException("no JobSource supports type: bogus"));
-        when(reports.query(eq(ORG_ID), any(), any(), any(), any(Integer.class)))
+        when(reports.query(eq(ORG_ID), any(ScoreReportFilter.class), any(), any(Integer.class)))
                 .thenReturn(new Page<>(List.of(), null, false));
 
         mvc.perform(post("/envoy")
@@ -210,7 +211,7 @@ class EnvoyPageIngestFormTest {
         when(ingestUseCase.ingest(any(JobSourceRequest.class), eq(ORG_ID))).thenReturn(saved);
         when(scoreUseCase.score(eq(postingId), eq("default"), eq(ORG_ID)))
                 .thenThrow(new LlmScoringException("LLM returned malformed JSON"));
-        when(reports.query(eq(ORG_ID), any(), any(), any(), any(Integer.class)))
+        when(reports.query(eq(ORG_ID), any(ScoreReportFilter.class), any(), any(Integer.class)))
                 .thenReturn(new Page<>(List.of(), null, false));
 
         mvc.perform(post("/envoy")
@@ -274,7 +275,7 @@ class EnvoyPageIngestFormTest {
 
 
                 .thenReturn(new CurrentOrganizationResolver.Resolved(user, ORG_ID));
-        when(reports.query(eq(ORG_ID), any(), any(), any(), any(Integer.class)))
+        when(reports.query(eq(ORG_ID), any(ScoreReportFilter.class), any(), any(Integer.class)))
                 .thenReturn(new Page<>(List.of(), null, false));
 
         mvc.perform(post("/envoy")

--- a/src/test/java/com/majordomo/adapter/in/web/envoy/ReportControllerTest.java
+++ b/src/test/java/com/majordomo/adapter/in/web/envoy/ReportControllerTest.java
@@ -6,6 +6,7 @@ import com.majordomo.application.identity.OrganizationAccessService;
 import com.majordomo.domain.model.Page;
 import com.majordomo.domain.model.UuidFactory;
 import com.majordomo.domain.model.envoy.Recommendation;
+import com.majordomo.domain.model.envoy.ScoreReportFilter;
 import com.majordomo.domain.model.envoy.ScoreReport;
 import com.majordomo.domain.port.in.envoy.QueryScoreReportsUseCase;
 import com.majordomo.domain.port.out.identity.ApiKeyRepository;
@@ -52,7 +53,7 @@ class ReportControllerTest {
     @WithMockUser
     void listPassesFiltersThrough() throws Exception {
         doNothing().when(organizationAccessService).verifyAccess(any());
-        when(query.query(eq(ORG_ID), any(), any(), any(), any(Integer.class)))
+        when(query.query(eq(ORG_ID), any(ScoreReportFilter.class), any(), any(Integer.class)))
                 .thenReturn(new Page<>(List.of(), null, false));
 
         mvc.perform(get("/api/envoy/reports")
@@ -62,7 +63,8 @@ class ReportControllerTest {
                         .param("limit", "25"))
                 .andExpect(status().isOk());
 
-        verify(query).query(eq(ORG_ID), eq(70), eq(Recommendation.APPLY_NOW), eq(null), eq(25));
+        verify(query).query(eq(ORG_ID),
+                eq(new ScoreReportFilter(70, Recommendation.APPLY_NOW)), eq(null), eq(25));
     }
 
     @Test

--- a/src/test/java/com/majordomo/application/envoy/RecentApplyNowQueryServiceTest.java
+++ b/src/test/java/com/majordomo/application/envoy/RecentApplyNowQueryServiceTest.java
@@ -4,6 +4,7 @@ import com.majordomo.domain.model.Page;
 import com.majordomo.domain.model.envoy.ApplyNowPosting;
 import com.majordomo.domain.model.envoy.JobPosting;
 import com.majordomo.domain.model.envoy.Recommendation;
+import com.majordomo.domain.model.envoy.ScoreReportFilter;
 import com.majordomo.domain.model.envoy.ScoreReport;
 import com.majordomo.domain.port.out.envoy.JobPostingRepository;
 import com.majordomo.domain.port.out.envoy.ScoreReportRepository;
@@ -37,7 +38,9 @@ class RecentApplyNowQueryServiceTest {
         UUID postingId = UUID.randomUUID();
         UUID reportId = UUID.randomUUID();
         ScoreReport report = report(reportId, orgId, postingId, 92);
-        when(reports.query(eq(orgId), isNull(), eq(Recommendation.APPLY_NOW), isNull(), eq(5)))
+        when(reports.query(eq(orgId),
+                        eq(ScoreReportFilter.withRecommendation(Recommendation.APPLY_NOW)),
+                        isNull(), eq(5)))
                 .thenReturn(new Page<>(List.of(report), null, false));
         when(postings.findById(postingId, orgId)).thenReturn(Optional.of(posting(postingId, orgId,
                 "Acme Inc", "Senior Engineer", "Remote")));
@@ -54,7 +57,9 @@ class RecentApplyNowQueryServiceTest {
         UUID orgId = UUID.randomUUID();
         UUID postingId = UUID.randomUUID();
         UUID reportId = UUID.randomUUID();
-        when(reports.query(eq(orgId), isNull(), eq(Recommendation.APPLY_NOW), isNull(), eq(5)))
+        when(reports.query(eq(orgId),
+                        eq(ScoreReportFilter.withRecommendation(Recommendation.APPLY_NOW)),
+                        isNull(), eq(5)))
                 .thenReturn(new Page<>(List.of(report(reportId, orgId, postingId, 90)), null, false));
         when(postings.findById(postingId, orgId)).thenReturn(Optional.empty());
 
@@ -68,24 +73,32 @@ class RecentApplyNowQueryServiceTest {
     @Test
     void clampsLimit() {
         UUID orgId = UUID.randomUUID();
-        when(reports.query(eq(orgId), isNull(), eq(Recommendation.APPLY_NOW), isNull(), eq(1)))
+        when(reports.query(eq(orgId),
+                        eq(ScoreReportFilter.withRecommendation(Recommendation.APPLY_NOW)),
+                        isNull(), eq(1)))
                 .thenReturn(new Page<>(List.of(), null, false));
 
         service.getRecentApplyNow(orgId, 0);
 
-        verify(reports).query(eq(orgId), isNull(), eq(Recommendation.APPLY_NOW), isNull(), eq(1));
+        verify(reports).query(eq(orgId),
+                eq(ScoreReportFilter.withRecommendation(Recommendation.APPLY_NOW)),
+                isNull(), eq(1));
     }
 
     /** Limit above 100 is clamped down. */
     @Test
     void clampsHighLimit() {
         UUID orgId = UUID.randomUUID();
-        when(reports.query(eq(orgId), isNull(), eq(Recommendation.APPLY_NOW), isNull(), eq(100)))
+        when(reports.query(eq(orgId),
+                        eq(ScoreReportFilter.withRecommendation(Recommendation.APPLY_NOW)),
+                        isNull(), eq(100)))
                 .thenReturn(new Page<>(List.of(), null, false));
 
         service.getRecentApplyNow(orgId, 5000);
 
-        verify(reports).query(eq(orgId), isNull(), eq(Recommendation.APPLY_NOW), isNull(), eq(100));
+        verify(reports).query(eq(orgId),
+                eq(ScoreReportFilter.withRecommendation(Recommendation.APPLY_NOW)),
+                isNull(), eq(100));
     }
 
     /** getStat counts APPLY_NOW reports and how many of their postings are applied. */
@@ -95,7 +108,9 @@ class RecentApplyNowQueryServiceTest {
         UUID p1 = UUID.randomUUID();
         UUID p2 = UUID.randomUUID();
         UUID p3 = UUID.randomUUID();
-        when(reports.query(eq(orgId), isNull(), eq(Recommendation.APPLY_NOW), isNull(), eq(50)))
+        when(reports.query(eq(orgId),
+                        eq(ScoreReportFilter.withRecommendation(Recommendation.APPLY_NOW)),
+                        isNull(), eq(50)))
                 .thenReturn(new com.majordomo.domain.model.Page<>(List.of(
                         report(UUID.randomUUID(), orgId, p1, 90),
                         report(UUID.randomUUID(), orgId, p2, 91),
@@ -115,7 +130,9 @@ class RecentApplyNowQueryServiceTest {
     @Test
     void getStatEmptyWhenNoReports() {
         UUID orgId = UUID.randomUUID();
-        when(reports.query(eq(orgId), isNull(), eq(Recommendation.APPLY_NOW), isNull(), eq(50)))
+        when(reports.query(eq(orgId),
+                        eq(ScoreReportFilter.withRecommendation(Recommendation.APPLY_NOW)),
+                        isNull(), eq(50)))
                 .thenReturn(new com.majordomo.domain.model.Page<>(List.of(), null, false));
 
         var stat = service.getStat(orgId);
@@ -128,7 +145,9 @@ class RecentApplyNowQueryServiceTest {
     void getStatTolerantOfMissingPosting() {
         UUID orgId = UUID.randomUUID();
         UUID p1 = UUID.randomUUID();
-        when(reports.query(eq(orgId), isNull(), eq(Recommendation.APPLY_NOW), isNull(), eq(50)))
+        when(reports.query(eq(orgId),
+                        eq(ScoreReportFilter.withRecommendation(Recommendation.APPLY_NOW)),
+                        isNull(), eq(50)))
                 .thenReturn(new com.majordomo.domain.model.Page<>(List.of(
                         report(UUID.randomUUID(), orgId, p1, 90)), null, false));
         when(postings.findById(p1, orgId)).thenReturn(Optional.empty());

--- a/src/test/java/com/majordomo/application/envoy/ScoreReportQueryServiceTest.java
+++ b/src/test/java/com/majordomo/application/envoy/ScoreReportQueryServiceTest.java
@@ -4,6 +4,7 @@ import com.majordomo.domain.model.Page;
 import com.majordomo.domain.model.UuidFactory;
 import com.majordomo.domain.model.envoy.Recommendation;
 import com.majordomo.domain.model.envoy.ScoreReport;
+import com.majordomo.domain.model.envoy.ScoreReportFilter;
 import com.majordomo.domain.port.out.envoy.ScoreReportRepository;
 import org.junit.jupiter.api.Test;
 
@@ -27,12 +28,13 @@ class ScoreReportQueryServiceTest {
     void clampsLimitAndDelegatesToRepository() {
         var repo = mock(ScoreReportRepository.class);
         var service = new ScoreReportQueryService(repo);
-        when(repo.query(eq(orgId), any(), any(), any(), eq(100)))
+        ScoreReportFilter filter = new ScoreReportFilter(60, Recommendation.APPLY_NOW);
+        when(repo.query(eq(orgId), any(ScoreReportFilter.class), any(), eq(100)))
                 .thenReturn(new Page<>(List.of(), null, false));
 
-        service.query(orgId, 60, Recommendation.APPLY_NOW, null, 500);
+        service.query(orgId, filter, null, 500);
 
-        verify(repo).query(orgId, 60, Recommendation.APPLY_NOW, null, 100);
+        verify(repo).query(orgId, filter, null, 100);
     }
 
     @Test

--- a/src/test/java/com/majordomo/domain/model/envoy/ScoreReportFilterTest.java
+++ b/src/test/java/com/majordomo/domain/model/envoy/ScoreReportFilterTest.java
@@ -1,0 +1,33 @@
+package com.majordomo.domain.model.envoy;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link ScoreReportFilter} factory helpers.
+ */
+class ScoreReportFilterTest {
+
+    /** none() returns a singleton with both fields null. */
+    @Test
+    void noneHasBothFieldsNull() {
+        var f = ScoreReportFilter.none();
+        assertThat(f.minFinalScore()).isNull();
+        assertThat(f.recommendation()).isNull();
+    }
+
+    /** none() is identity-stable so callers can safely compare with eq(). */
+    @Test
+    void noneReturnsSameInstance() {
+        assertThat(ScoreReportFilter.none()).isSameAs(ScoreReportFilter.none());
+    }
+
+    /** withRecommendation builds a filter constrained to the given tier. */
+    @Test
+    void withRecommendationOnlyBindsRecommendation() {
+        var f = ScoreReportFilter.withRecommendation(Recommendation.APPLY_NOW);
+        assertThat(f.minFinalScore()).isNull();
+        assertThat(f.recommendation()).isEqualTo(Recommendation.APPLY_NOW);
+    }
+}


### PR DESCRIPTION
## Summary

`ScoreReportRepository.query(orgId, minFinalScore, recommendation, cursor, limit)` (5 params) becomes `query(orgId, ScoreReportFilter, cursor, limit)` (4 params). Same change in `QueryScoreReportsUseCase` and `ScoreReportQueryService`. As filters grow (e.g. APPLY_NOW + applied/dismissed once future issues land), the signature stays stable.

## What changed

- New `ScoreReportFilter(Integer minFinalScore, Recommendation recommendation)` record in `domain/model/envoy/`.
- Factories: `ScoreReportFilter.none()` (singleton) and `ScoreReportFilter.withRecommendation(...)`.
- Three callers updated: `EnvoyPageController`, `ReportController`, `RecentApplyNowQueryService`.
- All affected tests updated to match the new shape.

No behavior change. Cursor + limit stay separate parameters because they aren't filters in the same sense — they're page-shape concerns.

Closes #197

## Test plan

- [x] New `ScoreReportFilterTest` (3 tests): `none()` shape, `none()` identity stability, `withRecommendation` shape.
- [x] All existing tests adapted to the new `query(...)` signature.
- [x] `./mvnw verify` — 383 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)