### PR TITLE
test(ledger,concierge): web slice tests (closes #188)

### DIFF
--- a/src/test/java/com/majordomo/adapter/in/web/concierge/ContactControllerTest.java
+++ b/src/test/java/com/majordomo/adapter/in/web/concierge/ContactControllerTest.java
@@ -1,0 +1,171 @@
+package com.majordomo.adapter.in.web.concierge;
+
+import com.majordomo.adapter.in.web.config.OAuth2UserService;
+import com.majordomo.adapter.in.web.config.SecurityConfig;
+import com.majordomo.application.identity.OrganizationAccessService;
+import com.majordomo.domain.model.Page;
+import com.majordomo.domain.model.UuidFactory;
+import com.majordomo.domain.model.concierge.Contact;
+import com.majordomo.domain.port.in.concierge.ManageContactUseCase;
+import com.majordomo.domain.port.out.identity.ApiKeyRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Slice tests for {@link ContactController}: list / get / create / update / archive.
+ */
+@WebMvcTest(ContactController.class)
+@Import(SecurityConfig.class)
+class ContactControllerTest {
+
+    @Autowired MockMvc mvc;
+
+    @MockitoBean ManageContactUseCase contactUseCase;
+    @MockitoBean OrganizationAccessService organizationAccessService;
+    @MockitoBean ApiKeyRepository apiKeyRepository;
+    @MockitoBean OAuth2UserService oAuth2UserService;
+
+    private static final UUID ORG_ID = UuidFactory.newId();
+
+    /** GET without `q` delegates to findByOrganizationId. */
+    @Test
+    @WithMockUser
+    void listWithoutQueryDelegatesToFindByOrg() throws Exception {
+        Contact c = sample(ORG_ID);
+        when(contactUseCase.findByOrganizationId(eq(ORG_ID), any(), any(Integer.class)))
+                .thenReturn(new Page<>(List.of(c), null, false));
+
+        mvc.perform(get("/api/contacts").param("organizationId", ORG_ID.toString()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.items[0].id").value(c.getId().toString()));
+
+        verify(organizationAccessService).verifyAccess(ORG_ID);
+    }
+
+    /** GET with `q` delegates to search. */
+    @Test
+    @WithMockUser
+    void listWithQueryDelegatesToSearch() throws Exception {
+        when(contactUseCase.search(eq(ORG_ID), eq("smith"), any(), any(Integer.class)))
+                .thenReturn(new Page<>(List.of(), null, false));
+
+        mvc.perform(get("/api/contacts")
+                        .param("organizationId", ORG_ID.toString())
+                        .param("q", "smith"))
+                .andExpect(status().isOk());
+
+        verify(contactUseCase).search(eq(ORG_ID), eq("smith"), any(), any(Integer.class));
+    }
+
+    /** GET /{id} returns 200 when found. */
+    @Test
+    @WithMockUser
+    void getByIdReturnsContact() throws Exception {
+        Contact c = sample(ORG_ID);
+        when(contactUseCase.findById(c.getId())).thenReturn(Optional.of(c));
+
+        mvc.perform(get("/api/contacts/{id}", c.getId()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(c.getId().toString()));
+    }
+
+    /** GET /{id} returns 404 when missing. */
+    @Test
+    @WithMockUser
+    void getByIdReturns404WhenMissing() throws Exception {
+        UUID id = UuidFactory.newId();
+        when(contactUseCase.findById(id)).thenReturn(Optional.empty());
+
+        mvc.perform(get("/api/contacts/{id}", id))
+                .andExpect(status().isNotFound());
+    }
+
+    /** POST creates and returns 201 + Location. */
+    @Test
+    @WithMockUser
+    void createReturns201WithLocation() throws Exception {
+        Contact saved = sample(ORG_ID);
+        when(contactUseCase.create(any(Contact.class))).thenReturn(saved);
+
+        String body = """
+                {
+                  "organizationId": "%s",
+                  "formattedName": "Jane Doe"
+                }
+                """.formatted(ORG_ID);
+
+        mvc.perform(post("/api/contacts")
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isCreated())
+                .andExpect(header().string("Location", "/api/contacts/" + saved.getId()));
+
+        verify(organizationAccessService).verifyAccess(ORG_ID);
+    }
+
+    /** PUT updates and returns 200. */
+    @Test
+    @WithMockUser
+    void updateReturnsUpdated() throws Exception {
+        UUID id = UuidFactory.newId();
+        Contact updated = sample(ORG_ID);
+        updated.setId(id);
+        updated.setFormattedName("Jane Smith");
+        when(contactUseCase.update(eq(id), any(Contact.class))).thenReturn(updated);
+
+        String body = """
+                {"organizationId":"%s","formattedName":"Jane Smith"}
+                """.formatted(ORG_ID);
+
+        mvc.perform(put("/api/contacts/{id}", id)
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.formattedName").value("Jane Smith"));
+    }
+
+    /** DELETE archives and returns 204. */
+    @Test
+    @WithMockUser
+    void archiveReturns204() throws Exception {
+        UUID id = UuidFactory.newId();
+
+        mvc.perform(delete("/api/contacts/{id}", id).with(csrf()))
+                .andExpect(status().isNoContent());
+
+        verify(contactUseCase).archive(id);
+    }
+
+    private static Contact sample(UUID orgId) {
+        Contact c = new Contact();
+        c.setId(UuidFactory.newId());
+        c.setOrganizationId(orgId);
+        c.setFormattedName("Jane Doe");
+        return c;
+    }
+}

--- a/src/test/java/com/majordomo/adapter/in/web/concierge/VCardControllerTest.java
+++ b/src/test/java/com/majordomo/adapter/in/web/concierge/VCardControllerTest.java
@@ -1,0 +1,159 @@
+package com.majordomo.adapter.in.web.concierge;
+
+import com.majordomo.adapter.in.web.config.OAuth2UserService;
+import com.majordomo.adapter.in.web.config.SecurityConfig;
+import com.majordomo.domain.model.UuidFactory;
+import com.majordomo.domain.model.concierge.Contact;
+import com.majordomo.domain.port.in.concierge.ManageContactUseCase;
+import com.majordomo.domain.port.out.identity.ApiKeyRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Slice tests for {@link VCardController}: vCard export + import.
+ */
+@WebMvcTest(VCardController.class)
+@Import(SecurityConfig.class)
+class VCardControllerTest {
+
+    @Autowired MockMvc mvc;
+
+    @MockitoBean ManageContactUseCase contactUseCase;
+    @MockitoBean ApiKeyRepository apiKeyRepository;
+    @MockitoBean OAuth2UserService oAuth2UserService;
+
+    private static final UUID ORG_ID = UuidFactory.newId();
+
+    /** GET /api/contacts/{id}/vcard returns a downloadable vcf. */
+    @Test
+    @WithMockUser
+    void exportSingleReturnsVcfAttachment() throws Exception {
+        Contact c = sample(ORG_ID, "Jane Doe");
+        when(contactUseCase.findById(c.getId())).thenReturn(Optional.of(c));
+
+        var result = mvc.perform(get("/api/contacts/{id}/vcard", c.getId())
+                        .accept("text/vcard"))
+                .andExpect(status().isOk())
+                .andExpect(header().string("Content-Disposition",
+                        "attachment; filename=\"contact.vcf\""))
+                .andReturn();
+
+        String body = result.getResponse().getContentAsString();
+        assertThat(body).contains("BEGIN:VCARD").contains("Jane Doe").contains("END:VCARD");
+    }
+
+    /** GET /api/contacts/{id}/vcard returns 404 when contact missing. */
+    @Test
+    @WithMockUser
+    void exportSingleReturns404WhenMissing() throws Exception {
+        UUID id = UuidFactory.newId();
+        when(contactUseCase.findById(id)).thenReturn(Optional.empty());
+
+        mvc.perform(get("/api/contacts/{id}/vcard", id).accept("text/vcard"))
+                .andExpect(status().isNotFound());
+    }
+
+    /** GET /api/contacts/export returns all org contacts as a multi-vcard file. */
+    @Test
+    @WithMockUser
+    void exportAllReturnsMultiVcard() throws Exception {
+        when(contactUseCase.findByOrganizationId(ORG_ID))
+                .thenReturn(List.of(sample(ORG_ID, "Alice"), sample(ORG_ID, "Bob")));
+
+        var result = mvc.perform(get("/api/contacts/export")
+                        .param("organizationId", ORG_ID.toString())
+                        .accept("text/vcard"))
+                .andExpect(status().isOk())
+                .andExpect(header().string("Content-Disposition",
+                        "attachment; filename=\"contacts.vcf\""))
+                .andReturn();
+
+        String body = result.getResponse().getContentAsString();
+        assertThat(body).contains("Alice").contains("Bob");
+    }
+
+    /** POST /api/contacts/import parses uploaded vCard, creates contacts. */
+    @Test
+    @WithMockUser
+    void importVCardCreatesContactsFromUpload() throws Exception {
+        String vcf = """
+                BEGIN:VCARD
+                VERSION:4.0
+                FN:Casey Imported
+                EMAIL:casey@example.com
+                END:VCARD
+                """;
+        MockMultipartFile file = new MockMultipartFile(
+                "file", "contacts.vcf", "text/vcard", vcf.getBytes());
+        Contact created = sample(ORG_ID, "Casey Imported");
+        when(contactUseCase.create(any(Contact.class))).thenReturn(created);
+
+        mvc.perform(multipart("/api/contacts/import")
+                        .file(file)
+                        .param("organizationId", ORG_ID.toString())
+                        .with(csrf())
+                        .contentType(MediaType.MULTIPART_FORM_DATA))
+                .andExpect(status().isOk());
+
+        verify(contactUseCase).create(any(Contact.class));
+    }
+
+    /** POST /api/contacts/import skips duplicates when skipDuplicates=true. */
+    @Test
+    @WithMockUser
+    void importVCardSkipsDuplicates() throws Exception {
+        String vcf = """
+                BEGIN:VCARD
+                VERSION:4.0
+                FN:Existing User
+                EMAIL:exists@example.com
+                END:VCARD
+                """;
+        MockMultipartFile file = new MockMultipartFile(
+                "file", "contacts.vcf", "text/vcard", vcf.getBytes());
+
+        Contact existing = sample(ORG_ID, "Existing User");
+        existing.setEmails(List.of("exists@example.com"));
+        when(contactUseCase.findByOrganizationId(ORG_ID)).thenReturn(List.of(existing));
+
+        mvc.perform(multipart("/api/contacts/import")
+                        .file(file)
+                        .param("organizationId", ORG_ID.toString())
+                        .param("skipDuplicates", "true")
+                        .with(csrf())
+                        .contentType(MediaType.MULTIPART_FORM_DATA))
+                .andExpect(status().isOk());
+
+        // Skipped — create should not be called.
+        verify(contactUseCase, org.mockito.Mockito.never()).create(any(Contact.class));
+    }
+
+    private static Contact sample(UUID orgId, String name) {
+        Contact c = new Contact();
+        c.setId(UuidFactory.newId());
+        c.setOrganizationId(orgId);
+        c.setFormattedName(name);
+        return c;
+    }
+}

--- a/src/test/java/com/majordomo/adapter/in/web/ledger/LedgerControllerTest.java
+++ b/src/test/java/com/majordomo/adapter/in/web/ledger/LedgerControllerTest.java
@@ -1,0 +1,124 @@
+package com.majordomo.adapter.in.web.ledger;
+
+import com.majordomo.adapter.in.web.config.OAuth2UserService;
+import com.majordomo.adapter.in.web.config.SecurityConfig;
+import com.majordomo.application.identity.OrganizationAccessService;
+import com.majordomo.domain.model.UuidFactory;
+import com.majordomo.domain.model.ledger.SpendSummary;
+import com.majordomo.domain.model.steward.Property;
+import com.majordomo.domain.port.in.ledger.QuerySpendUseCase;
+import com.majordomo.domain.port.out.identity.ApiKeyRepository;
+import com.majordomo.domain.port.out.steward.PropertyRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.math.BigDecimal;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Slice tests for {@link LedgerController}: spend queries under {@code /api/ledger}.
+ */
+@WebMvcTest(LedgerController.class)
+@Import(SecurityConfig.class)
+class LedgerControllerTest {
+
+    @Autowired MockMvc mvc;
+
+    @MockitoBean QuerySpendUseCase querySpendUseCase;
+    @MockitoBean OrganizationAccessService organizationAccessService;
+    @MockitoBean PropertyRepository propertyRepository;
+    @MockitoBean ApiKeyRepository apiKeyRepository;
+    @MockitoBean OAuth2UserService oAuth2UserService;
+
+    private static final UUID ORG_ID = UuidFactory.newId();
+    private static final UUID PROPERTY_ID = UuidFactory.newId();
+
+    /** GET /api/ledger/properties/{id}/spend resolves org via property and returns the summary. */
+    @Test
+    @WithMockUser
+    void spendForPropertyReturnsSummary() throws Exception {
+        Property property = new Property();
+        property.setId(PROPERTY_ID);
+        property.setOrganizationId(ORG_ID);
+        when(propertyRepository.findById(PROPERTY_ID)).thenReturn(Optional.of(property));
+        when(querySpendUseCase.spendForProperty(PROPERTY_ID)).thenReturn(
+                new SpendSummary(new BigDecimal("250000.00"),
+                        new BigDecimal("1200.00"), new BigDecimal("251200.00")));
+
+        mvc.perform(get("/api/ledger/properties/{propertyId}/spend", PROPERTY_ID))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.purchasePrice").value(250000.00))
+                .andExpect(jsonPath("$.maintenanceCost").value(1200.00))
+                .andExpect(jsonPath("$.totalCost").value(251200.00));
+
+        verify(organizationAccessService).verifyAccess(ORG_ID);
+    }
+
+    /** GET /api/ledger/properties/{id}/spend returns 404 + correlation id when property missing. */
+    @Test
+    @WithMockUser
+    void spendForPropertyReturns404WhenPropertyMissing() throws Exception {
+        when(propertyRepository.findById(PROPERTY_ID)).thenReturn(Optional.empty());
+
+        mvc.perform(get("/api/ledger/properties/{propertyId}/spend", PROPERTY_ID))
+                .andExpect(status().isNotFound());
+
+        verify(querySpendUseCase, never()).spendForProperty(PROPERTY_ID);
+    }
+
+    /** GET /api/ledger/organizations/{id}/spend verifies access and returns the org summary. */
+    @Test
+    @WithMockUser
+    void spendForOrganizationReturnsSummary() throws Exception {
+        when(querySpendUseCase.spendForOrganization(ORG_ID)).thenReturn(
+                new SpendSummary(new BigDecimal("500000.00"),
+                        new BigDecimal("3400.50"), new BigDecimal("503400.50")));
+
+        mvc.perform(get("/api/ledger/organizations/{organizationId}/spend", ORG_ID))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.totalCost").value(503400.50));
+
+        verify(organizationAccessService).verifyAccess(ORG_ID);
+    }
+
+    /** Cross-org access on the org-spend endpoint returns 403. */
+    @Test
+    @WithMockUser
+    void spendForOrganizationReturns403WhenAccessDenied() throws Exception {
+        doThrow(new AccessDeniedException("denied"))
+                .when(organizationAccessService).verifyAccess(ORG_ID);
+
+        mvc.perform(get("/api/ledger/organizations/{organizationId}/spend", ORG_ID))
+                .andExpect(status().isForbidden());
+
+        verify(querySpendUseCase, never()).spendForOrganization(ORG_ID);
+    }
+
+    /** GET /api/ledger/organizations/{id}/projected-annual returns the projected annual spend. */
+    @Test
+    @WithMockUser
+    void projectedAnnualReturnsBigDecimal() throws Exception {
+        when(querySpendUseCase.projectedAnnualSpend(ORG_ID)).thenReturn(new BigDecimal("12345.67"));
+
+        mvc.perform(get("/api/ledger/organizations/{organizationId}/projected-annual", ORG_ID))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").value(12345.67));
+
+        verify(organizationAccessService).verifyAccess(ORG_ID);
+    }
+}


### PR DESCRIPTION
## Summary

17 new `@WebMvcTest` cases close the remaining web-controller coverage gaps from the JaCoCo baseline.

**LedgerController (5 tests):**
- `spendForProperty` 200 (verifies access via property's org)
- `spendForProperty` 404 when property missing
- `spendForOrganization` 200
- `spendForOrganization` 403 on `AccessDeniedException`
- `projectedAnnualSpend` 200

**ContactController (7 tests):**
- list without query → `findByOrganizationId`
- list with `q` → `search`
- `getById` 200 / 404
- `create` 201 + Location
- `update` 200
- `archive` 204

**VCardController (5 tests):**
- `exportSingle` 200 + Content-Disposition + body contains FN
- `exportSingle` 404 when missing
- `exportAll` 200 with multi-vcard body
- `importVCard` multipart upload creates contacts
- `importVCard` with `skipDuplicates=true` skips entries with matching email

Closes #188

## Coverage delta

- `adapter.in.web.ledger`: **38.5% → 100.0%** (13/13)
- `adapter.in.web.concierge`: **52.2% → 100.0%** (113/113)

## Test plan

- [x] `./mvnw verify` — 423 tests, 0 failures.
- [x] JaCoCo report regenerated; both packages now at 100% line coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)