### PR TITLE
chore(coverage): merge integration-test coverage into JaCoCo report (closes #189)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,14 +75,15 @@ JSON under `/api/envoy`.
 ## Build Commands
 
 ```bash
-./mvnw validate          # Checkstyle only
-./mvnw compile           # Compile
-./mvnw test              # Run tests
-./mvnw verify            # Full build (compile + checkstyle + test + JaCoCo report)
-./mvnw spring-boot:run   # Start app (requires PostgreSQL + Redis)
+./mvnw validate                       # Checkstyle only
+./mvnw compile                        # Compile
+./mvnw test                           # Unit tests
+./mvnw verify                         # Compile + checkstyle + unit tests + JaCoCo (unit only)
+./mvnw -Pintegration-tests verify     # Above + Failsafe IT phase, JaCoCo merged report
+./mvnw spring-boot:run                # Start app (requires PostgreSQL + Redis)
 ```
 
-JaCoCo writes a coverage report to `target/site/jacoco/index.html` after `verify`. Integration tests (`*IntegrationTest.java`) are excluded from the default Surefire run, so persistence-adapter coverage in the report under-represents what is actually tested — see issue #189 to merge integration-test data into the report.
+JaCoCo writes a coverage report to `target/site/jacoco/index.html` after `verify`. The default profile covers unit tests only. Activate the `integration-tests` profile (Docker required for Testcontainers) to also run `*IntegrationTest.java` via Failsafe; the report then reads a merged exec file (`jacoco-merged.exec`) that includes persistence-adapter coverage too.
 
 ## Known Trade-offs
 

--- a/pom.xml
+++ b/pom.xml
@@ -202,6 +202,13 @@
                 <artifactId>jacoco-maven-plugin</artifactId>
                 <version>${jacoco.version}</version>
                 <executions>
+                    <!--
+                        Default profile: Surefire runs unit tests, agent writes
+                        jacoco.exec, report uses jacoco.exec directly.
+                        The integration-tests profile additionally writes
+                        jacoco-it.exec (Failsafe) and overrides the report to
+                        read a merged exec file.
+                    -->
                     <execution>
                         <id>jacoco-prepare</id>
                         <goals>
@@ -254,15 +261,112 @@
             <id>integration-tests</id>
             <build>
                 <plugins>
+                    <!--
+                        Surefire still runs unit tests only (excluding
+                        *IntegrationTest.java); Failsafe runs integration tests
+                        in the integration-test phase. Splitting them this way
+                        lets JaCoCo's prepare-agent-integration write a
+                        separate jacoco-it.exec file that the merge goal
+                        combines with the unit-test jacoco.exec.
+                    -->
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration combine.self="override">
+                        <configuration>
                             <environmentVariables>
                                 <DOCKER_HOST>${env.DOCKER_HOST}</DOCKER_HOST>
                                 <TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE>${env.TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE}</TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE>
                             </environmentVariables>
                         </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <configuration>
+                            <includes>
+                                <include>**/*IntegrationTest.java</include>
+                            </includes>
+                            <environmentVariables>
+                                <DOCKER_HOST>${env.DOCKER_HOST}</DOCKER_HOST>
+                                <TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE>${env.TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE}</TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE>
+                            </environmentVariables>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>integration-test</id>
+                                <goals>
+                                    <goal>integration-test</goal>
+                                </goals>
+                            </execution>
+                            <execution>
+                                <id>verify</id>
+                                <goals>
+                                    <goal>verify</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.jacoco</groupId>
+                        <artifactId>jacoco-maven-plugin</artifactId>
+                        <executions>
+                            <!--
+                                Attach the IT-phase agent so integration tests
+                                write to a separate exec file.
+                            -->
+                            <execution>
+                                <id>jacoco-prepare-it</id>
+                                <phase>pre-integration-test</phase>
+                                <goals>
+                                    <goal>prepare-agent-integration</goal>
+                                </goals>
+                                <configuration>
+                                    <destFile>${project.build.directory}/jacoco-it.exec</destFile>
+                                </configuration>
+                            </execution>
+                            <!--
+                                Merge unit + integration exec files before the
+                                default report execution runs.
+                            -->
+                            <execution>
+                                <id>jacoco-merge</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>merge</goal>
+                                </goals>
+                                <configuration>
+                                    <fileSets>
+                                        <fileSet>
+                                            <directory>${project.build.directory}</directory>
+                                            <includes>
+                                                <include>jacoco.exec</include>
+                                                <include>jacoco-it.exec</include>
+                                            </includes>
+                                        </fileSet>
+                                    </fileSets>
+                                    <destFile>${project.build.directory}/jacoco-merged.exec</destFile>
+                                </configuration>
+                            </execution>
+                            <!--
+                                Override the default report execution to read
+                                the merged exec file. The merge goal binds to
+                                the same phase ('verify'), but executions in
+                                the same phase run in declaration order, and
+                                the profile's plugin definitions are appended
+                                after the parent's, so jacoco-merge runs
+                                before jacoco-report.
+                            -->
+                            <execution>
+                                <id>jacoco-report</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>report</goal>
+                                </goals>
+                                <configuration>
+                                    <dataFile>${project.build.directory}/jacoco-merged.exec</dataFile>
+                                </configuration>
+                            </execution>
+                        </executions>
                     </plugin>
                 </plugins>
             </build>


### PR DESCRIPTION
## Summary

Splits unit and integration test runs in the `integration-tests` profile so JaCoCo can produce a merged coverage report covering both. Default `mvn verify` is unchanged.

## What changed

**Default profile:** unchanged. Surefire excludes `*IntegrationTest.java`, JaCoCo writes `jacoco.exec`, report uses it directly.

**`integration-tests` profile:**

1. Adds **Failsafe** to run `*IntegrationTest.java` in the `integration-test` phase (with the existing Docker env vars).
2. Adds a JaCoCo `prepare-agent-integration` execution that writes a separate `jacoco-it.exec`.
3. Adds a JaCoCo `merge` execution at the start of the `verify` phase that combines `jacoco.exec` + `jacoco-it.exec` into `jacoco-merged.exec`.
4. Overrides the JaCoCo `report` execution to read the merged file.

CLAUDE.md updated: build commands now show both forms; the under-reporting caveat is removed.

Closes #189

## Why

Persistence adapters under `adapter.out.persistence.*` were reporting 2–8% line coverage in the JaCoCo baseline (#177) because they're exercised exclusively by Testcontainers integration tests, which the default Surefire run excludes. After this PR, `./mvnw -Pintegration-tests verify` (the CI form when Docker is available) produces an accurate per-package report.

## Test plan

- [x] `./mvnw verify` — 423 tests, 0 failures (default profile unchanged).
- [x] `./mvnw -Pintegration-tests help:effective-pom` — profile parses cleanly.
- [ ] Local `./mvnw -Pintegration-tests verify` — not run (Docker daemon unavailable on this host). CI will exercise this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)