### PR TITLE
refactor(envoy): LlmCallObserver wraps LLM scoring observability (closes #196)

### DIFF
--- a/src/main/java/com/majordomo/application/envoy/JobScorerService.java
+++ b/src/main/java/com/majordomo/application/envoy/JobScorerService.java
@@ -26,8 +26,8 @@ import java.util.UUID;
  * {@link ScoreAssembler}, and persist the report. The LLM makes only the fuzzy
  * interpretive choices.
  *
- * <p>LLM-call observability (token counters and latency timer) is delegated to
- * {@link EnvoyMetrics}.</p>
+ * <p>Observability (latency timer + token counters) is delegated to
+ * {@link LlmCallObserver}, so this service holds no observability code.</p>
  */
 @Service
 public class JobScorerService implements ScoreJobPostingUseCase {
@@ -38,7 +38,7 @@ public class JobScorerService implements ScoreJobPostingUseCase {
     private final LlmScoringPort llm;
     private final ScoreAssembler assembler;
     private final EventPublisher eventPublisher;
-    private final EnvoyMetrics metrics;
+    private final LlmCallObserver llmObserver;
 
     /**
      * Constructs the scorer with all required collaborators.
@@ -49,7 +49,7 @@ public class JobScorerService implements ScoreJobPostingUseCase {
      * @param llm            outbound LLM scoring port
      * @param assembler      deterministic LLM-response validator
      * @param eventPublisher domain event publisher
-     * @param metrics        envoy metrics helper
+     * @param llmObserver    observer that wraps each LLM call with metrics
      */
     public JobScorerService(RubricRepository rubrics,
                             JobPostingRepository postings,
@@ -57,14 +57,14 @@ public class JobScorerService implements ScoreJobPostingUseCase {
                             LlmScoringPort llm,
                             ScoreAssembler assembler,
                             EventPublisher eventPublisher,
-                            EnvoyMetrics metrics) {
+                            LlmCallObserver llmObserver) {
         this.rubrics = rubrics;
         this.postings = postings;
         this.reports = reports;
         this.llm = llm;
         this.assembler = assembler;
         this.eventPublisher = eventPublisher;
-        this.metrics = metrics;
+        this.llmObserver = llmObserver;
     }
 
     @Override
@@ -100,21 +100,8 @@ public class JobScorerService implements ScoreJobPostingUseCase {
     }
 
     private ScoreReport runOne(JobPosting posting, Rubric rubric) {
-        String modelId = llm.modelId();
-        long startNs = System.nanoTime();
-        LlmScoreResponse resp;
-        try {
-            resp = llm.score(posting, rubric);
-        } catch (RuntimeException e) {
-            metrics.recordLlmCallDuration(modelId, "error", System.nanoTime() - startNs);
-            throw e;
-        }
-        metrics.recordLlmCallDuration(modelId, "success", System.nanoTime() - startNs);
-        resp.usage().ifPresent(usage -> metrics.recordLlmTokenUsage(
-                posting.getOrganizationId(), modelId, rubric.name(),
-                usage.inputTokens(), usage.outputTokens()));
-
-        ScoreReport report = assembler.assemble(posting, rubric, resp, modelId);
+        LlmScoreResponse resp = llmObserver.observe(llm, posting, rubric);
+        ScoreReport report = assembler.assemble(posting, rubric, resp, llm.modelId());
         ScoreReport saved = reports.save(report);
         eventPublisher.publish(new JobPostingScored(
                 saved.id(), saved.organizationId(), saved.postingId(),

--- a/src/main/java/com/majordomo/application/envoy/LlmCallObserver.java
+++ b/src/main/java/com/majordomo/application/envoy/LlmCallObserver.java
@@ -1,0 +1,56 @@
+package com.majordomo.application.envoy;
+
+import com.majordomo.domain.model.envoy.JobPosting;
+import com.majordomo.domain.model.envoy.LlmScoreResponse;
+import com.majordomo.domain.model.envoy.Rubric;
+import com.majordomo.domain.port.out.envoy.LlmScoringPort;
+import org.springframework.stereotype.Component;
+
+/**
+ * Wraps a single {@link LlmScoringPort#score} call with observability:
+ * latency timer (success / error outcome) and token-usage counters when the
+ * provider supplies a usage payload. Lets {@link JobScorerService} stay pure
+ * orchestration — no timer plumbing, no try/catch around the LLM call.
+ */
+@Component
+public class LlmCallObserver {
+
+    private final EnvoyMetrics metrics;
+
+    /**
+     * Constructs the observer.
+     *
+     * @param metrics envoy metrics helper
+     */
+    public LlmCallObserver(EnvoyMetrics metrics) {
+        this.metrics = metrics;
+    }
+
+    /**
+     * Invokes {@code llm.score(posting, rubric)} with observation around it.
+     * Records the call duration tagged with model + outcome, and increments
+     * token counters tagged with org + model + rubric when usage data is
+     * present. Re-throws any {@link RuntimeException} from the underlying
+     * call after recording an {@code error}-outcome timer sample.
+     *
+     * @param llm     LLM scoring port
+     * @param posting posting being scored (provides org id for token tags)
+     * @param rubric  rubric used (provides rubric name for token tags)
+     * @return the LLM's structured verdict
+     */
+    public LlmScoreResponse observe(LlmScoringPort llm, JobPosting posting, Rubric rubric) {
+        String modelId = llm.modelId();
+        long startNs = System.nanoTime();
+        try {
+            LlmScoreResponse resp = llm.score(posting, rubric);
+            metrics.recordLlmCallDuration(modelId, "success", System.nanoTime() - startNs);
+            resp.usage().ifPresent(usage -> metrics.recordLlmTokenUsage(
+                    posting.getOrganizationId(), modelId, rubric.name(),
+                    usage.inputTokens(), usage.outputTokens()));
+            return resp;
+        } catch (RuntimeException e) {
+            metrics.recordLlmCallDuration(modelId, "error", System.nanoTime() - startNs);
+            throw e;
+        }
+    }
+}

--- a/src/test/java/com/majordomo/application/envoy/JobScorerServiceTest.java
+++ b/src/test/java/com/majordomo/application/envoy/JobScorerServiceTest.java
@@ -59,7 +59,7 @@ class JobScorerServiceTest {
         meterRegistry = new SimpleMeterRegistry();
         scorer = new JobScorerService(
                 rubrics, postings, reports, llm, new ScoreAssembler(),
-                eventPublisher, new EnvoyMetrics(meterRegistry));
+                eventPublisher, new LlmCallObserver(new EnvoyMetrics(meterRegistry)));
         rubric = new Rubric(UuidFactory.newId(), Optional.empty(), 1, "default",
                 List.of(),
                 List.of(new Category("compensation", "pay", 20,

--- a/src/test/java/com/majordomo/application/envoy/LlmCallObserverTest.java
+++ b/src/test/java/com/majordomo/application/envoy/LlmCallObserverTest.java
@@ -1,0 +1,118 @@
+package com.majordomo.application.envoy;
+
+import com.majordomo.domain.model.UuidFactory;
+import com.majordomo.domain.model.envoy.Category;
+import com.majordomo.domain.model.envoy.JobPosting;
+import com.majordomo.domain.model.envoy.LlmScoreResponse;
+import com.majordomo.domain.model.envoy.Rubric;
+import com.majordomo.domain.model.envoy.Thresholds;
+import com.majordomo.domain.model.envoy.Tier;
+import com.majordomo.domain.port.out.envoy.LlmScoringPort;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for {@link LlmCallObserver}. The observer's contract: invoke
+ * {@code llm.score(...)} once, record a duration timer tagged with model +
+ * outcome, and (when usage is present) increment input/output token counters
+ * tagged with org + model + rubric.
+ */
+class LlmCallObserverTest {
+
+    private final SimpleMeterRegistry registry = new SimpleMeterRegistry();
+    private final EnvoyMetrics metrics = new EnvoyMetrics(registry);
+    private final LlmCallObserver observer = new LlmCallObserver(metrics);
+    private final LlmScoringPort llm = mock(LlmScoringPort.class);
+
+    private final UUID orgId = UuidFactory.newId();
+    private JobPosting posting;
+    private Rubric rubric;
+
+    @BeforeEach
+    void setUp() {
+        posting = new JobPosting();
+        posting.setId(UuidFactory.newId());
+        posting.setOrganizationId(orgId);
+        posting.setRawText("body");
+        rubric = new Rubric(UuidFactory.newId(), Optional.empty(), 1, "default",
+                List.of(),
+                List.of(new Category("compensation", "pay", 20,
+                        List.of(new Tier("Good", 15, "$200k")))),
+                List.of(), new Thresholds(20, 15, 5), Instant.now());
+        when(llm.modelId()).thenReturn("claude-sonnet-4-6");
+    }
+
+    /** Success path: returns the response, records success timer + token counters. */
+    @Test
+    void successPathRecordsTimerAndTokens() {
+        when(llm.score(any(), any())).thenReturn(new LlmScoreResponse(
+                Optional.empty(),
+                List.of(new LlmScoreResponse.CategoryVerdict("compensation", "Good", "rationale")),
+                List.of(),
+                Optional.of(new LlmScoreResponse.Usage(100L, 50L, 200L))));
+
+        var resp = observer.observe(llm, posting, rubric);
+
+        assertThat(resp).isNotNull();
+        assertThat(resp.usage()).isPresent();
+        assertThat(registry.get("envoy_llm_call_duration")
+                .tag("model", "claude-sonnet-4-6")
+                .tag("outcome", "success")
+                .timer().count()).isEqualTo(1L);
+        assertThat(registry.get("envoy_llm_input_tokens_total")
+                .tag("org", orgId.toString())
+                .tag("model", "claude-sonnet-4-6")
+                .tag("rubric", "default")
+                .counter().count()).isEqualTo(100.0);
+        assertThat(registry.get("envoy_llm_output_tokens_total")
+                .tag("org", orgId.toString())
+                .tag("model", "claude-sonnet-4-6")
+                .tag("rubric", "default")
+                .counter().count()).isEqualTo(50.0);
+    }
+
+    /** Success without usage: timer fires, token counters never registered. */
+    @Test
+    void successWithoutUsageRecordsTimerOnly() {
+        when(llm.score(any(), any())).thenReturn(new LlmScoreResponse(
+                Optional.empty(),
+                List.of(new LlmScoreResponse.CategoryVerdict("compensation", "Good", "ok")),
+                List.of(), Optional.empty()));
+
+        observer.observe(llm, posting, rubric);
+
+        assertThat(registry.get("envoy_llm_call_duration")
+                .tag("outcome", "success").timer().count()).isEqualTo(1L);
+        assertThat(registry.find("envoy_llm_input_tokens_total").counter()).isNull();
+        assertThat(registry.find("envoy_llm_output_tokens_total").counter()).isNull();
+    }
+
+    /** Error path: re-throws the exception and records an error-outcome timer. */
+    @Test
+    void errorPathReThrowsAndRecordsErrorTimer() {
+        when(llm.score(any(), any())).thenThrow(new LlmScoringException("boom"));
+
+        assertThatThrownBy(() -> observer.observe(llm, posting, rubric))
+                .isInstanceOf(LlmScoringException.class);
+
+        assertThat(registry.get("envoy_llm_call_duration")
+                .tag("model", "claude-sonnet-4-6")
+                .tag("outcome", "error")
+                .timer().count()).isEqualTo(1L);
+        // No success-outcome sample.
+        assertThat(registry.find("envoy_llm_call_duration")
+                .tag("outcome", "success").timer()).isNull();
+    }
+}


### PR DESCRIPTION
## Summary

Pulls latency-timer + token-counter recording out of `JobScorerService.runOne` and into a new `LlmCallObserver`. The scorer's hot loop is now pure orchestration:

```java
LlmScoreResponse resp = llmObserver.observe(llm, posting, rubric);
ScoreReport report = assembler.assemble(posting, rubric, resp, llm.modelId());
ScoreReport saved = reports.save(report);
eventPublisher.publish(new JobPostingScored(...));
```

The observer holds the try/catch around `llm.score(...)` and the timer/counter recording. `JobScorerService` no longer depends on `EnvoyMetrics` directly — `LlmCallObserver` does.

Metric names and tag conventions are unchanged (still `envoy_llm_call_duration` with `model`/`outcome` and `envoy_llm_input_tokens_total` / `envoy_llm_output_tokens_total` with `org`/`model`/`rubric`).

Closes #196

## Test plan

- [x] New `LlmCallObserverTest` (3 tests): success path records timer + tokens; success without usage records timer only; error path re-throws + records error-outcome timer.
- [x] `JobScorerServiceTest` updated to construct via `new LlmCallObserver(new EnvoyMetrics(meterRegistry))`. All 12 existing tests still pass — the same metric assertions hold because the metric contract is unchanged.
- [x] `./mvnw verify` — 426 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)