### PR TITLE
chore(persistence): JsonColumnCodec utility (closes #195)

### DIFF
--- a/src/main/java/com/majordomo/adapter/out/persistence/JsonColumnCodec.java
+++ b/src/main/java/com/majordomo/adapter/out/persistence/JsonColumnCodec.java
@@ -1,0 +1,92 @@
+package com.majordomo.adapter.out.persistence;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
+/**
+ * Codec for JSONB persistence columns. Centralises the Jackson setup and the
+ * try/catch translation of serialisation errors into {@link IllegalStateException}
+ * that mappers across the persistence layer were previously duplicating.
+ *
+ * <p>This is a static-only utility because the {@link ObjectMapper} is thread-safe
+ * after configuration and there is exactly one canonical configuration for the
+ * codebase: {@link JavaTimeModule} for {@code Instant}/{@code LocalDate} round-trip
+ * and {@link Jdk8Module} for {@code Optional}.</p>
+ */
+public final class JsonColumnCodec {
+
+    private static final ObjectMapper MAPPER = JsonMapper.builder()
+            .addModule(new JavaTimeModule())
+            .addModule(new Jdk8Module())
+            .build();
+
+    private JsonColumnCodec() { }
+
+    /**
+     * Serialises a value to its JSON string form for storage in a JSONB column.
+     *
+     * @param value value to serialise (may be {@code null}, in which case
+     *              {@code null} is returned)
+     * @param label short label included in the error message — typically the
+     *              entity type or column name being serialised
+     * @return the JSON representation, or {@code null} if {@code value} was {@code null}
+     * @throws IllegalStateException if Jackson fails to serialise
+     */
+    public static String encode(Object value, String label) {
+        if (value == null) {
+            return null;
+        }
+        try {
+            return MAPPER.writeValueAsString(value);
+        } catch (Exception ex) {
+            throw new IllegalStateException("Failed to serialise " + label, ex);
+        }
+    }
+
+    /**
+     * Deserialises a JSON string into a class.
+     *
+     * @param json  JSON payload (may be {@code null}, in which case {@code null} is returned)
+     * @param type  target class
+     * @param label short label included in the error message
+     * @param <T>   target type
+     * @return the deserialised value, or {@code null} if {@code json} was {@code null}
+     * @throws IllegalStateException if Jackson fails to deserialise
+     */
+    public static <T> T decode(String json, Class<T> type, String label) {
+        if (json == null) {
+            return null;
+        }
+        try {
+            return MAPPER.readValue(json, type);
+        } catch (Exception ex) {
+            throw new IllegalStateException("Failed to deserialise " + label, ex);
+        }
+    }
+
+    /**
+     * Deserialises a JSON string into a generic type via {@link TypeReference}.
+     * Use for collection/map shapes where {@link #decode(String, Class, String)}
+     * cannot infer the element types.
+     *
+     * @param json  JSON payload (may be {@code null}, in which case {@code null} is returned)
+     * @param type  target type token
+     * @param label short label included in the error message
+     * @param <T>   target type
+     * @return the deserialised value, or {@code null} if {@code json} was {@code null}
+     * @throws IllegalStateException if Jackson fails to deserialise
+     */
+    public static <T> T decode(String json, TypeReference<T> type, String label) {
+        if (json == null) {
+            return null;
+        }
+        try {
+            return MAPPER.readValue(json, type);
+        } catch (Exception ex) {
+            throw new IllegalStateException("Failed to deserialise " + label, ex);
+        }
+    }
+}

--- a/src/main/java/com/majordomo/adapter/out/persistence/envoy/JobPostingMapper.java
+++ b/src/main/java/com/majordomo/adapter/out/persistence/envoy/JobPostingMapper.java
@@ -1,7 +1,7 @@
 package com.majordomo.adapter.out.persistence.envoy;
 
 import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.majordomo.adapter.out.persistence.JsonColumnCodec;
 import com.majordomo.domain.model.envoy.JobPosting;
 
 import java.util.HashMap;
@@ -9,11 +9,11 @@ import java.util.Map;
 
 /**
  * Maps between the {@link JobPosting} POJO and {@link JobPostingEntity},
- * serialising the {@code extracted} hint map to/from JSON.
+ * serialising the {@code extracted} hint map to/from JSON via
+ * {@link JsonColumnCodec}.
  */
 final class JobPostingMapper {
 
-    private static final ObjectMapper MAPPER = new ObjectMapper();
     private static final TypeReference<Map<String, String>> MAP_TYPE =
             new TypeReference<>() { };
 
@@ -33,12 +33,7 @@ final class JobPostingMapper {
         e.setArchivedAt(p.getArchivedAt());
         e.setAppliedAt(p.getAppliedAt());
         e.setDismissedAt(p.getDismissedAt());
-        try {
-            e.setExtracted(p.getExtracted() == null ? null
-                    : MAPPER.writeValueAsString(p.getExtracted()));
-        } catch (Exception ex) {
-            throw new IllegalStateException("Failed to serialise JobPosting.extracted", ex);
-        }
+        e.setExtracted(JsonColumnCodec.encode(p.getExtracted(), "JobPosting.extracted"));
         return e;
     }
 
@@ -56,13 +51,9 @@ final class JobPostingMapper {
         p.setArchivedAt(e.getArchivedAt());
         p.setAppliedAt(e.getAppliedAt());
         p.setDismissedAt(e.getDismissedAt());
-        try {
-            p.setExtracted(e.getExtracted() == null ? new HashMap<>()
-                    : MAPPER.readValue(e.getExtracted(), MAP_TYPE));
-        } catch (Exception ex) {
-            throw new IllegalStateException(
-                    "Failed to deserialise JobPosting.extracted for " + e.getId(), ex);
-        }
+        Map<String, String> extracted = JsonColumnCodec.decode(
+                e.getExtracted(), MAP_TYPE, "JobPosting.extracted for " + e.getId());
+        p.setExtracted(extracted == null ? new HashMap<>() : extracted);
         return p;
     }
 }

--- a/src/main/java/com/majordomo/adapter/out/persistence/envoy/RubricMapper.java
+++ b/src/main/java/com/majordomo/adapter/out/persistence/envoy/RubricMapper.java
@@ -1,21 +1,14 @@
 package com.majordomo.adapter.out.persistence.envoy;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.json.JsonMapper;
-import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.majordomo.adapter.out.persistence.JsonColumnCodec;
 import com.majordomo.domain.model.envoy.Rubric;
 
 /**
  * Maps between the {@link Rubric} record and {@link RubricEntity}, serialising
- * the record to/from JSON for the {@code body} JSONB column.
+ * the record to/from JSON for the {@code body} JSONB column via
+ * {@link JsonColumnCodec}.
  */
 final class RubricMapper {
-
-    private static final ObjectMapper MAPPER = JsonMapper.builder()
-            .addModule(new JavaTimeModule())
-            .addModule(new Jdk8Module())
-            .build();
 
     private RubricMapper() { }
 
@@ -26,19 +19,11 @@ final class RubricMapper {
         e.setName(rubric.name());
         e.setVersion(rubric.version());
         e.setEffectiveFrom(rubric.effectiveFrom());
-        try {
-            e.setBody(MAPPER.writeValueAsString(rubric));
-        } catch (Exception ex) {
-            throw new IllegalStateException("Failed to serialise Rubric", ex);
-        }
+        e.setBody(JsonColumnCodec.encode(rubric, "Rubric"));
         return e;
     }
 
     static Rubric toDomain(RubricEntity e) {
-        try {
-            return MAPPER.readValue(e.getBody(), Rubric.class);
-        } catch (Exception ex) {
-            throw new IllegalStateException("Failed to deserialise Rubric " + e.getId(), ex);
-        }
+        return JsonColumnCodec.decode(e.getBody(), Rubric.class, "Rubric " + e.getId());
     }
 }

--- a/src/main/java/com/majordomo/adapter/out/persistence/envoy/ScoreReportMapper.java
+++ b/src/main/java/com/majordomo/adapter/out/persistence/envoy/ScoreReportMapper.java
@@ -1,9 +1,6 @@
 package com.majordomo.adapter.out.persistence.envoy;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.json.JsonMapper;
-import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.majordomo.adapter.out.persistence.JsonColumnCodec;
 import com.majordomo.domain.model.envoy.LlmScoreResponse;
 import com.majordomo.domain.model.envoy.ScoreReport;
 
@@ -22,11 +19,6 @@ import java.util.Optional;
  * are treated as if usage were absent rather than producing a half-formed value.
  */
 final class ScoreReportMapper {
-
-    private static final ObjectMapper MAPPER = JsonMapper.builder()
-            .addModule(new JavaTimeModule())
-            .addModule(new Jdk8Module())
-            .build();
 
     private ScoreReportMapper() { }
 
@@ -51,22 +43,13 @@ final class ScoreReportMapper {
                     e.setOutputTokens(null);
                     e.setLatencyMs(null);
                 });
-        try {
-            e.setBody(MAPPER.writeValueAsString(report));
-        } catch (Exception ex) {
-            throw new IllegalStateException("Failed to serialise ScoreReport", ex);
-        }
+        e.setBody(JsonColumnCodec.encode(report, "ScoreReport"));
         return e;
     }
 
     static ScoreReport toDomain(ScoreReportEntity e) {
-        ScoreReport fromBody;
-        try {
-            fromBody = MAPPER.readValue(e.getBody(), ScoreReport.class);
-        } catch (Exception ex) {
-            throw new IllegalStateException(
-                    "Failed to deserialise ScoreReport " + e.getId(), ex);
-        }
+        ScoreReport fromBody = JsonColumnCodec.decode(
+                e.getBody(), ScoreReport.class, "ScoreReport " + e.getId());
         Optional<LlmScoreResponse.Usage> columnUsage = readUsageFromColumns(e);
         // Prefer the scalar columns when present. They are the canonical home for usage
         // data going forward; the JSONB body may also carry a `usage` field (newly

--- a/src/test/java/com/majordomo/adapter/out/persistence/JsonColumnCodecTest.java
+++ b/src/test/java/com/majordomo/adapter/out/persistence/JsonColumnCodecTest.java
@@ -1,0 +1,91 @@
+package com.majordomo.adapter.out.persistence;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Tests for {@link JsonColumnCodec}.
+ */
+class JsonColumnCodecTest {
+
+    /** A round-trip through encode/decode preserves a record's fields. */
+    @Test
+    void roundTripsRecord() {
+        Sample original = new Sample("alice", 42, Instant.parse("2026-04-29T12:00:00Z"));
+
+        String json = JsonColumnCodec.encode(original, "Sample");
+        Sample decoded = JsonColumnCodec.decode(json, Sample.class, "Sample");
+
+        assertThat(decoded).isEqualTo(original);
+    }
+
+    /** TypeReference path round-trips a generic Map. */
+    @Test
+    void roundTripsTypeReference() {
+        Map<String, String> original = Map.of("key", "value", "k2", "v2");
+        String json = JsonColumnCodec.encode(original, "Map");
+
+        Map<String, String> decoded = JsonColumnCodec.decode(
+                json, new TypeReference<Map<String, String>>() { }, "Map");
+
+        assertThat(decoded).isEqualTo(original);
+    }
+
+    /** Optional fields survive a round-trip thanks to Jdk8Module. */
+    @Test
+    void roundTripsOptional() {
+        WithOptional original = new WithOptional(Optional.of("present"));
+        String json = JsonColumnCodec.encode(original, "WithOptional");
+
+        WithOptional decoded = JsonColumnCodec.decode(
+                json, WithOptional.class, "WithOptional");
+
+        assertThat(decoded.value()).contains("present");
+    }
+
+    /** java.time.Instant survives a round-trip thanks to JavaTimeModule. */
+    @Test
+    void roundTripsInstant() {
+        WithInstant original = new WithInstant(Instant.parse("2026-04-29T12:00:00Z"));
+        String json = JsonColumnCodec.encode(original, "WithInstant");
+
+        WithInstant decoded = JsonColumnCodec.decode(
+                json, WithInstant.class, "WithInstant");
+
+        assertThat(decoded.when()).isEqualTo(original.when());
+    }
+
+    /** encode(null, ...) returns null without throwing. */
+    @Test
+    void encodeReturnsNullForNullValue() {
+        assertThat(JsonColumnCodec.encode(null, "Anything")).isNull();
+    }
+
+    /** decode(null, ...) returns null without throwing. */
+    @Test
+    void decodeReturnsNullForNullJson() {
+        assertThat(JsonColumnCodec.decode(null, Sample.class, "x")).isNull();
+        assertThat(JsonColumnCodec.decode(
+                null, new TypeReference<List<String>>() { }, "x")).isNull();
+    }
+
+    /** decode of malformed JSON wraps Jackson's exception as IllegalStateException. */
+    @Test
+    void decodeWrapsJacksonErrors() {
+        assertThatThrownBy(() -> JsonColumnCodec.decode("not-json", Sample.class, "Sample"))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Sample");
+    }
+
+    record Sample(String name, int count, Instant when) { }
+    record WithOptional(Optional<String> value) { }
+    record WithInstant(Instant when) { }
+}


### PR DESCRIPTION
## Summary

#195 asked for a MapStruct spike or a JSON-column codec utility, with an explicit decision recorded. **Conclusion: skip MapStruct, ship the codec utility.**

## What changed

- New `JsonColumnCodec` (`adapter/out/persistence/`) centralising:
  - the canonical Jackson configuration (`JavaTimeModule` + `Jdk8Module`)
  - try/catch translation of Jackson errors into `IllegalStateException`
  - null-tolerant `encode` / `decode(Class)` / `decode(TypeReference)` helpers
- Three mappers refactored to use it:
  - `RubricMapper` (whole-record JSON body)
  - `ScoreReportMapper` (whole-record JSON body, alongside scalar usage columns)
  - `JobPostingMapper` (Map&lt;String,String&gt; via `TypeReference`)

Each mapper's JSON-handling lines collapse from ~6 to 1.

## Why MapStruct was rejected

The actual complexity in these mappers is JSON serialisation of nested records (`Rubric`, `ScoreReport`) and a `Map<String,String>` — not field-by-field copy. MapStruct would not eliminate the JSON code; it would still require custom `@Mapping` helper methods for those columns, *and* it would add:

- An annotation processor in the build path
- Generated source files in `target/generated-sources/`
- A new dependency to maintain

For the (modest) LOC savings on the field-copy lines, the trade-off isn't worth the extra build complexity at this scale. If field-by-field copy ever becomes the dominant cost — i.e. the JSON columns shrink and the entity surface explodes — the answer might flip. Tracked as a future possibility, not adopted now.

Closes #195

## Test plan

- [x] New `JsonColumnCodecTest` (7 tests): record round-trip, `TypeReference` round-trip, `Optional` round-trip (Jdk8Module), `Instant` round-trip (JavaTimeModule), null handling on both sides, error wrapping.
- [x] All existing mapper round-trip tests (used by repository adapter integration tests) still pass.
- [x] `./mvnw verify` — 433 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)