### PR TITLE
test(web): slice tests for top-level adapter.in.web controllers (closes #215)

### DIFF
--- a/src/test/java/com/majordomo/adapter/in/web/AttachmentControllerTest.java
+++ b/src/test/java/com/majordomo/adapter/in/web/AttachmentControllerTest.java
@@ -1,0 +1,193 @@
+package com.majordomo.adapter.in.web;
+
+import com.majordomo.adapter.in.web.config.OAuth2UserService;
+import com.majordomo.adapter.in.web.config.SecurityConfig;
+import com.majordomo.domain.model.Attachment;
+import com.majordomo.domain.model.UuidFactory;
+import com.majordomo.domain.port.in.ManageAttachmentUseCase;
+import com.majordomo.domain.port.out.identity.ApiKeyRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.io.ByteArrayInputStream;
+import java.util.List;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Slice tests for {@link AttachmentController}.
+ */
+@WebMvcTest(AttachmentController.class)
+@Import(SecurityConfig.class)
+class AttachmentControllerTest {
+
+    @Autowired MockMvc mvc;
+
+    @MockitoBean ManageAttachmentUseCase attachmentUseCase;
+    @MockitoBean ApiKeyRepository apiKeyRepository;
+    @MockitoBean OAuth2UserService oAuth2UserService;
+
+    private static final UUID PROPERTY_ID = UuidFactory.newId();
+    private static final UUID SCHEDULE_ID = UuidFactory.newId();
+    private static final UUID RECORD_ID = UuidFactory.newId();
+
+    /** POST property attachment returns 201 + Location. */
+    @Test
+    @WithMockUser
+    void uploadForPropertyReturns201() throws Exception {
+        Attachment saved = sample();
+        when(attachmentUseCase.upload(eq("PROPERTY"), eq(PROPERTY_ID),
+                any(), any(), any(Long.class), any())).thenReturn(saved);
+
+        var file = new MockMultipartFile("file", "deed.pdf",
+                "application/pdf", "body".getBytes());
+
+        mvc.perform(multipart("/api/properties/{id}/attachments", PROPERTY_ID)
+                        .file(file).with(csrf()))
+                .andExpect(status().isCreated())
+                .andExpect(header().string("Location", "/api/attachments/" + saved.getId()));
+    }
+
+    /** GET property attachments returns the list. */
+    @Test
+    @WithMockUser
+    void listForPropertyReturnsAttachments() throws Exception {
+        Attachment a = sample();
+        when(attachmentUseCase.list("PROPERTY", PROPERTY_ID)).thenReturn(List.of(a));
+
+        mvc.perform(get("/api/properties/{id}/attachments", PROPERTY_ID))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].id").value(a.getId().toString()));
+    }
+
+    /** POST service-record attachment returns 201. */
+    @Test
+    @WithMockUser
+    void uploadForServiceRecordReturns201() throws Exception {
+        Attachment saved = sample();
+        when(attachmentUseCase.upload(eq("SERVICE_RECORD"), eq(RECORD_ID),
+                any(), any(), any(Long.class), any())).thenReturn(saved);
+
+        var file = new MockMultipartFile("file", "receipt.pdf",
+                "application/pdf", "body".getBytes());
+
+        mvc.perform(multipart("/api/schedules/{sid}/records/{rid}/attachments",
+                        SCHEDULE_ID, RECORD_ID)
+                        .file(file).with(csrf()))
+                .andExpect(status().isCreated())
+                .andExpect(header().string("Location", "/api/attachments/" + saved.getId()));
+    }
+
+    /** GET service-record attachments returns the list. */
+    @Test
+    @WithMockUser
+    void listForServiceRecordReturnsAttachments() throws Exception {
+        Attachment a = sample();
+        when(attachmentUseCase.list("SERVICE_RECORD", RECORD_ID)).thenReturn(List.of(a));
+
+        mvc.perform(get("/api/schedules/{sid}/records/{rid}/attachments",
+                        SCHEDULE_ID, RECORD_ID))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].id").value(a.getId().toString()));
+    }
+
+    /** GET /api/attachments/{id} streams the file with attachment Content-Disposition. */
+    @Test
+    @WithMockUser
+    void downloadStreamsFileWithDisposition() throws Exception {
+        Attachment metadata = sample();
+        when(attachmentUseCase.getMetadata(metadata.getId())).thenReturn(metadata);
+        when(attachmentUseCase.download(metadata.getId()))
+                .thenReturn(new ByteArrayInputStream("file body".getBytes()));
+
+        mvc.perform(get("/api/attachments/{id}", metadata.getId()))
+                .andExpect(status().isOk())
+                .andExpect(header().string("Content-Disposition",
+                        "attachment; filename=\"deed.pdf\""))
+                .andExpect(header().string("Content-Type", "application/pdf"));
+    }
+
+    /** DELETE /api/attachments/{id} archives and returns 204. */
+    @Test
+    @WithMockUser
+    void archiveReturns204() throws Exception {
+        UUID id = UuidFactory.newId();
+
+        mvc.perform(delete("/api/attachments/{id}", id).with(csrf()))
+                .andExpect(status().isNoContent());
+
+        verify(attachmentUseCase).archive(id);
+    }
+
+    /** GET /api/properties/{id}/gallery returns image attachments. */
+    @Test
+    @WithMockUser
+    void galleryReturnsImages() throws Exception {
+        Attachment a = sample();
+        when(attachmentUseCase.listImages("PROPERTY", PROPERTY_ID)).thenReturn(List.of(a));
+
+        mvc.perform(get("/api/properties/{id}/gallery", PROPERTY_ID))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].id").value(a.getId().toString()));
+    }
+
+    /** PUT /api/attachments/{id}/primary marks an attachment primary. */
+    @Test
+    @WithMockUser
+    void setAsPrimaryDelegates() throws Exception {
+        Attachment a = sample();
+        when(attachmentUseCase.setPrimary(a.getId())).thenReturn(a);
+
+        mvc.perform(put("/api/attachments/{id}/primary", a.getId()).with(csrf()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(a.getId().toString()));
+    }
+
+    /** PUT /api/attachments/{id}/order updates the sort order. */
+    @Test
+    @WithMockUser
+    void updateOrderDelegates() throws Exception {
+        Attachment a = sample();
+        when(attachmentUseCase.updateSortOrder(a.getId(), 7)).thenReturn(a);
+
+        mvc.perform(put("/api/attachments/{id}/order", a.getId())
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"sortOrder\":7}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(a.getId().toString()));
+
+        verify(attachmentUseCase).updateSortOrder(a.getId(), 7);
+    }
+
+    private static Attachment sample() {
+        Attachment a = new Attachment();
+        a.setId(UuidFactory.newId());
+        a.setEntityType("PROPERTY");
+        a.setEntityId(PROPERTY_ID);
+        a.setFilename("deed.pdf");
+        a.setContentType("application/pdf");
+        a.setSizeBytes(1024L);
+        a.setStoragePath("path/to/deed.pdf");
+        return a;
+    }
+}

--- a/src/test/java/com/majordomo/adapter/in/web/AuditControllerTest.java
+++ b/src/test/java/com/majordomo/adapter/in/web/AuditControllerTest.java
@@ -1,0 +1,121 @@
+package com.majordomo.adapter.in.web;
+
+import com.majordomo.adapter.in.web.config.OAuth2UserService;
+import com.majordomo.adapter.in.web.config.SecurityConfig;
+import com.majordomo.application.identity.OrganizationAccessService;
+import com.majordomo.domain.model.AuditLogEntry;
+import com.majordomo.domain.model.UuidFactory;
+import com.majordomo.domain.model.steward.Property;
+import com.majordomo.domain.port.out.AuditLogRepository;
+import com.majordomo.domain.port.out.identity.ApiKeyRepository;
+import com.majordomo.domain.port.out.steward.PropertyRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Slice tests for {@link AuditController}: query by entity + organization feed.
+ */
+@WebMvcTest(AuditController.class)
+@Import(SecurityConfig.class)
+class AuditControllerTest {
+
+    @Autowired MockMvc mvc;
+
+    @MockitoBean AuditLogRepository auditLogRepository;
+    @MockitoBean PropertyRepository propertyRepository;
+    @MockitoBean OrganizationAccessService organizationAccessService;
+    @MockitoBean ApiKeyRepository apiKeyRepository;
+    @MockitoBean OAuth2UserService oAuth2UserService;
+
+    private static final UUID ORG_ID = UuidFactory.newId();
+
+    /** GET /api/audit returns entries for the requested entity. */
+    @Test
+    @WithMockUser
+    void queryByEntityReturnsEntries() throws Exception {
+        UUID entityId = UuidFactory.newId();
+        AuditLogEntry entry = entry("Property", entityId, "ARCHIVE",
+                Instant.parse("2026-04-01T00:00:00Z"));
+        when(auditLogRepository.findByEntityTypeAndEntityId("Property", entityId))
+                .thenReturn(List.of(entry));
+
+        mvc.perform(get("/api/audit")
+                        .param("entityType", "Property")
+                        .param("entityId", entityId.toString()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].action").value("ARCHIVE"))
+                .andExpect(jsonPath("$[0].entityId").value(entityId.toString()));
+    }
+
+    /** GET /api/audit/organizations/{id} aggregates entries across the org's properties, sorted desc. */
+    @Test
+    @WithMockUser
+    void organizationFeedAggregatesAndSortsDescending() throws Exception {
+        UUID p1 = UuidFactory.newId();
+        UUID p2 = UuidFactory.newId();
+        Property prop1 = property(p1, ORG_ID);
+        Property prop2 = property(p2, ORG_ID);
+        when(propertyRepository.findByOrganizationId(ORG_ID))
+                .thenReturn(List.of(prop1, prop2));
+
+        AuditLogEntry older = entry("Property", p1, "CREATE",
+                Instant.parse("2026-04-01T00:00:00Z"));
+        AuditLogEntry newer = entry("Property", p2, "ARCHIVE",
+                Instant.parse("2026-04-15T00:00:00Z"));
+        when(auditLogRepository.findByEntityTypeAndEntityId("Property", p1))
+                .thenReturn(List.of(older));
+        when(auditLogRepository.findByEntityTypeAndEntityId("Property", p2))
+                .thenReturn(List.of(newer));
+
+        mvc.perform(get("/api/audit/organizations/{orgId}", ORG_ID))
+                .andExpect(status().isOk())
+                // Newer entry first.
+                .andExpect(jsonPath("$[0].action").value("ARCHIVE"))
+                .andExpect(jsonPath("$[1].action").value("CREATE"));
+    }
+
+    /** Cross-org access on the org feed returns 403. */
+    @Test
+    @WithMockUser
+    void organizationFeedReturns403WhenAccessDenied() throws Exception {
+        doThrow(new AccessDeniedException("denied"))
+                .when(organizationAccessService).verifyAccess(ORG_ID);
+
+        mvc.perform(get("/api/audit/organizations/{orgId}", ORG_ID))
+                .andExpect(status().isForbidden());
+    }
+
+    private static AuditLogEntry entry(String entityType, UUID entityId,
+                                       String action, Instant occurredAt) {
+        AuditLogEntry e = new AuditLogEntry();
+        e.setId(UuidFactory.newId());
+        e.setEntityType(entityType);
+        e.setEntityId(entityId);
+        e.setAction(action);
+        e.setOccurredAt(occurredAt);
+        return e;
+    }
+
+    private static Property property(UUID id, UUID orgId) {
+        Property p = new Property();
+        p.setId(id);
+        p.setOrganizationId(orgId);
+        return p;
+    }
+}

--- a/src/test/java/com/majordomo/adapter/in/web/DashboardControllerTest.java
+++ b/src/test/java/com/majordomo/adapter/in/web/DashboardControllerTest.java
@@ -1,0 +1,74 @@
+package com.majordomo.adapter.in.web;
+
+import com.majordomo.adapter.in.web.config.OAuth2UserService;
+import com.majordomo.adapter.in.web.config.SecurityConfig;
+import com.majordomo.application.identity.OrganizationAccessService;
+import com.majordomo.domain.model.DashboardSummary;
+import com.majordomo.domain.model.UuidFactory;
+import com.majordomo.domain.port.in.DashboardUseCase;
+import com.majordomo.domain.port.out.identity.ApiKeyRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.UUID;
+
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Slice tests for {@link DashboardController} (REST). The Thymeleaf
+ * {@code DashboardPageController} is covered separately.
+ */
+@WebMvcTest(DashboardController.class)
+@Import(SecurityConfig.class)
+class DashboardControllerTest {
+
+    @Autowired MockMvc mvc;
+
+    @MockitoBean DashboardUseCase dashboardUseCase;
+    @MockitoBean OrganizationAccessService organizationAccessService;
+    @MockitoBean ApiKeyRepository apiKeyRepository;
+    @MockitoBean OAuth2UserService oAuth2UserService;
+
+    private static final UUID ORG_ID = UuidFactory.newId();
+
+    /** GET /api/dashboard returns the summary after access verification. */
+    @Test
+    @WithMockUser
+    void getSummaryReturnsSummary() throws Exception {
+        DashboardSummary summary = new DashboardSummary(
+                3, 5, List.of(), List.of(), List.of(), new BigDecimal("1200.00"));
+        when(dashboardUseCase.getSummary(ORG_ID)).thenReturn(summary);
+
+        mvc.perform(get("/api/dashboard").param("organizationId", ORG_ID.toString()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.propertyCount").value(3))
+                .andExpect(jsonPath("$.contactCount").value(5))
+                .andExpect(jsonPath("$.totalSpend").value(1200.00));
+
+        verify(organizationAccessService).verifyAccess(ORG_ID);
+    }
+
+    /** Cross-org access returns 403. */
+    @Test
+    @WithMockUser
+    void getSummaryReturns403WhenAccessDenied() throws Exception {
+        doThrow(new AccessDeniedException("denied"))
+                .when(organizationAccessService).verifyAccess(ORG_ID);
+
+        mvc.perform(get("/api/dashboard").param("organizationId", ORG_ID.toString()))
+                .andExpect(status().isForbidden());
+    }
+}


### PR DESCRIPTION
## Summary

Found while doing a fresh coverage scan after the #186–#188 sweep landed: three top-level `adapter.in.web/` controllers had been overlooked because they don't live under a service-named subpackage.

**Before:**
- `AttachmentController`: 10.3% (3/29)
- `AuditController`: 31.2% (5/16)
- `DashboardController` (REST): 66.7% (4/6)

**After:** 100% on all three (69/69 lines for the package).

## What changed

14 new `@WebMvcTest` cases:

**AttachmentController (9):**
- POST property attachment (multipart) → 201 + Location
- GET property attachments
- POST service-record attachment → 201
- GET service-record attachments
- GET `/api/attachments/{id}` streams file with Content-Disposition + Content-Type
- DELETE `/api/attachments/{id}` → 204
- GET `/api/properties/{id}/gallery`
- PUT `/api/attachments/{id}/primary`
- PUT `/api/attachments/{id}/order` (with JSON body)

**AuditController (3):**
- GET `/api/audit?entityType=&entityId=` returns entity entries
- GET `/api/audit/organizations/{id}` aggregates across properties + sorts desc
- 403 on cross-org access

**DashboardController (REST) (2):**
- GET `/api/dashboard?organizationId=` returns summary
- 403 on cross-org access

Closes #215

## Test plan

- [x] `./mvnw verify` — 447 tests, 0 failures.
- [x] JaCoCo report regenerated; `adapter.in.web` (top-level) now at 100%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)