### PR TITLE
feat(herald): schedule list + filter UI at /schedules (closes #217)

### DIFF
--- a/src/main/java/com/majordomo/adapter/in/web/herald/SchedulePageController.java
+++ b/src/main/java/com/majordomo/adapter/in/web/herald/SchedulePageController.java
@@ -1,0 +1,127 @@
+package com.majordomo.adapter.in.web.herald;
+
+import com.majordomo.application.herald.ScheduleAccessGuard;
+import com.majordomo.application.identity.CurrentOrganizationResolver;
+import com.majordomo.domain.model.herald.Frequency;
+import com.majordomo.domain.model.herald.MaintenanceSchedule;
+import com.majordomo.domain.model.steward.Property;
+import com.majordomo.domain.port.out.herald.MaintenanceScheduleRepository;
+import com.majordomo.domain.port.out.steward.PropertyRepository;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
+/**
+ * Thymeleaf controller for the Herald UI. The REST surface lives at
+ * {@code /api/schedules} on {@link ScheduleController} and is not touched by
+ * this controller — separating the two follows the Envoy convention
+ * ({@code /api/envoy/*} REST, {@code /envoy/*} Thymeleaf).
+ */
+@Controller
+public class SchedulePageController {
+
+    private final CurrentOrganizationResolver currentOrg;
+    private final ScheduleAccessGuard guard;
+    private final MaintenanceScheduleRepository scheduleRepository;
+    private final PropertyRepository propertyRepository;
+
+    /**
+     * One row in the {@code /schedules} list.
+     *
+     * @param schedule    the schedule
+     * @param property    the owning property (never {@code null} — the auth guard
+     *                    ensures the user can see every row's property)
+     * @param daysUntilDue {@code null} if {@code nextDue} is null; otherwise the
+     *                    integer day delta (negative = overdue, 0 = today)
+     */
+    public record ScheduleRow(
+            MaintenanceSchedule schedule, Property property, Integer daysUntilDue) { }
+
+    /**
+     * Constructs the controller.
+     *
+     * @param currentOrg         resolves the authenticated user's organizations
+     * @param guard              authorization helper for property-scoped reads
+     * @param scheduleRepository outbound port for schedule reads
+     * @param propertyRepository outbound port for property reads
+     */
+    public SchedulePageController(CurrentOrganizationResolver currentOrg,
+                                  ScheduleAccessGuard guard,
+                                  MaintenanceScheduleRepository scheduleRepository,
+                                  PropertyRepository propertyRepository) {
+        this.currentOrg = currentOrg;
+        this.guard = guard;
+        this.scheduleRepository = scheduleRepository;
+        this.propertyRepository = propertyRepository;
+    }
+
+    /**
+     * Renders the schedule list page.
+     *
+     * @param frequency      optional Frequency filter (null = any)
+     * @param dueWithinDays  optional "due within N days" filter (null = any)
+     * @param principal      authenticated user
+     * @param model          Thymeleaf model
+     * @return the {@code schedules} template, or a redirect to {@code /} when
+     *         the user has no organization
+     */
+    @GetMapping("/schedules")
+    public String list(@RequestParam(required = false) Frequency frequency,
+                       @RequestParam(required = false) Integer dueWithinDays,
+                       @AuthenticationPrincipal UserDetails principal,
+                       Model model) {
+        var ctx = currentOrg.resolve(principal);
+        if (ctx.organizationId() == null) {
+            return "redirect:/";
+        }
+
+        Set<UUID> orgIds = guard.currentUserOrganizationIds();
+        // Pull all properties + their schedules (N+1 by property is fine at personal scale).
+        List<Property> properties = new ArrayList<>();
+        for (UUID orgId : orgIds) {
+            properties.addAll(propertyRepository.findByOrganizationId(orgId));
+        }
+
+        LocalDate today = LocalDate.now();
+        LocalDate dueCutoff = dueWithinDays == null ? null : today.plusDays(dueWithinDays);
+
+        List<ScheduleRow> rows = new ArrayList<>();
+        for (Property property : properties) {
+            for (MaintenanceSchedule s : scheduleRepository.findByPropertyId(property.getId())) {
+                if (s.getArchivedAt() != null) {
+                    continue;
+                }
+                if (frequency != null && s.getFrequency() != frequency) {
+                    continue;
+                }
+                if (dueCutoff != null && (s.getNextDue() == null || s.getNextDue().isAfter(dueCutoff))) {
+                    continue;
+                }
+                Integer days = s.getNextDue() == null ? null
+                        : (int) ChronoUnit.DAYS.between(today, s.getNextDue());
+                rows.add(new ScheduleRow(s, property, days));
+            }
+        }
+        // Soonest-due first; nulls (no nextDue set) sink to the bottom.
+        rows.sort(Comparator.comparing(
+                (ScheduleRow r) -> r.daysUntilDue() == null ? Integer.MAX_VALUE : r.daysUntilDue()));
+
+        model.addAttribute("rows", rows);
+        model.addAttribute("frequency", frequency);
+        model.addAttribute("dueWithinDays", dueWithinDays);
+        model.addAttribute("frequencies", Frequency.values());
+        model.addAttribute("username", ctx.user().getUsername());
+        return "schedules";
+    }
+}

--- a/src/main/resources/templates/schedules.html
+++ b/src/main/resources/templates/schedules.html
@@ -1,0 +1,117 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org"
+      xmlns:sec="http://www.thymeleaf.org/extras/spring-security"
+      lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Schedules - Majordomo</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-gray-100 min-h-screen">
+
+    <div th:replace="~{fragments/header :: header}"></div>
+
+    <div class="flex min-h-screen">
+        <div th:replace="~{fragments/sidebar :: sidebar('schedules')}"></div>
+
+        <main class="flex-1 p-6">
+
+            <div class="flex items-baseline justify-between mb-6">
+                <h1 class="text-2xl font-bold text-gray-900">Schedules</h1>
+                <span class="text-sm text-gray-500"
+                      th:text="${#lists.size(rows)} + ' schedules'">0 schedules</span>
+            </div>
+
+            <!-- Filter strip -->
+            <div class="bg-white rounded-lg shadow p-4 mb-6">
+                <form method="get" th:action="@{/schedules}" class="flex flex-wrap items-end gap-4">
+                    <div class="flex flex-col">
+                        <label for="frequency"
+                               class="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-1">
+                            Frequency
+                        </label>
+                        <select id="frequency" name="frequency"
+                                class="block rounded border-gray-300 text-sm focus:border-indigo-500 focus:ring-indigo-500 px-2 py-1.5">
+                            <option value="" th:selected="${frequency == null}">Any</option>
+                            <option th:each="f : ${frequencies}"
+                                    th:value="${f}"
+                                    th:text="${f}"
+                                    th:selected="${frequency != null and frequency.name() == f.name()}">FREQ</option>
+                        </select>
+                    </div>
+                    <div class="flex flex-col">
+                        <label for="dueWithinDays"
+                               class="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-1">
+                            Due within (days)
+                        </label>
+                        <input id="dueWithinDays" name="dueWithinDays" type="number" min="0"
+                               th:value="${dueWithinDays}"
+                               class="block rounded border-gray-300 text-sm focus:border-indigo-500 focus:ring-indigo-500 px-2 py-1.5 w-32">
+                    </div>
+                    <div class="flex gap-2">
+                        <button type="submit"
+                                class="inline-flex items-center rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-indigo-700">
+                            Filter
+                        </button>
+                        <a th:href="@{/schedules}"
+                           class="inline-flex items-center rounded-md bg-white px-3 py-1.5 text-sm font-medium text-gray-700 ring-1 ring-gray-300 hover:bg-gray-50">
+                            Reset
+                        </a>
+                    </div>
+                </form>
+            </div>
+
+            <!-- Empty state -->
+            <div th:if="${#lists.isEmpty(rows)}"
+                 class="bg-white rounded-lg shadow p-8 text-center text-gray-500">
+                No schedules match. Add a maintenance schedule to a property to see it here.
+            </div>
+
+            <!-- Schedule table -->
+            <div th:unless="${#lists.isEmpty(rows)}" class="bg-white rounded-lg shadow overflow-hidden">
+                <table class="min-w-full divide-y divide-gray-200">
+                    <thead class="bg-gray-50">
+                        <tr>
+                            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Description</th>
+                            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Property</th>
+                            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Frequency</th>
+                            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Next due</th>
+                            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">In</th>
+                        </tr>
+                    </thead>
+                    <tbody class="bg-white divide-y divide-gray-200">
+                        <tr th:each="row : ${rows}" class="hover:bg-gray-50">
+                            <td class="px-6 py-3 text-sm">
+                                <a th:href="@{|/schedules/${row.schedule().getId()}|}"
+                                   class="font-medium text-gray-900 hover:text-indigo-700"
+                                   th:text="${row.schedule().getDescription()}">desc</a>
+                            </td>
+                            <td class="px-6 py-3 text-sm text-gray-700"
+                                th:text="${row.property().getName()}">property</td>
+                            <td class="px-6 py-3 text-sm text-gray-700"
+                                th:text="${row.schedule().getFrequency()}">FREQ</td>
+                            <td class="px-6 py-3 text-sm text-gray-700"
+                                th:text="${row.schedule().getNextDue() != null ? row.schedule().getNextDue() : '—'}">date</td>
+                            <td class="px-6 py-3 text-sm">
+                                <span th:if="${row.daysUntilDue() == null}" class="text-gray-400">—</span>
+                                <span th:if="${row.daysUntilDue() != null and row.daysUntilDue() < 0}"
+                                      class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-red-100 text-red-800"
+                                      th:text="${-row.daysUntilDue()} + ' days overdue'">overdue</span>
+                                <span th:if="${row.daysUntilDue() != null and row.daysUntilDue() == 0}"
+                                      class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-amber-100 text-amber-800">
+                                    today
+                                </span>
+                                <span th:if="${row.daysUntilDue() != null and row.daysUntilDue() > 0}"
+                                      class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-emerald-100 text-emerald-800"
+                                      th:text="'in ' + ${row.daysUntilDue()} + ' days'">in N days</span>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+
+        </main>
+    </div>
+</body>
+</html>

--- a/src/test/java/com/majordomo/adapter/in/web/herald/SchedulePageControllerTest.java
+++ b/src/test/java/com/majordomo/adapter/in/web/herald/SchedulePageControllerTest.java
@@ -1,0 +1,203 @@
+package com.majordomo.adapter.in.web.herald;
+
+import com.majordomo.adapter.in.web.config.OAuth2UserService;
+import com.majordomo.adapter.in.web.config.SecurityConfig;
+import com.majordomo.application.herald.ScheduleAccessGuard;
+import com.majordomo.application.identity.CurrentOrganizationResolver;
+import com.majordomo.domain.model.UuidFactory;
+import com.majordomo.domain.model.herald.Frequency;
+import com.majordomo.domain.model.herald.MaintenanceSchedule;
+import com.majordomo.domain.model.identity.User;
+import com.majordomo.domain.model.steward.Property;
+import com.majordomo.domain.port.out.herald.MaintenanceScheduleRepository;
+import com.majordomo.domain.port.out.identity.ApiKeyRepository;
+import com.majordomo.domain.port.out.steward.PropertyRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
+
+/**
+ * Slice tests for {@link SchedulePageController}: list + filter at {@code /schedules}.
+ */
+@WebMvcTest(SchedulePageController.class)
+@Import(SecurityConfig.class)
+class SchedulePageControllerTest {
+
+    @Autowired MockMvc mvc;
+
+    @MockitoBean CurrentOrganizationResolver currentOrg;
+    @MockitoBean ScheduleAccessGuard guard;
+    @MockitoBean MaintenanceScheduleRepository scheduleRepository;
+    @MockitoBean PropertyRepository propertyRepository;
+    @MockitoBean ApiKeyRepository apiKeyRepository;
+    @MockitoBean OAuth2UserService oAuth2UserService;
+
+    private static final UUID ORG_ID = UuidFactory.newId();
+
+    /** Renders schedules with property name + days-until-due, sorted soonest first. */
+    @Test
+    @WithMockUser
+    void listRendersSchedulesWithPropertyName() throws Exception {
+        seedAuth();
+        Property p = property("Beach House", ORG_ID);
+        when(propertyRepository.findByOrganizationId(ORG_ID)).thenReturn(List.of(p));
+        when(scheduleRepository.findByPropertyId(p.getId())).thenReturn(List.of(
+                schedule("HVAC service", p.getId(), Frequency.ANNUAL,
+                        LocalDate.now().plusDays(30), null)));
+
+        MvcResult result = mvc.perform(get("/schedules"))
+                .andExpect(status().isOk())
+                .andExpect(view().name("schedules"))
+                .andReturn();
+
+        String body = result.getResponse().getContentAsString();
+        assertThat(body).contains("HVAC service");
+        assertThat(body).contains("Beach House");
+        assertThat(body).contains("ANNUAL");
+        assertThat(body).contains("in 30 days");
+    }
+
+    /** Archived schedules are filtered out. */
+    @Test
+    @WithMockUser
+    void listSkipsArchivedSchedules() throws Exception {
+        seedAuth();
+        Property p = property("Cabin", ORG_ID);
+        when(propertyRepository.findByOrganizationId(ORG_ID)).thenReturn(List.of(p));
+        when(scheduleRepository.findByPropertyId(p.getId())).thenReturn(List.of(
+                schedule("Active", p.getId(), Frequency.QUARTERLY,
+                        LocalDate.now().plusDays(7), null),
+                schedule("Archived old", p.getId(), Frequency.ANNUAL,
+                        LocalDate.now(), Instant.parse("2025-01-01T00:00:00Z"))));
+
+        MvcResult result = mvc.perform(get("/schedules"))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        String body = result.getResponse().getContentAsString();
+        assertThat(body).contains("Active").doesNotContain("Archived old");
+    }
+
+    /** Frequency filter narrows the result set. */
+    @Test
+    @WithMockUser
+    void filterByFrequencyNarrowsResults() throws Exception {
+        seedAuth();
+        Property p = property("Cabin", ORG_ID);
+        when(propertyRepository.findByOrganizationId(ORG_ID)).thenReturn(List.of(p));
+        when(scheduleRepository.findByPropertyId(p.getId())).thenReturn(List.of(
+                schedule("Filter change", p.getId(), Frequency.QUARTERLY,
+                        LocalDate.now().plusDays(7), null),
+                schedule("Roof inspection", p.getId(), Frequency.ANNUAL,
+                        LocalDate.now().plusDays(180), null)));
+
+        MvcResult result = mvc.perform(get("/schedules").param("frequency", "QUARTERLY"))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        String body = result.getResponse().getContentAsString();
+        assertThat(body).contains("Filter change").doesNotContain("Roof inspection");
+    }
+
+    /** dueWithinDays filter narrows the result set. */
+    @Test
+    @WithMockUser
+    void filterByDueWithinDaysNarrowsResults() throws Exception {
+        seedAuth();
+        Property p = property("Cabin", ORG_ID);
+        when(propertyRepository.findByOrganizationId(ORG_ID)).thenReturn(List.of(p));
+        when(scheduleRepository.findByPropertyId(p.getId())).thenReturn(List.of(
+                schedule("Soon", p.getId(), Frequency.MONTHLY,
+                        LocalDate.now().plusDays(5), null),
+                schedule("Distant", p.getId(), Frequency.ANNUAL,
+                        LocalDate.now().plusDays(200), null)));
+
+        MvcResult result = mvc.perform(get("/schedules").param("dueWithinDays", "30"))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        String body = result.getResponse().getContentAsString();
+        assertThat(body).contains("Soon").doesNotContain("Distant");
+    }
+
+    /** Empty state renders when no schedules match. */
+    @Test
+    @WithMockUser
+    void emptyStateRendersWhenNoSchedules() throws Exception {
+        seedAuth();
+        when(propertyRepository.findByOrganizationId(ORG_ID)).thenReturn(List.of());
+
+        mvc.perform(get("/schedules"))
+                .andExpect(status().isOk())
+                .andExpect(content().string(org.hamcrest.Matchers.containsString(
+                        "No schedules match")));
+    }
+
+    /** User with no organization redirects home. */
+    @Test
+    @WithMockUser
+    void redirectsHomeWhenNoOrganization() throws Exception {
+        User user = new User(UuidFactory.newId(), "lonely", "l@example.com");
+        when(currentOrg.resolve(any(UserDetails.class)))
+                .thenReturn(new CurrentOrganizationResolver.Resolved(user, null));
+
+        mvc.perform(get("/schedules"))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(view().name("redirect:/"));
+    }
+
+    /** Unauthenticated request redirects to login. */
+    @Test
+    void unauthenticatedRedirectsToLogin() throws Exception {
+        mvc.perform(get("/schedules"))
+                .andExpect(status().is3xxRedirection());
+    }
+
+    private void seedAuth() {
+        User user = new User(UuidFactory.newId(), "robsartin", "rob@example.com");
+        when(currentOrg.resolve(any(UserDetails.class)))
+                .thenReturn(new CurrentOrganizationResolver.Resolved(user, ORG_ID));
+        when(guard.currentUserOrganizationIds()).thenReturn(Set.of(ORG_ID));
+    }
+
+    private static Property property(String name, UUID orgId) {
+        Property p = new Property();
+        p.setId(UuidFactory.newId());
+        p.setOrganizationId(orgId);
+        p.setName(name);
+        return p;
+    }
+
+    private static MaintenanceSchedule schedule(String description, UUID propertyId,
+                                                Frequency freq, LocalDate nextDue,
+                                                Instant archivedAt) {
+        MaintenanceSchedule s = new MaintenanceSchedule();
+        s.setId(UuidFactory.newId());
+        s.setPropertyId(propertyId);
+        s.setDescription(description);
+        s.setFrequency(freq);
+        s.setNextDue(nextDue);
+        s.setArchivedAt(archivedAt);
+        return s;
+    }
+}


### PR DESCRIPTION
## Summary

First slice of the Herald UI parity work proposed in #172. Adds a Thymeleaf list view at `/schedules` for the authenticated user's maintenance schedules across every property they can access.

The REST surface at `/api/schedules` (`ScheduleController`) is **unchanged and stays pure REST** — new work lives in a separate Thymeleaf `SchedulePageController`, mirroring the Envoy convention (`/api/envoy/*` REST, `/envoy/*` Thymeleaf).

Closes #217

## What changed

- **`SchedulePageController`** (`adapter/in/web/herald/`): single endpoint `GET /schedules` with optional `frequency` and `dueWithinDays` query params. Reuses `CurrentOrganizationResolver` (#191) and `ScheduleAccessGuard.currentUserOrganizationIds()` (#184). Sorts soonest-due first; archived rows excluded.
- **`schedules.html`**: Tailwind table with filter strip + empty state + per-row days-until-due badge (red for overdue, amber for today, emerald for upcoming). Rows link to `/schedules/{id}` (target is the #218 slice — link is present so navigation is intuitive once that lands).
- **Sidebar**: already had a "Schedules" link to `/schedules`; no fragment change needed.

## Test plan

- [x] 7 slice tests in `SchedulePageControllerTest`: basic render + property name, archived rows filtered, frequency filter, `dueWithinDays` filter, empty state, no-org redirect, unauth redirect.
- [x] `./mvnw verify` — 454 tests, 0 failures.
- [ ] Manual browser smoke — not run; safe to verify locally with `docker-compose up -d && ./mvnw spring-boot:run`.

## Notes

- Read path is N+1 by property (one schedule query per accessible property). At personal scale (handful of properties × handful of schedules), this is fine. If a join becomes warranted, an application-layer projection service can be added without touching the controller.

🤖 Generated with [Claude Code](https://claude.com/claude-code)