### PR TITLE
feat(herald): schedule detail + inline record-add at /schedules/{id} (closes #218)

### DIFF
--- a/src/main/java/com/majordomo/adapter/in/web/herald/SchedulePageController.java
+++ b/src/main/java/com/majordomo/adapter/in/web/herald/SchedulePageController.java
@@ -2,9 +2,13 @@ package com.majordomo.adapter.in.web.herald;
 
 import com.majordomo.application.herald.ScheduleAccessGuard;
 import com.majordomo.application.identity.CurrentOrganizationResolver;
+import com.majordomo.domain.model.EntityNotFoundException;
+import com.majordomo.domain.model.EntityType;
 import com.majordomo.domain.model.herald.Frequency;
 import com.majordomo.domain.model.herald.MaintenanceSchedule;
+import com.majordomo.domain.model.herald.ServiceRecord;
 import com.majordomo.domain.model.steward.Property;
+import com.majordomo.domain.port.in.herald.ManageScheduleUseCase;
 import com.majordomo.domain.port.out.herald.MaintenanceScheduleRepository;
 import com.majordomo.domain.port.out.steward.PropertyRepository;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -12,9 +16,13 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
+import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -24,15 +32,16 @@ import java.util.UUID;
 
 /**
  * Thymeleaf controller for the Herald UI. The REST surface lives at
- * {@code /api/schedules} on {@link ScheduleController} and is not touched by
- * this controller — separating the two follows the Envoy convention
- * ({@code /api/envoy/*} REST, {@code /envoy/*} Thymeleaf).
+ * {@code /api/schedules} on {@link com.majordomo.adapter.in.web.herald.ScheduleController}
+ * and is not touched by this controller — separating the two follows the Envoy
+ * convention ({@code /api/envoy/*} REST, {@code /envoy/*} Thymeleaf).
  */
 @Controller
 public class SchedulePageController {
 
     private final CurrentOrganizationResolver currentOrg;
     private final ScheduleAccessGuard guard;
+    private final ManageScheduleUseCase scheduleUseCase;
     private final MaintenanceScheduleRepository scheduleRepository;
     private final PropertyRepository propertyRepository;
 
@@ -53,15 +62,18 @@ public class SchedulePageController {
      *
      * @param currentOrg         resolves the authenticated user's organizations
      * @param guard              authorization helper for property-scoped reads
+     * @param scheduleUseCase    inbound port for schedule writes (record-add)
      * @param scheduleRepository outbound port for schedule reads
      * @param propertyRepository outbound port for property reads
      */
     public SchedulePageController(CurrentOrganizationResolver currentOrg,
                                   ScheduleAccessGuard guard,
+                                  ManageScheduleUseCase scheduleUseCase,
                                   MaintenanceScheduleRepository scheduleRepository,
                                   PropertyRepository propertyRepository) {
         this.currentOrg = currentOrg;
         this.guard = guard;
+        this.scheduleUseCase = scheduleUseCase;
         this.scheduleRepository = scheduleRepository;
         this.propertyRepository = propertyRepository;
     }
@@ -123,5 +135,118 @@ public class SchedulePageController {
         model.addAttribute("frequencies", Frequency.values());
         model.addAttribute("username", ctx.user().getUsername());
         return "schedules";
+    }
+
+    /**
+     * Renders the detail page for a single schedule, including its full
+     * service-record history (most recent first) and an inline form to log a
+     * new service event.
+     *
+     * @param id        schedule id
+     * @param principal authenticated user
+     * @param model     Thymeleaf model
+     * @return the {@code schedule-detail} template, or {@code redirect:/} if
+     *         the user has no organization
+     */
+    @GetMapping("/schedules/{id}")
+    public String detail(@PathVariable UUID id,
+                         @AuthenticationPrincipal UserDetails principal,
+                         Model model) {
+        var ctx = currentOrg.resolve(principal);
+        if (ctx.organizationId() == null) {
+            return "redirect:/";
+        }
+        guard.verifyForSchedule(id);
+        renderDetail(id, ctx.user().getUsername(), model);
+        return "schedule-detail";
+    }
+
+    /**
+     * Records a completed service event against the given schedule, then
+     * redirects to {@code GET /schedules/{id}} so the new entry renders at the
+     * top. On validation failure the detail page is re-rendered with field
+     * state preserved and a {@code recordError} attribute set.
+     *
+     * @param id          schedule id
+     * @param performedOn date the service was performed (required)
+     * @param description short description (required, non-blank)
+     * @param cost        optional cost
+     * @param notes       optional free-form notes
+     * @param principal   authenticated user
+     * @param model       Thymeleaf model
+     * @return redirect to the detail page on success; {@code schedule-detail}
+     *         on a handled validation failure; {@code redirect:/} if no org
+     */
+    @PostMapping("/schedules/{id}/records")
+    public String addRecord(@PathVariable UUID id,
+                            @RequestParam(required = false) String performedOn,
+                            @RequestParam(required = false) String description,
+                            @RequestParam(required = false) BigDecimal cost,
+                            @RequestParam(required = false) String notes,
+                            @AuthenticationPrincipal UserDetails principal,
+                            Model model) {
+        var ctx = currentOrg.resolve(principal);
+        if (ctx.organizationId() == null) {
+            return "redirect:/";
+        }
+        guard.verifyForSchedule(id);
+
+        String error = validateRecordInputs(performedOn, description);
+        if (error != null) {
+            renderDetail(id, ctx.user().getUsername(), model);
+            model.addAttribute("recordError", error);
+            // Echo posted values back so the form keeps state.
+            model.addAttribute("formPerformedOn", performedOn);
+            model.addAttribute("formDescription", description);
+            model.addAttribute("formCost", cost);
+            model.addAttribute("formNotes", notes);
+            return "schedule-detail";
+        }
+
+        ServiceRecord record = new ServiceRecord();
+        record.setPerformedOn(LocalDate.parse(performedOn));
+        record.setDescription(description);
+        record.setCost(cost);
+        record.setNotes(notes);
+        scheduleUseCase.recordService(id, record);
+        return "redirect:/schedules/" + id;
+    }
+
+    /**
+     * Populates the model with everything the detail template needs.
+     */
+    private void renderDetail(UUID id, String username, Model model) {
+        MaintenanceSchedule schedule = scheduleRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(
+                        EntityType.MAINTENANCE_SCHEDULE.name(), id));
+        Property property = propertyRepository.findById(schedule.getPropertyId()).orElse(null);
+        List<ServiceRecord> records = new ArrayList<>(
+                scheduleUseCase.findRecordsByScheduleId(id));
+        records.sort(Comparator.comparing(ServiceRecord::getPerformedOn,
+                Comparator.nullsLast(Comparator.reverseOrder())));
+
+        Integer days = schedule.getNextDue() == null ? null
+                : (int) ChronoUnit.DAYS.between(LocalDate.now(), schedule.getNextDue());
+
+        model.addAttribute("schedule", schedule);
+        model.addAttribute("property", property);
+        model.addAttribute("records", records);
+        model.addAttribute("daysUntilDue", days);
+        model.addAttribute("username", username);
+    }
+
+    private static String validateRecordInputs(String performedOn, String description) {
+        if (performedOn == null || performedOn.isBlank()) {
+            return "Performed-on date is required.";
+        }
+        try {
+            LocalDate.parse(performedOn);
+        } catch (DateTimeParseException ex) {
+            return "Performed-on must be a valid date (YYYY-MM-DD).";
+        }
+        if (description == null || description.isBlank()) {
+            return "Description is required.";
+        }
+        return null;
     }
 }

--- a/src/main/resources/templates/schedule-detail.html
+++ b/src/main/resources/templates/schedule-detail.html
@@ -1,0 +1,162 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org"
+      xmlns:sec="http://www.thymeleaf.org/extras/spring-security"
+      lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Schedule - Majordomo</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-gray-100 min-h-screen">
+
+    <div th:replace="~{fragments/header :: header}"></div>
+
+    <div class="flex min-h-screen">
+        <div th:replace="~{fragments/sidebar :: sidebar('schedules')}"></div>
+
+        <main class="flex-1 p-6">
+
+            <!-- Breadcrumb -->
+            <nav class="mb-4" aria-label="Breadcrumb">
+                <ol class="flex items-center space-x-2 text-sm text-gray-500">
+                    <li><a th:href="@{/schedules}" class="hover:text-indigo-600 transition">Schedules</a></li>
+                    <li class="flex items-center space-x-2">
+                        <span>&rsaquo;</span>
+                        <span class="text-gray-900 font-medium"
+                              th:text="${schedule.getDescription()}">Description</span>
+                    </li>
+                </ol>
+            </nav>
+
+            <!-- Header card -->
+            <div class="bg-white rounded-lg shadow mb-6 px-6 py-5 flex items-start justify-between gap-6">
+                <div class="min-w-0">
+                    <h1 class="text-2xl font-bold text-gray-900"
+                        th:text="${schedule.getDescription()}">Description</h1>
+                    <div class="mt-2 flex flex-wrap gap-x-4 gap-y-1 text-sm text-gray-600">
+                        <span th:if="${property != null}"
+                              th:text="'Property: ' + ${property.getName()}">Property</span>
+                        <span th:text="'Frequency: ' + ${schedule.getFrequency()}">Frequency</span>
+                        <span th:if="${schedule.getNextDue() != null}"
+                              th:text="'Next due: ' + ${schedule.getNextDue()}">Next due</span>
+                        <span th:if="${schedule.getEstimatedCost() != null}"
+                              th:text="'Est. cost: $' + ${#numbers.formatDecimal(schedule.getEstimatedCost(), 1, 2)}">Cost</span>
+                    </div>
+                </div>
+                <div th:if="${daysUntilDue != null}" class="shrink-0">
+                    <span th:if="${daysUntilDue < 0}"
+                          class="inline-flex items-center px-3 py-1 rounded-full text-sm font-semibold bg-red-100 text-red-800"
+                          th:text="${-daysUntilDue} + ' days overdue'">overdue</span>
+                    <span th:if="${daysUntilDue == 0}"
+                          class="inline-flex items-center px-3 py-1 rounded-full text-sm font-semibold bg-amber-100 text-amber-800">
+                        due today
+                    </span>
+                    <span th:if="${daysUntilDue > 0}"
+                          class="inline-flex items-center px-3 py-1 rounded-full text-sm font-semibold bg-emerald-100 text-emerald-800"
+                          th:text="'in ' + ${daysUntilDue} + ' days'">in N days</span>
+                </div>
+            </div>
+
+            <!-- Add service record form -->
+            <section class="bg-white rounded-lg shadow mb-6">
+                <div class="px-6 py-4 border-b border-gray-200">
+                    <h2 class="text-lg font-semibold text-gray-900">Log a service event</h2>
+                </div>
+                <div class="p-6 space-y-4">
+                    <div th:if="${recordError}"
+                         class="rounded-md bg-red-50 border border-red-200 px-4 py-3 text-sm text-red-700"
+                         th:text="${recordError}">Error message</div>
+
+                    <form method="post" th:action="@{|/schedules/${schedule.getId()}/records|}"
+                          class="space-y-4">
+                        <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+                            <div class="flex flex-col">
+                                <label for="performedOn"
+                                       class="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-1">
+                                    Performed on
+                                </label>
+                                <input id="performedOn" name="performedOn" type="date" required
+                                       th:value="${formPerformedOn}"
+                                       class="block rounded border-gray-300 text-sm focus:border-indigo-500 focus:ring-indigo-500 px-2 py-1.5">
+                            </div>
+                            <div class="flex flex-col md:col-span-2">
+                                <label for="description"
+                                       class="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-1">
+                                    Description
+                                </label>
+                                <input id="description" name="description" type="text" required
+                                       th:value="${formDescription}"
+                                       placeholder="What was done"
+                                       class="block rounded border-gray-300 text-sm focus:border-indigo-500 focus:ring-indigo-500 px-2 py-1.5">
+                            </div>
+                        </div>
+                        <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+                            <div class="flex flex-col">
+                                <label for="cost"
+                                       class="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-1">
+                                    Cost (optional)
+                                </label>
+                                <input id="cost" name="cost" type="number" step="0.01" min="0"
+                                       th:value="${formCost}"
+                                       class="block rounded border-gray-300 text-sm focus:border-indigo-500 focus:ring-indigo-500 px-2 py-1.5">
+                            </div>
+                            <div class="flex flex-col md:col-span-2">
+                                <label for="notes"
+                                       class="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-1">
+                                    Notes (optional)
+                                </label>
+                                <input id="notes" name="notes" type="text"
+                                       th:value="${formNotes}"
+                                       class="block rounded border-gray-300 text-sm focus:border-indigo-500 focus:ring-indigo-500 px-2 py-1.5">
+                            </div>
+                        </div>
+                        <div>
+                            <button type="submit"
+                                    class="inline-flex items-center rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-indigo-700">
+                                Log service event
+                            </button>
+                        </div>
+                    </form>
+                </div>
+            </section>
+
+            <!-- Service record history -->
+            <section class="bg-white rounded-lg shadow">
+                <div class="px-6 py-4 border-b border-gray-200">
+                    <h2 class="text-lg font-semibold text-gray-900">Service history</h2>
+                </div>
+                <div class="p-0">
+                    <p th:if="${#lists.isEmpty(records)}" class="p-6 text-gray-400 text-sm">
+                        No service events recorded yet.
+                    </p>
+                    <table th:unless="${#lists.isEmpty(records)}"
+                           class="min-w-full divide-y divide-gray-200">
+                        <thead class="bg-gray-50">
+                            <tr>
+                                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Performed</th>
+                                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Description</th>
+                                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Cost</th>
+                                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Notes</th>
+                            </tr>
+                        </thead>
+                        <tbody class="bg-white divide-y divide-gray-200">
+                            <tr th:each="r : ${records}">
+                                <td class="px-6 py-3 text-sm text-gray-700"
+                                    th:text="${r.getPerformedOn() != null ? r.getPerformedOn() : '—'}">date</td>
+                                <td class="px-6 py-3 text-sm text-gray-900"
+                                    th:text="${r.getDescription()}">desc</td>
+                                <td class="px-6 py-3 text-sm text-gray-700"
+                                    th:text="${r.getCost() != null ? '$' + #numbers.formatDecimal(r.getCost(), 1, 2) : '—'}">cost</td>
+                                <td class="px-6 py-3 text-sm text-gray-700"
+                                    th:text="${r.getNotes() != null ? r.getNotes() : '—'}">notes</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+            </section>
+
+        </main>
+    </div>
+</body>
+</html>

--- a/src/test/java/com/majordomo/adapter/in/web/herald/SchedulePageControllerTest.java
+++ b/src/test/java/com/majordomo/adapter/in/web/herald/SchedulePageControllerTest.java
@@ -47,6 +47,7 @@ class SchedulePageControllerTest {
 
     @MockitoBean CurrentOrganizationResolver currentOrg;
     @MockitoBean ScheduleAccessGuard guard;
+    @MockitoBean com.majordomo.domain.port.in.herald.ManageScheduleUseCase scheduleUseCase;
     @MockitoBean MaintenanceScheduleRepository scheduleRepository;
     @MockitoBean PropertyRepository propertyRepository;
     @MockitoBean ApiKeyRepository apiKeyRepository;

--- a/src/test/java/com/majordomo/adapter/in/web/herald/SchedulePageDetailTest.java
+++ b/src/test/java/com/majordomo/adapter/in/web/herald/SchedulePageDetailTest.java
@@ -1,0 +1,271 @@
+package com.majordomo.adapter.in.web.herald;
+
+import com.majordomo.adapter.in.web.config.OAuth2UserService;
+import com.majordomo.adapter.in.web.config.SecurityConfig;
+import com.majordomo.application.herald.ScheduleAccessGuard;
+import com.majordomo.application.identity.CurrentOrganizationResolver;
+import com.majordomo.domain.model.UuidFactory;
+import com.majordomo.domain.model.herald.Frequency;
+import com.majordomo.domain.model.herald.MaintenanceSchedule;
+import com.majordomo.domain.model.herald.ServiceRecord;
+import com.majordomo.domain.model.identity.User;
+import com.majordomo.domain.model.steward.Property;
+import com.majordomo.domain.port.in.herald.ManageScheduleUseCase;
+import com.majordomo.domain.port.out.herald.MaintenanceScheduleRepository;
+import com.majordomo.domain.port.out.identity.ApiKeyRepository;
+import com.majordomo.domain.port.out.steward.PropertyRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
+
+/**
+ * Slice tests for {@link SchedulePageController#detail} and
+ * {@link SchedulePageController#addRecord}.
+ */
+@WebMvcTest(SchedulePageController.class)
+@Import(SecurityConfig.class)
+class SchedulePageDetailTest {
+
+    @Autowired MockMvc mvc;
+
+    @MockitoBean CurrentOrganizationResolver currentOrg;
+    @MockitoBean ScheduleAccessGuard guard;
+    @MockitoBean ManageScheduleUseCase scheduleUseCase;
+    @MockitoBean MaintenanceScheduleRepository scheduleRepository;
+    @MockitoBean PropertyRepository propertyRepository;
+    @MockitoBean ApiKeyRepository apiKeyRepository;
+    @MockitoBean OAuth2UserService oAuth2UserService;
+
+    private static final UUID ORG_ID = UuidFactory.newId();
+    private UUID scheduleId;
+    private UUID propertyId;
+
+    @BeforeEach
+    void seedAuth() {
+        User user = new User(UuidFactory.newId(), "robsartin", "rob@example.com");
+        when(currentOrg.resolve(any(UserDetails.class)))
+                .thenReturn(new CurrentOrganizationResolver.Resolved(user, ORG_ID));
+        scheduleId = UuidFactory.newId();
+        propertyId = UuidFactory.newId();
+    }
+
+    /** GET renders schedule, property, and chronological records (newest first). */
+    @Test
+    @WithMockUser
+    void detailRendersScheduleWithRecordsNewestFirst() throws Exception {
+        Property property = property("Cabin", ORG_ID);
+        property.setId(propertyId);
+        MaintenanceSchedule schedule = schedule("HVAC service", propertyId,
+                Frequency.ANNUAL, LocalDate.now().plusDays(45));
+        schedule.setId(scheduleId);
+        when(scheduleRepository.findById(scheduleId)).thenReturn(Optional.of(schedule));
+        when(propertyRepository.findById(propertyId)).thenReturn(Optional.of(property));
+        when(scheduleUseCase.findRecordsByScheduleId(scheduleId)).thenReturn(List.of(
+                record(scheduleId, LocalDate.of(2025, 6, 1), "First service", null),
+                record(scheduleId, LocalDate.of(2026, 4, 1), "Most recent service",
+                        new BigDecimal("199.99"))));
+
+        MvcResult result = mvc.perform(get("/schedules/{id}", scheduleId))
+                .andExpect(status().isOk())
+                .andExpect(view().name("schedule-detail"))
+                .andReturn();
+
+        String body = result.getResponse().getContentAsString();
+        assertThat(body).contains("HVAC service").contains("Cabin").contains("ANNUAL");
+        // Newest first: "Most recent service" must appear before "First service".
+        int newer = body.indexOf("Most recent service");
+        int older = body.indexOf("First service");
+        assertThat(newer).isPositive();
+        assertThat(older).isGreaterThan(newer);
+        assertThat(body).contains("$199.99");
+
+        verify(guard).verifyForSchedule(scheduleId);
+    }
+
+    /** GET returns 404 when the schedule does not exist. */
+    @Test
+    @WithMockUser
+    void detailReturns404WhenScheduleMissing() throws Exception {
+        when(scheduleRepository.findById(scheduleId)).thenReturn(Optional.empty());
+
+        mvc.perform(get("/schedules/{id}", scheduleId))
+                .andExpect(status().isNotFound());
+    }
+
+    /** GET renders empty-state when the schedule has no records yet. */
+    @Test
+    @WithMockUser
+    void detailEmptyStateWhenNoRecords() throws Exception {
+        MaintenanceSchedule schedule = schedule("New schedule", propertyId,
+                Frequency.MONTHLY, LocalDate.now().plusDays(7));
+        schedule.setId(scheduleId);
+        when(scheduleRepository.findById(scheduleId)).thenReturn(Optional.of(schedule));
+        when(propertyRepository.findById(propertyId)).thenReturn(Optional.empty());
+        when(scheduleUseCase.findRecordsByScheduleId(scheduleId)).thenReturn(List.of());
+
+        mvc.perform(get("/schedules/{id}", scheduleId))
+                .andExpect(status().isOk())
+                .andExpect(content().string(org.hamcrest.Matchers.containsString(
+                        "No service events recorded yet")));
+    }
+
+    /** Cross-org access on the detail page returns 403 (guard throws). */
+    @Test
+    @WithMockUser
+    void detailReturns403WhenAccessDenied() throws Exception {
+        doThrow(new AccessDeniedException("denied")).when(guard).verifyForSchedule(scheduleId);
+
+        mvc.perform(get("/schedules/{id}", scheduleId))
+                .andExpect(status().isForbidden());
+
+        verify(scheduleRepository, never()).findById(any());
+    }
+
+    /** POST records a service event, redirects to the detail page. */
+    @Test
+    @WithMockUser
+    void addRecordRedirectsToDetailOnSuccess() throws Exception {
+        when(scheduleUseCase.recordService(eq(scheduleId), any(ServiceRecord.class)))
+                .thenAnswer(inv -> inv.getArgument(1));
+
+        mvc.perform(post("/schedules/{id}/records", scheduleId)
+                        .with(csrf())
+                        .param("performedOn", "2026-04-29")
+                        .param("description", "Replaced filter")
+                        .param("cost", "29.99")
+                        .param("notes", "Carbon-activated"))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(view().name("redirect:/schedules/" + scheduleId));
+
+        ArgumentCaptor<ServiceRecord> captor = ArgumentCaptor.forClass(ServiceRecord.class);
+        verify(scheduleUseCase).recordService(eq(scheduleId), captor.capture());
+        ServiceRecord saved = captor.getValue();
+        assertThat(saved.getPerformedOn()).isEqualTo(LocalDate.of(2026, 4, 29));
+        assertThat(saved.getDescription()).isEqualTo("Replaced filter");
+        assertThat(saved.getCost()).isEqualByComparingTo("29.99");
+        assertThat(saved.getNotes()).isEqualTo("Carbon-activated");
+        verify(guard).verifyForSchedule(scheduleId);
+    }
+
+    /** POST with blank description re-renders detail page with error and field state. */
+    @Test
+    @WithMockUser
+    void addRecordRendersDetailWithErrorOnBlankDescription() throws Exception {
+        seedDetailLookups();
+
+        MvcResult result = mvc.perform(post("/schedules/{id}/records", scheduleId)
+                        .with(csrf())
+                        .param("performedOn", "2026-04-29")
+                        .param("description", "")
+                        .param("notes", "n/a"))
+                .andExpect(status().isOk())
+                .andExpect(view().name("schedule-detail"))
+                .andReturn();
+
+        String body = result.getResponse().getContentAsString();
+        assertThat(body).contains("Description is required.");
+        // Field state echoed back.
+        assertThat(body).contains("value=\"2026-04-29\"");
+        assertThat(body).contains("value=\"n/a\"");
+        verify(scheduleUseCase, never()).recordService(any(), any());
+    }
+
+    /** POST with missing performedOn re-renders with error. */
+    @Test
+    @WithMockUser
+    void addRecordRendersDetailWithErrorOnMissingDate() throws Exception {
+        seedDetailLookups();
+
+        mvc.perform(post("/schedules/{id}/records", scheduleId)
+                        .with(csrf())
+                        .param("description", "no date"))
+                .andExpect(status().isOk())
+                .andExpect(content().string(org.hamcrest.Matchers.containsString(
+                        "Performed-on date is required.")));
+
+        verify(scheduleUseCase, never()).recordService(any(), any());
+    }
+
+    /** POST is gated by the access guard. */
+    @Test
+    @WithMockUser
+    void addRecordReturns403WhenAccessDenied() throws Exception {
+        doThrow(new AccessDeniedException("denied")).when(guard).verifyForSchedule(scheduleId);
+
+        mvc.perform(post("/schedules/{id}/records", scheduleId)
+                        .with(csrf())
+                        .param("performedOn", "2026-04-29")
+                        .param("description", "x"))
+                .andExpect(status().isForbidden());
+
+        verify(scheduleUseCase, never()).recordService(any(), any());
+    }
+
+    private void seedDetailLookups() {
+        MaintenanceSchedule schedule = schedule("HVAC", propertyId, Frequency.ANNUAL,
+                LocalDate.now().plusDays(10));
+        schedule.setId(scheduleId);
+        when(scheduleRepository.findById(scheduleId)).thenReturn(Optional.of(schedule));
+        when(propertyRepository.findById(propertyId)).thenReturn(Optional.empty());
+        when(scheduleUseCase.findRecordsByScheduleId(scheduleId)).thenReturn(List.of());
+    }
+
+    private static Property property(String name, UUID orgId) {
+        Property p = new Property();
+        p.setId(UuidFactory.newId());
+        p.setOrganizationId(orgId);
+        p.setName(name);
+        return p;
+    }
+
+    private static MaintenanceSchedule schedule(String description, UUID propertyId,
+                                                Frequency freq, LocalDate nextDue) {
+        MaintenanceSchedule s = new MaintenanceSchedule();
+        s.setId(UuidFactory.newId());
+        s.setPropertyId(propertyId);
+        s.setDescription(description);
+        s.setFrequency(freq);
+        s.setNextDue(nextDue);
+        return s;
+    }
+
+    private static ServiceRecord record(UUID scheduleId, LocalDate performedOn,
+                                        String description, BigDecimal cost) {
+        ServiceRecord r = new ServiceRecord();
+        r.setId(UuidFactory.newId());
+        r.setScheduleId(scheduleId);
+        r.setPerformedOn(performedOn);
+        r.setDescription(description);
+        r.setCost(cost);
+        return r;
+    }
+}


### PR DESCRIPTION
## Summary

Second slice of the Herald UI parity work. Builds on #217's list view by adding a per-schedule detail page with service-record history and an inline "log a service event" form.

The REST surface at `/api/schedules` (`ScheduleController`) is **unchanged and stays pure REST.** `POST /schedules/{id}/records` is a *separate* Thymeleaf endpoint from `POST /api/schedules/{id}/records` — both call the same `ManageScheduleUseCase.recordService` underneath; the UI redirects to the detail page, REST returns `201 + Location`.

Closes #218

## What changed

- **`SchedulePageController`** gains `GET /schedules/{id}` (detail) + `POST /schedules/{id}/records` (inline form).
  - Detail GET 404s via `EntityNotFoundException` (caught by `GlobalExceptionHandler`).
  - Records sorted newest-first in the page controller; cost rendered as `$%.2f`.
  - Auth: `guard.verifyForSchedule(id)` on both endpoints.
- **`schedule-detail.html`**: header card with schedule + property + days-until-due badge; inline "log a service event" form (date / description required, cost / notes optional); service history table with empty state.
- Validation re-renders the detail page with `recordError` + `formPerformedOn` / `formDescription` / `formCost` / `formNotes` echoed back so the form keeps state.

## Test plan

- [x] 8 new tests in `SchedulePageDetailTest` (kept separate from the list test to keep both files focused):
  - GET renders schedule + records newest-first
  - GET 404 when schedule missing
  - GET empty-state when no records
  - GET 403 on cross-org access
  - POST happy path → redirect, captor confirms record fields
  - POST blank description → re-renders detail with error + field state
  - POST missing date → re-renders detail with error
  - POST 403 on cross-org access
- [x] Existing `SchedulePageControllerTest` updated to register the new `ManageScheduleUseCase` mock bean.
- [x] `./mvnw verify` — 462 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)