### PR TITLE
feat(herald): schedule add/edit forms at /schedules/new and /schedules/{id}/edit (closes #219)

### DIFF
--- a/src/main/java/com/majordomo/adapter/in/web/herald/SchedulePageController.java
+++ b/src/main/java/com/majordomo/adapter/in/web/herald/SchedulePageController.java
@@ -213,6 +213,234 @@ public class SchedulePageController {
     }
 
     /**
+     * Renders the new-schedule form.
+     *
+     * @param principal authenticated user
+     * @param model     Thymeleaf model
+     * @return the {@code schedule-form} template, or {@code redirect:/} if no org
+     */
+    @GetMapping("/schedules/new")
+    public String newForm(@AuthenticationPrincipal UserDetails principal, Model model) {
+        var ctx = currentOrg.resolve(principal);
+        if (ctx.organizationId() == null) {
+            return "redirect:/";
+        }
+        renderForm(null, null, ctx.user().getUsername(), model);
+        return "schedule-form";
+    }
+
+    /**
+     * Renders the edit form pre-populated for an existing schedule.
+     *
+     * @param id        schedule id
+     * @param principal authenticated user
+     * @param model     Thymeleaf model
+     * @return the {@code schedule-form} template, or {@code redirect:/} if no org
+     */
+    @GetMapping("/schedules/{id}/edit")
+    public String editForm(@PathVariable UUID id,
+                           @AuthenticationPrincipal UserDetails principal,
+                           Model model) {
+        var ctx = currentOrg.resolve(principal);
+        if (ctx.organizationId() == null) {
+            return "redirect:/";
+        }
+        guard.verifyForSchedule(id);
+        MaintenanceSchedule existing = scheduleRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(
+                        EntityType.MAINTENANCE_SCHEDULE.name(), id));
+        renderForm(id, existing, ctx.user().getUsername(), model);
+        return "schedule-form";
+    }
+
+    /**
+     * Creates a new schedule and redirects to its detail page. Validates
+     * inputs server-side; on failure re-renders the form with field state
+     * preserved and a {@code formError} attribute set.
+     *
+     * @param propertyId          owning property (required)
+     * @param description         schedule description (required, non-blank)
+     * @param frequency           {@link Frequency} name (required)
+     * @param nextDue             next-due date in {@code YYYY-MM-DD} (required)
+     * @param contactId           optional service-contact id
+     * @param customIntervalDays  optional, only meaningful with {@link Frequency#CUSTOM}
+     * @param estimatedCost       optional cost-per-occurrence
+     * @param principal           authenticated user
+     * @param model               Thymeleaf model
+     * @return redirect to the new schedule's detail page on success;
+     *         {@code schedule-form} on a handled validation failure;
+     *         {@code redirect:/} if the user has no organization
+     */
+    @PostMapping("/schedules")
+    public String create(@RequestParam(required = false) UUID propertyId,
+                         @RequestParam(required = false) String description,
+                         @RequestParam(required = false) String frequency,
+                         @RequestParam(required = false) String nextDue,
+                         @RequestParam(required = false) UUID contactId,
+                         @RequestParam(required = false) Integer customIntervalDays,
+                         @RequestParam(required = false) BigDecimal estimatedCost,
+                         @AuthenticationPrincipal UserDetails principal,
+                         Model model) {
+        var ctx = currentOrg.resolve(principal);
+        if (ctx.organizationId() == null) {
+            return "redirect:/";
+        }
+        if (propertyId == null) {
+            renderForm(null, null, ctx.user().getUsername(), model);
+            model.addAttribute("formError", "Property is required.");
+            echoFormState(model, propertyId, description, frequency, nextDue,
+                    contactId, customIntervalDays, estimatedCost);
+            return "schedule-form";
+        }
+        guard.verifyForProperty(propertyId);
+
+        String error = validateFormInputs(description, frequency, nextDue);
+        if (error != null) {
+            renderForm(null, null, ctx.user().getUsername(), model);
+            model.addAttribute("formError", error);
+            echoFormState(model, propertyId, description, frequency, nextDue,
+                    contactId, customIntervalDays, estimatedCost);
+            return "schedule-form";
+        }
+
+        MaintenanceSchedule schedule = new MaintenanceSchedule();
+        schedule.setPropertyId(propertyId);
+        schedule.setDescription(description);
+        schedule.setFrequency(Frequency.valueOf(frequency));
+        schedule.setNextDue(LocalDate.parse(nextDue));
+        schedule.setContactId(contactId);
+        schedule.setCustomIntervalDays(customIntervalDays);
+        schedule.setEstimatedCost(estimatedCost);
+        MaintenanceSchedule saved = scheduleUseCase.create(schedule);
+        return "redirect:/schedules/" + saved.getId();
+    }
+
+    /**
+     * Updates an existing schedule and redirects to its detail page. If the
+     * caller is reassigning the schedule to a different property, the new
+     * property is also access-checked.
+     *
+     * @param id                  schedule id
+     * @param propertyId          owning property (required; may differ from current)
+     * @param description         schedule description (required, non-blank)
+     * @param frequency           {@link Frequency} name (required)
+     * @param nextDue             next-due date in {@code YYYY-MM-DD} (required)
+     * @param contactId           optional service-contact id
+     * @param customIntervalDays  optional, only meaningful with {@link Frequency#CUSTOM}
+     * @param estimatedCost       optional cost-per-occurrence
+     * @param principal           authenticated user
+     * @param model               Thymeleaf model
+     * @return redirect to the schedule's detail page on success;
+     *         {@code schedule-form} on a handled validation failure;
+     *         {@code redirect:/} if the user has no organization
+     */
+    @PostMapping("/schedules/{id}")
+    public String update(@PathVariable UUID id,
+                         @RequestParam(required = false) UUID propertyId,
+                         @RequestParam(required = false) String description,
+                         @RequestParam(required = false) String frequency,
+                         @RequestParam(required = false) String nextDue,
+                         @RequestParam(required = false) UUID contactId,
+                         @RequestParam(required = false) Integer customIntervalDays,
+                         @RequestParam(required = false) BigDecimal estimatedCost,
+                         @AuthenticationPrincipal UserDetails principal,
+                         Model model) {
+        var ctx = currentOrg.resolve(principal);
+        if (ctx.organizationId() == null) {
+            return "redirect:/";
+        }
+        guard.verifyForSchedule(id);
+        MaintenanceSchedule existing = scheduleRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(
+                        EntityType.MAINTENANCE_SCHEDULE.name(), id));
+
+        if (propertyId == null) {
+            renderForm(id, existing, ctx.user().getUsername(), model);
+            model.addAttribute("formError", "Property is required.");
+            echoFormState(model, propertyId, description, frequency, nextDue,
+                    contactId, customIntervalDays, estimatedCost);
+            return "schedule-form";
+        }
+        // If the user is reassigning the schedule to a different property,
+        // verify they can also access the new property.
+        if (!propertyId.equals(existing.getPropertyId())) {
+            guard.verifyForProperty(propertyId);
+        }
+
+        String error = validateFormInputs(description, frequency, nextDue);
+        if (error != null) {
+            renderForm(id, existing, ctx.user().getUsername(), model);
+            model.addAttribute("formError", error);
+            echoFormState(model, propertyId, description, frequency, nextDue,
+                    contactId, customIntervalDays, estimatedCost);
+            return "schedule-form";
+        }
+
+        MaintenanceSchedule updated = new MaintenanceSchedule();
+        updated.setPropertyId(propertyId);
+        updated.setDescription(description);
+        updated.setFrequency(Frequency.valueOf(frequency));
+        updated.setNextDue(LocalDate.parse(nextDue));
+        updated.setContactId(contactId);
+        updated.setCustomIntervalDays(customIntervalDays);
+        updated.setEstimatedCost(estimatedCost);
+        scheduleUseCase.update(id, updated);
+        return "redirect:/schedules/" + id;
+    }
+
+    /**
+     * Populates the model for the schedule form, used by both new and edit modes.
+     */
+    private void renderForm(UUID editingId, MaintenanceSchedule existing,
+                            String username, Model model) {
+        // Properties the user can pick from.
+        List<Property> properties = new ArrayList<>();
+        for (UUID orgId : guard.currentUserOrganizationIds()) {
+            properties.addAll(propertyRepository.findByOrganizationId(orgId));
+        }
+        model.addAttribute("properties", properties);
+        model.addAttribute("frequencies", Frequency.values());
+        model.addAttribute("editingId", editingId);
+        model.addAttribute("existing", existing);
+        model.addAttribute("username", username);
+    }
+
+    private static void echoFormState(Model model, UUID propertyId, String description,
+                                      String frequency, String nextDue, UUID contactId,
+                                      Integer customIntervalDays, BigDecimal estimatedCost) {
+        model.addAttribute("formPropertyId", propertyId);
+        model.addAttribute("formDescription", description);
+        model.addAttribute("formFrequency", frequency);
+        model.addAttribute("formNextDue", nextDue);
+        model.addAttribute("formContactId", contactId);
+        model.addAttribute("formCustomIntervalDays", customIntervalDays);
+        model.addAttribute("formEstimatedCost", estimatedCost);
+    }
+
+    private static String validateFormInputs(String description, String frequency, String nextDue) {
+        if (description == null || description.isBlank()) {
+            return "Description is required.";
+        }
+        if (frequency == null || frequency.isBlank()) {
+            return "Frequency is required.";
+        }
+        try {
+            Frequency.valueOf(frequency);
+        } catch (IllegalArgumentException ex) {
+            return "Frequency must be one of: " + List.of(Frequency.values());
+        }
+        if (nextDue == null || nextDue.isBlank()) {
+            return "Next due date is required.";
+        }
+        try {
+            LocalDate.parse(nextDue);
+        } catch (DateTimeParseException ex) {
+            return "Next due must be a valid date (YYYY-MM-DD).";
+        }
+        return null;
+    }
+
+    /**
      * Populates the model with everything the detail template needs.
      */
     private void renderDetail(UUID id, String username, Model model) {

--- a/src/main/resources/templates/schedule-form.html
+++ b/src/main/resources/templates/schedule-form.html
@@ -1,0 +1,162 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org"
+      xmlns:sec="http://www.thymeleaf.org/extras/spring-security"
+      lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title th:text="${editingId != null ? 'Edit schedule' : 'New schedule'} + ' - Majordomo'">Schedule form</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-gray-100 min-h-screen">
+
+    <div th:replace="~{fragments/header :: header}"></div>
+
+    <div class="flex min-h-screen">
+        <div th:replace="~{fragments/sidebar :: sidebar('schedules')}"></div>
+
+        <main class="flex-1 p-6">
+
+            <!-- Breadcrumb -->
+            <nav class="mb-4" aria-label="Breadcrumb">
+                <ol class="flex items-center space-x-2 text-sm text-gray-500">
+                    <li><a th:href="@{/schedules}" class="hover:text-indigo-600 transition">Schedules</a></li>
+                    <li class="flex items-center space-x-2">
+                        <span>&rsaquo;</span>
+                        <span class="text-gray-900 font-medium"
+                              th:text="${editingId != null ? 'Edit' : 'New'}">Edit</span>
+                    </li>
+                </ol>
+            </nav>
+
+            <div class="bg-white rounded-lg shadow">
+                <div class="px-6 py-4 border-b border-gray-200">
+                    <h1 class="text-xl font-semibold text-gray-900"
+                        th:text="${editingId != null ? 'Edit schedule' : 'New schedule'}">Title</h1>
+                </div>
+                <div class="p-6 space-y-4">
+
+                    <div th:if="${formError}"
+                         class="rounded-md bg-red-50 border border-red-200 px-4 py-3 text-sm text-red-700"
+                         th:text="${formError}">Error</div>
+
+                    <form method="post"
+                          th:action="${editingId != null ? '/schedules/' + editingId : '/schedules'}"
+                          class="space-y-4">
+
+                        <!-- Property picker -->
+                        <div class="flex flex-col">
+                            <label for="propertyId"
+                                   class="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-1">
+                                Property
+                            </label>
+                            <select id="propertyId" name="propertyId" required
+                                    class="block rounded border-gray-300 text-sm focus:border-indigo-500 focus:ring-indigo-500 px-2 py-1.5">
+                                <option value="">— select a property —</option>
+                                <option th:each="p : ${properties}"
+                                        th:value="${p.getId()}"
+                                        th:text="${p.getName()}"
+                                        th:selected="${(formPropertyId != null and formPropertyId == p.getId())
+                                                or (formPropertyId == null and existing != null and existing.getPropertyId() == p.getId())}">
+                                    Property name
+                                </option>
+                            </select>
+                        </div>
+
+                        <!-- Description -->
+                        <div class="flex flex-col">
+                            <label for="description"
+                                   class="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-1">
+                                Description
+                            </label>
+                            <input id="description" name="description" type="text" required
+                                   th:value="${formDescription != null ? formDescription
+                                              : (existing != null ? existing.getDescription() : '')}"
+                                   class="block rounded border-gray-300 text-sm focus:border-indigo-500 focus:ring-indigo-500 px-2 py-1.5">
+                        </div>
+
+                        <!-- Frequency + nextDue + customIntervalDays -->
+                        <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+                            <div class="flex flex-col">
+                                <label for="frequency"
+                                       class="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-1">
+                                    Frequency
+                                </label>
+                                <select id="frequency" name="frequency" required
+                                        class="block rounded border-gray-300 text-sm focus:border-indigo-500 focus:ring-indigo-500 px-2 py-1.5">
+                                    <option value="">— select —</option>
+                                    <option th:each="f : ${frequencies}"
+                                            th:value="${f}"
+                                            th:text="${f}"
+                                            th:selected="${(formFrequency != null and formFrequency == f.name())
+                                                    or (formFrequency == null and existing != null and existing.getFrequency() == f)}">
+                                        FREQ
+                                    </option>
+                                </select>
+                            </div>
+                            <div class="flex flex-col">
+                                <label for="nextDue"
+                                       class="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-1">
+                                    Next due
+                                </label>
+                                <input id="nextDue" name="nextDue" type="date" required
+                                       th:value="${formNextDue != null ? formNextDue
+                                                  : (existing != null and existing.getNextDue() != null ? existing.getNextDue() : '')}"
+                                       class="block rounded border-gray-300 text-sm focus:border-indigo-500 focus:ring-indigo-500 px-2 py-1.5">
+                            </div>
+                            <div class="flex flex-col">
+                                <label for="customIntervalDays"
+                                       class="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-1">
+                                    Custom interval (days)
+                                </label>
+                                <input id="customIntervalDays" name="customIntervalDays" type="number" min="1"
+                                       th:value="${formCustomIntervalDays != null ? formCustomIntervalDays
+                                                  : (existing != null and existing.getCustomIntervalDays() != null ? existing.getCustomIntervalDays() : '')}"
+                                       placeholder="for CUSTOM frequency"
+                                       class="block rounded border-gray-300 text-sm focus:border-indigo-500 focus:ring-indigo-500 px-2 py-1.5">
+                            </div>
+                        </div>
+
+                        <!-- Estimated cost + contact id (optional) -->
+                        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                            <div class="flex flex-col">
+                                <label for="estimatedCost"
+                                       class="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-1">
+                                    Estimated cost (optional)
+                                </label>
+                                <input id="estimatedCost" name="estimatedCost" type="number" step="0.01" min="0"
+                                       th:value="${formEstimatedCost != null ? formEstimatedCost
+                                                  : (existing != null and existing.getEstimatedCost() != null ? existing.getEstimatedCost() : '')}"
+                                       class="block rounded border-gray-300 text-sm focus:border-indigo-500 focus:ring-indigo-500 px-2 py-1.5">
+                            </div>
+                            <div class="flex flex-col">
+                                <label for="contactId"
+                                       class="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-1">
+                                    Service contact id (optional)
+                                </label>
+                                <input id="contactId" name="contactId" type="text"
+                                       th:value="${formContactId != null ? formContactId
+                                                  : (existing != null and existing.getContactId() != null ? existing.getContactId() : '')}"
+                                       placeholder="UUID of the contact who services this"
+                                       class="block rounded border-gray-300 text-sm font-mono focus:border-indigo-500 focus:ring-indigo-500 px-2 py-1.5">
+                            </div>
+                        </div>
+
+                        <div class="flex items-center gap-2">
+                            <button type="submit"
+                                    class="inline-flex items-center rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-indigo-700">
+                                <span th:text="${editingId != null ? 'Save changes' : 'Create schedule'}">Submit</span>
+                            </button>
+                            <a th:href="${editingId != null ? '/schedules/' + editingId : '/schedules'}"
+                               class="inline-flex items-center rounded-md bg-white px-3 py-1.5 text-sm font-medium text-gray-700 ring-1 ring-gray-300 hover:bg-gray-50">
+                                Cancel
+                            </a>
+                        </div>
+                    </form>
+                </div>
+            </div>
+
+        </main>
+    </div>
+</body>
+</html>

--- a/src/test/java/com/majordomo/adapter/in/web/herald/SchedulePageFormTest.java
+++ b/src/test/java/com/majordomo/adapter/in/web/herald/SchedulePageFormTest.java
@@ -1,0 +1,306 @@
+package com.majordomo.adapter.in.web.herald;
+
+import com.majordomo.adapter.in.web.config.OAuth2UserService;
+import com.majordomo.adapter.in.web.config.SecurityConfig;
+import com.majordomo.application.herald.ScheduleAccessGuard;
+import com.majordomo.application.identity.CurrentOrganizationResolver;
+import com.majordomo.domain.model.UuidFactory;
+import com.majordomo.domain.model.herald.Frequency;
+import com.majordomo.domain.model.herald.MaintenanceSchedule;
+import com.majordomo.domain.model.identity.User;
+import com.majordomo.domain.model.steward.Property;
+import com.majordomo.domain.port.in.herald.ManageScheduleUseCase;
+import com.majordomo.domain.port.out.herald.MaintenanceScheduleRepository;
+import com.majordomo.domain.port.out.identity.ApiKeyRepository;
+import com.majordomo.domain.port.out.steward.PropertyRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
+
+/**
+ * Slice tests for the schedule add/edit forms exposed by
+ * {@link SchedulePageController}.
+ */
+@WebMvcTest(SchedulePageController.class)
+@Import(SecurityConfig.class)
+class SchedulePageFormTest {
+
+    @Autowired MockMvc mvc;
+
+    @MockitoBean CurrentOrganizationResolver currentOrg;
+    @MockitoBean ScheduleAccessGuard guard;
+    @MockitoBean ManageScheduleUseCase scheduleUseCase;
+    @MockitoBean MaintenanceScheduleRepository scheduleRepository;
+    @MockitoBean PropertyRepository propertyRepository;
+    @MockitoBean ApiKeyRepository apiKeyRepository;
+    @MockitoBean OAuth2UserService oAuth2UserService;
+
+    private static final UUID ORG_ID = UuidFactory.newId();
+    private UUID propertyId;
+    private UUID scheduleId;
+
+    @BeforeEach
+    void seedAuth() {
+        User user = new User(UuidFactory.newId(), "robsartin", "rob@example.com");
+        when(currentOrg.resolve(any(UserDetails.class)))
+                .thenReturn(new CurrentOrganizationResolver.Resolved(user, ORG_ID));
+        when(guard.currentUserOrganizationIds()).thenReturn(Set.of(ORG_ID));
+        propertyId = UuidFactory.newId();
+        scheduleId = UuidFactory.newId();
+        when(propertyRepository.findByOrganizationId(ORG_ID)).thenReturn(List.of(
+                property(propertyId, "Cabin")));
+    }
+
+    /** GET /schedules/new renders the form with property options. */
+    @Test
+    @WithMockUser
+    void newFormRendersWithPropertyOptions() throws Exception {
+        MvcResult result = mvc.perform(get("/schedules/new"))
+                .andExpect(status().isOk())
+                .andExpect(view().name("schedule-form"))
+                .andReturn();
+
+        String body = result.getResponse().getContentAsString();
+        assertThat(body).contains("New schedule").contains("Cabin");
+        assertThat(body).contains("ANNUAL").contains("WEEKLY");
+    }
+
+    /** GET /schedules/{id}/edit pre-populates the form fields. */
+    @Test
+    @WithMockUser
+    void editFormPrePopulates() throws Exception {
+        MaintenanceSchedule existing = schedule("HVAC service", propertyId,
+                Frequency.QUARTERLY, LocalDate.of(2026, 7, 1));
+        existing.setId(scheduleId);
+        existing.setEstimatedCost(new BigDecimal("125.00"));
+        when(scheduleRepository.findById(scheduleId)).thenReturn(Optional.of(existing));
+
+        MvcResult result = mvc.perform(get("/schedules/{id}/edit", scheduleId))
+                .andExpect(status().isOk())
+                .andExpect(view().name("schedule-form"))
+                .andReturn();
+
+        String body = result.getResponse().getContentAsString();
+        assertThat(body).contains("Edit schedule");
+        assertThat(body).contains("value=\"HVAC service\"");
+        assertThat(body).contains("value=\"2026-07-01\"");
+        assertThat(body).contains("value=\"125.00\"");
+        verify(guard).verifyForSchedule(scheduleId);
+    }
+
+    /** GET /schedules/{id}/edit returns 404 when missing. */
+    @Test
+    @WithMockUser
+    void editFormReturns404WhenMissing() throws Exception {
+        when(scheduleRepository.findById(scheduleId)).thenReturn(Optional.empty());
+
+        mvc.perform(get("/schedules/{id}/edit", scheduleId))
+                .andExpect(status().isNotFound());
+    }
+
+    /** POST /schedules creates and redirects to the new detail page. */
+    @Test
+    @WithMockUser
+    void createRedirectsToDetailPage() throws Exception {
+        MaintenanceSchedule saved = schedule("HVAC service", propertyId,
+                Frequency.ANNUAL, LocalDate.of(2026, 6, 1));
+        UUID newId = UuidFactory.newId();
+        saved.setId(newId);
+        when(scheduleUseCase.create(any(MaintenanceSchedule.class))).thenReturn(saved);
+
+        mvc.perform(post("/schedules")
+                        .with(csrf())
+                        .param("propertyId", propertyId.toString())
+                        .param("description", "HVAC service")
+                        .param("frequency", "ANNUAL")
+                        .param("nextDue", "2026-06-01")
+                        .param("estimatedCost", "199.99"))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(view().name("redirect:/schedules/" + newId));
+
+        ArgumentCaptor<MaintenanceSchedule> captor = ArgumentCaptor.forClass(MaintenanceSchedule.class);
+        verify(scheduleUseCase).create(captor.capture());
+        MaintenanceSchedule submitted = captor.getValue();
+        assertThat(submitted.getDescription()).isEqualTo("HVAC service");
+        assertThat(submitted.getFrequency()).isEqualTo(Frequency.ANNUAL);
+        assertThat(submitted.getNextDue()).isEqualTo(LocalDate.of(2026, 6, 1));
+        assertThat(submitted.getEstimatedCost()).isEqualByComparingTo("199.99");
+        verify(guard).verifyForProperty(propertyId);
+    }
+
+    /** POST /schedules with blank description re-renders the form with state preserved. */
+    @Test
+    @WithMockUser
+    void createRendersFormOnValidationError() throws Exception {
+        MvcResult result = mvc.perform(post("/schedules")
+                        .with(csrf())
+                        .param("propertyId", propertyId.toString())
+                        .param("description", "")
+                        .param("frequency", "ANNUAL")
+                        .param("nextDue", "2026-06-01"))
+                .andExpect(status().isOk())
+                .andExpect(view().name("schedule-form"))
+                .andReturn();
+
+        String body = result.getResponse().getContentAsString();
+        assertThat(body).contains("Description is required.");
+        // Form state echoed.
+        assertThat(body).contains("value=\"2026-06-01\"");
+        verify(scheduleUseCase, never()).create(any());
+    }
+
+    /** POST /schedules with no propertyId re-renders form with error. */
+    @Test
+    @WithMockUser
+    void createRendersFormWhenPropertyMissing() throws Exception {
+        mvc.perform(post("/schedules")
+                        .with(csrf())
+                        .param("description", "x")
+                        .param("frequency", "ANNUAL")
+                        .param("nextDue", "2026-06-01"))
+                .andExpect(status().isOk())
+                .andExpect(content().string(org.hamcrest.Matchers.containsString(
+                        "Property is required.")));
+
+        verify(guard, never()).verifyForProperty(any());
+    }
+
+    /** POST /schedules returns 403 when the user can't access the property. */
+    @Test
+    @WithMockUser
+    void createReturns403WhenPropertyAccessDenied() throws Exception {
+        doThrow(new AccessDeniedException("denied"))
+                .when(guard).verifyForProperty(propertyId);
+
+        mvc.perform(post("/schedules")
+                        .with(csrf())
+                        .param("propertyId", propertyId.toString())
+                        .param("description", "HVAC")
+                        .param("frequency", "ANNUAL")
+                        .param("nextDue", "2026-06-01"))
+                .andExpect(status().isForbidden());
+
+        verify(scheduleUseCase, never()).create(any());
+    }
+
+    /** POST /schedules/{id} updates and redirects to the detail page. */
+    @Test
+    @WithMockUser
+    void updateRedirectsToDetailPage() throws Exception {
+        MaintenanceSchedule existing = schedule("Old", propertyId,
+                Frequency.QUARTERLY, LocalDate.of(2026, 1, 1));
+        existing.setId(scheduleId);
+        when(scheduleRepository.findById(scheduleId)).thenReturn(Optional.of(existing));
+        MaintenanceSchedule updated = schedule("New", propertyId,
+                Frequency.ANNUAL, LocalDate.of(2026, 7, 1));
+        updated.setId(scheduleId);
+        when(scheduleUseCase.update(eq(scheduleId), any(MaintenanceSchedule.class)))
+                .thenReturn(updated);
+
+        mvc.perform(post("/schedules/{id}", scheduleId)
+                        .with(csrf())
+                        .param("propertyId", propertyId.toString())
+                        .param("description", "New")
+                        .param("frequency", "ANNUAL")
+                        .param("nextDue", "2026-07-01"))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(view().name("redirect:/schedules/" + scheduleId));
+
+        verify(guard).verifyForSchedule(scheduleId);
+    }
+
+    /** POST /schedules/{id} re-checks property access when the property changes. */
+    @Test
+    @WithMockUser
+    void updateRevalidatesPropertyWhenChanged() throws Exception {
+        MaintenanceSchedule existing = schedule("HVAC", propertyId,
+                Frequency.ANNUAL, LocalDate.of(2026, 1, 1));
+        existing.setId(scheduleId);
+        when(scheduleRepository.findById(scheduleId)).thenReturn(Optional.of(existing));
+
+        UUID newPropertyId = UuidFactory.newId();
+        when(scheduleUseCase.update(any(), any())).thenReturn(existing);
+
+        mvc.perform(post("/schedules/{id}", scheduleId)
+                        .with(csrf())
+                        .param("propertyId", newPropertyId.toString())
+                        .param("description", "HVAC")
+                        .param("frequency", "ANNUAL")
+                        .param("nextDue", "2026-07-01"))
+                .andExpect(status().is3xxRedirection());
+
+        verify(guard).verifyForSchedule(scheduleId);
+        verify(guard).verifyForProperty(newPropertyId);
+    }
+
+    /** POST /schedules/{id} with bad inputs re-renders form. */
+    @Test
+    @WithMockUser
+    void updateRendersFormOnValidationError() throws Exception {
+        MaintenanceSchedule existing = schedule("HVAC", propertyId,
+                Frequency.ANNUAL, LocalDate.of(2026, 1, 1));
+        existing.setId(scheduleId);
+        when(scheduleRepository.findById(scheduleId)).thenReturn(Optional.of(existing));
+
+        mvc.perform(post("/schedules/{id}", scheduleId)
+                        .with(csrf())
+                        .param("propertyId", propertyId.toString())
+                        .param("description", "valid")
+                        .param("frequency", "ANNUAL")
+                        .param("nextDue", "not-a-date"))
+                .andExpect(status().isOk())
+                .andExpect(view().name("schedule-form"))
+                .andExpect(content().string(org.hamcrest.Matchers.containsString(
+                        "Next due must be a valid date")));
+
+        verify(scheduleUseCase, never()).update(any(), any());
+    }
+
+    private static Property property(UUID id, String name) {
+        Property p = new Property();
+        p.setId(id);
+        p.setOrganizationId(ORG_ID);
+        p.setName(name);
+        return p;
+    }
+
+    private static MaintenanceSchedule schedule(String desc, UUID propertyId,
+                                                Frequency freq, LocalDate nextDue) {
+        MaintenanceSchedule s = new MaintenanceSchedule();
+        s.setPropertyId(propertyId);
+        s.setDescription(desc);
+        s.setFrequency(freq);
+        s.setNextDue(nextDue);
+        return s;
+    }
+}


### PR DESCRIPTION
## Summary

Third (and final) slice of the Herald UI parity work proposed in #172. Closes the v1 loop: list (#217) → detail + record-add (#218) → **add/edit forms (this PR)**. The user can now manage their maintenance schedules end-to-end without touching the REST API.

The REST surface at `/api/schedules` (`ScheduleController`) is **unchanged and stays pure REST.** `POST /schedules` and `POST /schedules/{id}` are *separate* Thymeleaf endpoints from the REST POST/PUT pair — both call the same use-case methods underneath; the UI redirects to the detail page, REST returns 201/200 with JSON.

Closes #219

## What changed

- **`SchedulePageController`** gains four endpoints:
  - `GET /schedules/new` — empty form, property picker scoped to user's accessible orgs.
  - `POST /schedules` — validates inputs, verifies property access, creates, redirects to `/schedules/{id}`.
  - `GET /schedules/{id}/edit` — same form pre-populated.
  - `POST /schedules/{id}` — validates, re-checks property access if the property changed, updates, redirects.
- **`schedule-form.html`** — shared Tailwind form template; mode-aware title + button label + form action via `editingId`. Property picker, frequency dropdown, next-due date, optional `customIntervalDays` (for `CUSTOM` frequency), `estimatedCost`, `contactId`.
- Validation: description required + non-blank, frequency required + valid enum value, nextDue required + parseable date. On failure the form re-renders with `formError` + every field echoed back so the user doesn't lose state.

## Test plan

- [x] 9 new tests in `SchedulePageFormTest`: new-form render, edit pre-populate, edit 404 missing, create happy path, validation errors (blank description, missing property, bad date), 403 on cross-org property, update happy path, update revalidates property when changed.
- [x] `./mvnw verify` — 472 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)