### PR TITLE
feat(steward): property list + filter UI at /properties (closes #223)

### DIFF
--- a/src/main/java/com/majordomo/adapter/in/web/steward/PropertyPageController.java
+++ b/src/main/java/com/majordomo/adapter/in/web/steward/PropertyPageController.java
@@ -1,5 +1,6 @@
 package com.majordomo.adapter.in.web.steward;
 
+import com.majordomo.application.identity.CurrentOrganizationResolver;
 import com.majordomo.domain.model.concierge.Contact;
 import com.majordomo.domain.model.steward.Property;
 import com.majordomo.domain.model.steward.PropertyContact;
@@ -10,6 +11,7 @@ import com.majordomo.domain.port.in.steward.ManagePropertyUseCase;
 import com.majordomo.domain.port.out.identity.MembershipRepository;
 import com.majordomo.domain.port.out.identity.UserRepository;
 import com.majordomo.domain.port.out.steward.PropertyContactRepository;
+import com.majordomo.domain.port.out.steward.PropertyRepository;
 
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -18,7 +20,10 @@ import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 
+import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.UUID;
 
@@ -38,6 +43,8 @@ public class PropertyPageController {
     private final ManageContactUseCase contactUseCase;
     private final ManageAttachmentUseCase attachmentUseCase;
     private final PropertyContactRepository propertyContactRepository;
+    private final PropertyRepository propertyRepository;
+    private final CurrentOrganizationResolver currentOrg;
     private final UserRepository userRepository;
     private final MembershipRepository membershipRepository;
 
@@ -49,6 +56,8 @@ public class PropertyPageController {
      * @param contactUseCase            the inbound port for contact management
      * @param attachmentUseCase         the inbound port for attachment management
      * @param propertyContactRepository the outbound port for property-contact associations
+     * @param propertyRepository        the outbound port for property reads (used by the list view)
+     * @param currentOrg                resolves the authenticated user's organization
      * @param userRepository            the outbound port for user lookups
      * @param membershipRepository      the outbound port for membership lookups
      */
@@ -57,6 +66,8 @@ public class PropertyPageController {
                                   ManageContactUseCase contactUseCase,
                                   ManageAttachmentUseCase attachmentUseCase,
                                   PropertyContactRepository propertyContactRepository,
+                                  PropertyRepository propertyRepository,
+                                  CurrentOrganizationResolver currentOrg,
                                   UserRepository userRepository,
                                   MembershipRepository membershipRepository) {
         this.propertyUseCase = propertyUseCase;
@@ -64,8 +75,69 @@ public class PropertyPageController {
         this.contactUseCase = contactUseCase;
         this.attachmentUseCase = attachmentUseCase;
         this.propertyContactRepository = propertyContactRepository;
+        this.propertyRepository = propertyRepository;
+        this.currentOrg = currentOrg;
         this.userRepository = userRepository;
         this.membershipRepository = membershipRepository;
+    }
+
+    /**
+     * Renders the property list page for the authenticated user's organization,
+     * with optional category and free-text filters.
+     *
+     * @param category  optional exact-match category filter
+     * @param q         optional case-insensitive query across name + description
+     * @param principal authenticated user
+     * @param model     Thymeleaf model
+     * @return the {@code properties} template, or a redirect home if the user
+     *         has no organization
+     */
+    @GetMapping
+    public String list(@RequestParam(required = false) String category,
+                       @RequestParam(required = false) String q,
+                       @AuthenticationPrincipal UserDetails principal,
+                       Model model) {
+        var ctx = currentOrg.resolve(principal);
+        if (ctx.organizationId() == null) {
+            return "redirect:/";
+        }
+        UUID orgId = ctx.organizationId();
+        List<Property> raw = new ArrayList<>(propertyRepository.findByOrganizationId(orgId));
+
+        String categoryFilter = (category == null || category.isBlank()) ? null : category.trim();
+        String qLower = (q == null || q.isBlank()) ? null : q.trim().toLowerCase();
+
+        List<Property> rows = new ArrayList<>();
+        for (Property p : raw) {
+            if (p.getArchivedAt() != null) {
+                continue;
+            }
+            if (categoryFilter != null && !categoryFilter.equalsIgnoreCase(p.getCategory())) {
+                continue;
+            }
+            if (qLower != null && !matchesQuery(p, qLower)) {
+                continue;
+            }
+            rows.add(p);
+        }
+        rows.sort(Comparator.comparing(
+                Property::getName, Comparator.nullsLast(String.CASE_INSENSITIVE_ORDER)));
+
+        model.addAttribute("rows", rows);
+        model.addAttribute("category", category);
+        model.addAttribute("q", q);
+        model.addAttribute("username", ctx.user().getUsername());
+        return "properties";
+    }
+
+    private static boolean matchesQuery(Property p, String qLower) {
+        if (p.getName() != null && p.getName().toLowerCase().contains(qLower)) {
+            return true;
+        }
+        if (p.getDescription() != null && p.getDescription().toLowerCase().contains(qLower)) {
+            return true;
+        }
+        return false;
     }
 
     /**

--- a/src/main/resources/templates/properties.html
+++ b/src/main/resources/templates/properties.html
@@ -1,0 +1,101 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org"
+      xmlns:sec="http://www.thymeleaf.org/extras/spring-security"
+      lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Properties - Majordomo</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-gray-100 min-h-screen">
+
+    <div th:replace="~{fragments/header :: header}"></div>
+
+    <div class="flex min-h-screen">
+        <div th:replace="~{fragments/sidebar :: sidebar('properties')}"></div>
+
+        <main class="flex-1 p-6">
+
+            <div class="flex items-baseline justify-between mb-6">
+                <h1 class="text-2xl font-bold text-gray-900">Properties</h1>
+                <span class="text-sm text-gray-500"
+                      th:text="${#lists.size(rows)} + ' properties'">0 properties</span>
+            </div>
+
+            <!-- Filter strip -->
+            <div class="bg-white rounded-lg shadow p-4 mb-6">
+                <form method="get" th:action="@{/properties}" class="flex flex-wrap items-end gap-4">
+                    <div class="flex flex-col">
+                        <label for="q"
+                               class="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-1">
+                            Search
+                        </label>
+                        <input id="q" name="q" type="text" th:value="${q}"
+                               placeholder="name or description"
+                               class="block rounded border-gray-300 text-sm focus:border-indigo-500 focus:ring-indigo-500 px-2 py-1.5 w-64">
+                    </div>
+                    <div class="flex flex-col">
+                        <label for="category"
+                               class="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-1">
+                            Category
+                        </label>
+                        <input id="category" name="category" type="text" th:value="${category}"
+                               class="block rounded border-gray-300 text-sm focus:border-indigo-500 focus:ring-indigo-500 px-2 py-1.5 w-48">
+                    </div>
+                    <div class="flex gap-2">
+                        <button type="submit"
+                                class="inline-flex items-center rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-indigo-700">
+                            Filter
+                        </button>
+                        <a th:href="@{/properties}"
+                           class="inline-flex items-center rounded-md bg-white px-3 py-1.5 text-sm font-medium text-gray-700 ring-1 ring-gray-300 hover:bg-gray-50">
+                            Reset
+                        </a>
+                    </div>
+                </form>
+            </div>
+
+            <!-- Empty state -->
+            <div th:if="${#lists.isEmpty(rows)}"
+                 class="bg-white rounded-lg shadow p-8 text-center text-gray-500">
+                No properties match. Add a property to start tracking it.
+            </div>
+
+            <!-- Property table -->
+            <div th:unless="${#lists.isEmpty(rows)}" class="bg-white rounded-lg shadow overflow-hidden">
+                <table class="min-w-full divide-y divide-gray-200">
+                    <thead class="bg-gray-50">
+                        <tr>
+                            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Name</th>
+                            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Category</th>
+                            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Status</th>
+                            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Location</th>
+                        </tr>
+                    </thead>
+                    <tbody class="bg-white divide-y divide-gray-200">
+                        <tr th:each="p : ${rows}" class="hover:bg-gray-50">
+                            <td class="px-6 py-3 text-sm">
+                                <a th:href="@{|/properties/${p.getId()}|}"
+                                   class="font-medium text-gray-900 hover:text-indigo-700"
+                                   th:text="${p.getName()}">name</a>
+                            </td>
+                            <td class="px-6 py-3 text-sm text-gray-700"
+                                th:text="${p.getCategory() != null ? p.getCategory() : '—'}">category</td>
+                            <td class="px-6 py-3 text-sm">
+                                <span th:if="${p.getStatus() != null}"
+                                      class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-gray-100 text-gray-800"
+                                      th:text="${p.getStatus()}">STATUS</span>
+                                <span th:unless="${p.getStatus() != null}" class="text-gray-400">—</span>
+                            </td>
+                            <td class="px-6 py-3 text-sm text-gray-700"
+                                th:text="${p.getLocation() != null ? p.getLocation() : '—'}">location</td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+
+        </main>
+    </div>
+</body>
+</html>

--- a/src/test/java/com/majordomo/adapter/in/web/steward/PropertyPageControllerTest.java
+++ b/src/test/java/com/majordomo/adapter/in/web/steward/PropertyPageControllerTest.java
@@ -60,6 +60,12 @@ class PropertyPageControllerTest {
     private PropertyContactRepository propertyContactRepository;
 
     @MockitoBean
+    private com.majordomo.domain.port.out.steward.PropertyRepository propertyRepository;
+
+    @MockitoBean
+    private com.majordomo.application.identity.CurrentOrganizationResolver currentOrg;
+
+    @MockitoBean
     private UserRepository userRepository;
 
     @MockitoBean

--- a/src/test/java/com/majordomo/adapter/in/web/steward/PropertyPageListTest.java
+++ b/src/test/java/com/majordomo/adapter/in/web/steward/PropertyPageListTest.java
@@ -1,0 +1,197 @@
+package com.majordomo.adapter.in.web.steward;
+
+import com.majordomo.adapter.in.web.config.OAuth2UserService;
+import com.majordomo.adapter.in.web.config.SecurityConfig;
+import com.majordomo.application.identity.CurrentOrganizationResolver;
+import com.majordomo.domain.model.UuidFactory;
+import com.majordomo.domain.model.identity.User;
+import com.majordomo.domain.model.steward.Property;
+import com.majordomo.domain.model.steward.PropertyStatus;
+import com.majordomo.domain.port.in.ManageAttachmentUseCase;
+import com.majordomo.domain.port.in.concierge.ManageContactUseCase;
+import com.majordomo.domain.port.in.herald.ManageScheduleUseCase;
+import com.majordomo.domain.port.in.steward.ManagePropertyUseCase;
+import com.majordomo.domain.port.out.identity.ApiKeyRepository;
+import com.majordomo.domain.port.out.identity.MembershipRepository;
+import com.majordomo.domain.port.out.identity.UserRepository;
+import com.majordomo.domain.port.out.steward.PropertyContactRepository;
+import com.majordomo.domain.port.out.steward.PropertyRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
+
+/**
+ * Slice tests for {@link PropertyPageController#list}: list + filter at {@code /properties}.
+ */
+@WebMvcTest(PropertyPageController.class)
+@Import(SecurityConfig.class)
+class PropertyPageListTest {
+
+    @Autowired MockMvc mvc;
+
+    @MockitoBean ManagePropertyUseCase propertyUseCase;
+    @MockitoBean ManageScheduleUseCase scheduleUseCase;
+    @MockitoBean ManageContactUseCase contactUseCase;
+    @MockitoBean ManageAttachmentUseCase attachmentUseCase;
+    @MockitoBean PropertyContactRepository propertyContactRepository;
+    @MockitoBean PropertyRepository propertyRepository;
+    @MockitoBean CurrentOrganizationResolver currentOrg;
+    @MockitoBean UserRepository userRepository;
+    @MockitoBean MembershipRepository membershipRepository;
+    @MockitoBean ApiKeyRepository apiKeyRepository;
+    @MockitoBean OAuth2UserService oAuth2UserService;
+
+    private static final UUID ORG_ID = UuidFactory.newId();
+
+    @BeforeEach
+    void seedAuth() {
+        User user = new User(UuidFactory.newId(), "robsartin", "rob@example.com");
+        when(currentOrg.resolve(any(UserDetails.class)))
+                .thenReturn(new CurrentOrganizationResolver.Resolved(user, ORG_ID));
+    }
+
+    /** Renders properties sorted by name with category, status, and location. */
+    @Test
+    @WithMockUser
+    void listRendersPropertiesSortedByName() throws Exception {
+        when(propertyRepository.findByOrganizationId(ORG_ID)).thenReturn(List.of(
+                property("Beach House", "vacation", PropertyStatus.ACTIVE, "Cape Cod", null),
+                property("Apartment", "rental", PropertyStatus.IN_SERVICE, "Boston", null)));
+
+        MvcResult result = mvc.perform(get("/properties"))
+                .andExpect(status().isOk())
+                .andExpect(view().name("properties"))
+                .andReturn();
+
+        String body = result.getResponse().getContentAsString();
+        assertThat(body).contains("Beach House").contains("Apartment");
+        assertThat(body).contains("vacation").contains("rental");
+        assertThat(body).contains("ACTIVE").contains("IN_SERVICE");
+        // Apartment sorts before Beach House alphabetically.
+        int apt = body.indexOf("Apartment");
+        int beach = body.indexOf("Beach House");
+        assertThat(apt).isPositive().isLessThan(beach);
+    }
+
+    /** Archived properties are filtered out. */
+    @Test
+    @WithMockUser
+    void listSkipsArchivedProperties() throws Exception {
+        when(propertyRepository.findByOrganizationId(ORG_ID)).thenReturn(List.of(
+                property("Active", "rental", PropertyStatus.ACTIVE, "x", null),
+                property("Archived old", "rental", PropertyStatus.DISPOSED, "y",
+                        Instant.parse("2025-01-01T00:00:00Z"))));
+
+        MvcResult result = mvc.perform(get("/properties"))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        String body = result.getResponse().getContentAsString();
+        assertThat(body).contains("Active").doesNotContain("Archived old");
+    }
+
+    /** Free-text query narrows results across name + description. */
+    @Test
+    @WithMockUser
+    void searchFiltersAcrossNameAndDescription() throws Exception {
+        Property cabin = property("Cabin", "vacation", PropertyStatus.ACTIVE, "Maine", null);
+        cabin.setDescription("Lakeside retreat with HVAC");
+        Property apartment = property("Apartment", "rental", PropertyStatus.ACTIVE, "Boston", null);
+        apartment.setDescription("City rental");
+        when(propertyRepository.findByOrganizationId(ORG_ID)).thenReturn(List.of(cabin, apartment));
+
+        // Match against description.
+        MvcResult lakeResult = mvc.perform(get("/properties").param("q", "lakeside"))
+                .andExpect(status().isOk())
+                .andReturn();
+        assertThat(lakeResult.getResponse().getContentAsString())
+                .contains("Cabin").doesNotContain("Apartment");
+
+        // Match against name.
+        MvcResult aptResult = mvc.perform(get("/properties").param("q", "apartment"))
+                .andExpect(status().isOk())
+                .andReturn();
+        assertThat(aptResult.getResponse().getContentAsString())
+                .contains("Apartment").doesNotContain("Cabin");
+    }
+
+    /** Category filter narrows results (case-insensitive exact match). */
+    @Test
+    @WithMockUser
+    void filterByCategoryNarrowsResults() throws Exception {
+        when(propertyRepository.findByOrganizationId(ORG_ID)).thenReturn(List.of(
+                property("Cabin", "vacation", PropertyStatus.ACTIVE, "Maine", null),
+                property("Apartment", "rental", PropertyStatus.ACTIVE, "Boston", null)));
+
+        MvcResult result = mvc.perform(get("/properties").param("category", "rental"))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        String body = result.getResponse().getContentAsString();
+        assertThat(body).contains("Apartment").doesNotContain("Cabin");
+    }
+
+    /** Empty state renders when no properties match. */
+    @Test
+    @WithMockUser
+    void emptyStateRendersWhenNoMatches() throws Exception {
+        when(propertyRepository.findByOrganizationId(ORG_ID)).thenReturn(List.of());
+
+        mvc.perform(get("/properties"))
+                .andExpect(status().isOk())
+                .andExpect(content().string(org.hamcrest.Matchers.containsString(
+                        "No properties match")));
+    }
+
+    /** User without an organization redirects home. */
+    @Test
+    @WithMockUser
+    void redirectsHomeWhenNoOrganization() throws Exception {
+        User lonely = new User(UuidFactory.newId(), "lonely", "l@example.com");
+        when(currentOrg.resolve(any(UserDetails.class)))
+                .thenReturn(new CurrentOrganizationResolver.Resolved(lonely, null));
+
+        mvc.perform(get("/properties"))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(view().name("redirect:/"));
+    }
+
+    /** Unauthenticated request redirects to login. */
+    @Test
+    void unauthenticatedRedirectsToLogin() throws Exception {
+        mvc.perform(get("/properties"))
+                .andExpect(status().is3xxRedirection());
+    }
+
+    private static Property property(String name, String category, PropertyStatus status,
+                                     String location, Instant archivedAt) {
+        Property p = new Property();
+        p.setId(UuidFactory.newId());
+        p.setOrganizationId(ORG_ID);
+        p.setName(name);
+        p.setCategory(category);
+        p.setStatus(status);
+        p.setLocation(location);
+        p.setArchivedAt(archivedAt);
+        return p;
+    }
+}


### PR DESCRIPTION
## Summary

First slice of Steward UI parity work from #172. Adds a Thymeleaf list view at `/properties` to complement the existing `property-detail.html` page. Closes the navigation hole: until now you needed a property's UUID to reach its detail page; the sidebar "Properties" link landed on a 404.

The REST surface at `/api/properties` (`PropertyController`) is **unchanged and stays pure REST.** New work extends the existing `PropertyPageController` (already at `@RequestMapping("/properties")`) with a list method — mirrors Herald's pattern.

Closes #223

## What changed

- **`PropertyPageController.list`**: `GET /properties` with optional `category` (case-insensitive exact match) and `q` (free-text across name + description) query params. Sorted alphabetically by name. Archived rows excluded. Reuses `CurrentOrganizationResolver` for auth + org resolution.
- **`properties.html`**: Tailwind table with filter strip + empty state. Rows link to `/properties/{id}` (existing detail page). Visual shape mirrors `schedules.html` so the two list pages feel consistent.
- **`PropertyPageControllerTest`** updated to register the two new mock beans (`PropertyRepository`, `CurrentOrganizationResolver`).

## Test plan

- [x] 7 new tests in `PropertyPageListTest`: sorted render with category/status/location, archived filtered, free-text search across name + description, category exact-match filter, empty state, no-org redirect, unauth redirect.
- [x] Existing `PropertyPageControllerTest` (5 tests) still passes.
- [x] `./mvnw verify` — 479 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)