### PR TITLE
feat(steward): property detail panels + per-property add-schedule link (closes #224)

### DIFF
--- a/src/main/java/com/majordomo/adapter/in/web/herald/SchedulePageController.java
+++ b/src/main/java/com/majordomo/adapter/in/web/herald/SchedulePageController.java
@@ -213,19 +213,26 @@ public class SchedulePageController {
     }
 
     /**
-     * Renders the new-schedule form.
+     * Renders the new-schedule form. The optional {@code propertyId} query
+     * param pre-selects a property in the picker — used by per-property
+     * "Add schedule" buttons.
      *
-     * @param principal authenticated user
-     * @param model     Thymeleaf model
+     * @param propertyId optional property id to pre-select in the picker
+     * @param principal  authenticated user
+     * @param model      Thymeleaf model
      * @return the {@code schedule-form} template, or {@code redirect:/} if no org
      */
     @GetMapping("/schedules/new")
-    public String newForm(@AuthenticationPrincipal UserDetails principal, Model model) {
+    public String newForm(@RequestParam(required = false) UUID propertyId,
+                          @AuthenticationPrincipal UserDetails principal, Model model) {
         var ctx = currentOrg.resolve(principal);
         if (ctx.organizationId() == null) {
             return "redirect:/";
         }
         renderForm(null, null, ctx.user().getUsername(), model);
+        if (propertyId != null) {
+            model.addAttribute("formPropertyId", propertyId);
+        }
         return "schedule-form";
     }
 

--- a/src/main/java/com/majordomo/adapter/in/web/steward/PropertyPageController.java
+++ b/src/main/java/com/majordomo/adapter/in/web/steward/PropertyPageController.java
@@ -2,12 +2,15 @@ package com.majordomo.adapter.in.web.steward;
 
 import com.majordomo.application.identity.CurrentOrganizationResolver;
 import com.majordomo.domain.model.concierge.Contact;
+import com.majordomo.domain.model.herald.MaintenanceSchedule;
+import com.majordomo.domain.model.herald.ServiceRecord;
 import com.majordomo.domain.model.steward.Property;
 import com.majordomo.domain.model.steward.PropertyContact;
 import com.majordomo.domain.port.in.ManageAttachmentUseCase;
 import com.majordomo.domain.port.in.concierge.ManageContactUseCase;
 import com.majordomo.domain.port.in.herald.ManageScheduleUseCase;
 import com.majordomo.domain.port.in.steward.ManagePropertyUseCase;
+import com.majordomo.domain.port.out.herald.ServiceRecordRepository;
 import com.majordomo.domain.port.out.identity.MembershipRepository;
 import com.majordomo.domain.port.out.identity.UserRepository;
 import com.majordomo.domain.port.out.steward.PropertyContactRepository;
@@ -22,6 +25,8 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
@@ -44,9 +49,23 @@ public class PropertyPageController {
     private final ManageAttachmentUseCase attachmentUseCase;
     private final PropertyContactRepository propertyContactRepository;
     private final PropertyRepository propertyRepository;
+    private final ServiceRecordRepository serviceRecordRepository;
     private final CurrentOrganizationResolver currentOrg;
     private final UserRepository userRepository;
     private final MembershipRepository membershipRepository;
+
+    /** Maximum service-records to surface in the "Recent service records" panel. */
+    private static final int RECENT_RECORDS_LIMIT = 10;
+
+    /**
+     * View-model row binding a {@link MaintenanceSchedule} to its days-until-due
+     * delta for the property-detail page.
+     *
+     * @param schedule    the schedule
+     * @param daysUntilDue {@code null} if {@code nextDue} is null; otherwise the
+     *                    integer day delta (negative = overdue, 0 = today)
+     */
+    public record ScheduleRow(MaintenanceSchedule schedule, Integer daysUntilDue) { }
 
     /**
      * Constructs the property page controller.
@@ -57,6 +76,7 @@ public class PropertyPageController {
      * @param attachmentUseCase         the inbound port for attachment management
      * @param propertyContactRepository the outbound port for property-contact associations
      * @param propertyRepository        the outbound port for property reads (used by the list view)
+     * @param serviceRecordRepository   the outbound port for service-record reads (recent activity panel)
      * @param currentOrg                resolves the authenticated user's organization
      * @param userRepository            the outbound port for user lookups
      * @param membershipRepository      the outbound port for membership lookups
@@ -67,6 +87,7 @@ public class PropertyPageController {
                                   ManageAttachmentUseCase attachmentUseCase,
                                   PropertyContactRepository propertyContactRepository,
                                   PropertyRepository propertyRepository,
+                                  ServiceRecordRepository serviceRecordRepository,
                                   CurrentOrganizationResolver currentOrg,
                                   UserRepository userRepository,
                                   MembershipRepository membershipRepository) {
@@ -76,6 +97,7 @@ public class PropertyPageController {
         this.attachmentUseCase = attachmentUseCase;
         this.propertyContactRepository = propertyContactRepository;
         this.propertyRepository = propertyRepository;
+        this.serviceRecordRepository = serviceRecordRepository;
         this.currentOrg = currentOrg;
         this.userRepository = userRepository;
         this.membershipRepository = membershipRepository;
@@ -171,7 +193,28 @@ public class PropertyPageController {
                 .filter(c -> c != null)
                 .toList();
 
-        var schedules = scheduleUseCase.findByPropertyId(id);
+        LocalDate today = LocalDate.now();
+        List<ScheduleRow> scheduleRows = new ArrayList<>();
+        for (MaintenanceSchedule s : scheduleUseCase.findByPropertyId(id)) {
+            if (s.getArchivedAt() != null) {
+                continue;
+            }
+            Integer days = s.getNextDue() == null ? null
+                    : (int) ChronoUnit.DAYS.between(today, s.getNextDue());
+            scheduleRows.add(new ScheduleRow(s, days));
+        }
+        scheduleRows.sort(Comparator.comparing(
+                (ScheduleRow r) -> r.daysUntilDue() == null ? Integer.MAX_VALUE : r.daysUntilDue()));
+
+        List<ServiceRecord> recentRecords = new ArrayList<>(
+                serviceRecordRepository.findByPropertyId(id));
+        recentRecords.removeIf(r -> r.getArchivedAt() != null);
+        recentRecords.sort(Comparator.comparing(
+                ServiceRecord::getPerformedOn, Comparator.nullsLast(Comparator.reverseOrder())));
+        if (recentRecords.size() > RECENT_RECORDS_LIMIT) {
+            recentRecords = new ArrayList<>(recentRecords.subList(0, RECENT_RECORDS_LIMIT));
+        }
+
         var attachments = attachmentUseCase.list("property", id);
 
         var user = userRepository.findByUsername(principal.getUsername()).orElseThrow();
@@ -181,7 +224,8 @@ public class PropertyPageController {
         model.addAttribute("children", children);
         model.addAttribute("propertyContacts", propertyContacts);
         model.addAttribute("contacts", contacts);
-        model.addAttribute("schedules", schedules);
+        model.addAttribute("scheduleRows", scheduleRows);
+        model.addAttribute("recentRecords", recentRecords);
         model.addAttribute("attachments", attachments);
         model.addAttribute("username", user.getUsername());
 

--- a/src/main/resources/templates/property-detail.html
+++ b/src/main/resources/templates/property-detail.html
@@ -175,29 +175,79 @@
 
         <!-- Maintenance Schedules -->
         <div class="bg-white rounded-lg shadow mb-6">
-            <div class="px-6 py-4 border-b border-gray-200">
+            <div class="px-6 py-4 border-b border-gray-200 flex items-center justify-between">
                 <h2 class="text-lg font-semibold text-gray-900">Maintenance Schedules</h2>
+                <a th:href="@{/schedules/new(propertyId=${property.id})}"
+                   class="inline-flex items-center rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-indigo-700">
+                    + Add schedule
+                </a>
             </div>
             <div class="p-6">
-                <p th:if="${#lists.isEmpty(schedules)}" class="text-gray-400 text-sm">No maintenance schedules for this property.</p>
-                <div th:unless="${#lists.isEmpty(schedules)}" class="overflow-x-auto">
+                <p th:if="${#lists.isEmpty(scheduleRows)}" class="text-gray-400 text-sm">No maintenance schedules for this property.</p>
+                <div th:unless="${#lists.isEmpty(scheduleRows)}" class="overflow-x-auto">
                     <table class="min-w-full divide-y divide-gray-200">
                         <thead class="bg-gray-50">
                             <tr>
                                 <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Description</th>
                                 <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Frequency</th>
                                 <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Next Due</th>
+                                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">In</th>
                             </tr>
                         </thead>
                         <tbody class="bg-white divide-y divide-gray-200">
-                            <tr th:each="schedule : ${schedules}">
-                                <td class="px-6 py-4 text-sm text-gray-900" th:text="${schedule.description}">Task</td>
-                                <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-600" th:text="${schedule.frequency}">Frequency</td>
-                                <td class="px-6 py-4 whitespace-nowrap text-sm"
-                                    th:classappend="${#temporals.createToday().isAfter(schedule.nextDue)} ? 'text-red-600 font-semibold' :
-                                                   (${#temporals.createToday().plusDays(7).isAfter(schedule.nextDue)} ? 'text-yellow-600 font-medium' : 'text-gray-700')"
-                                    th:text="${schedule.nextDue}">
+                            <tr th:each="row : ${scheduleRows}">
+                                <td class="px-6 py-3 text-sm">
+                                    <a th:href="@{|/schedules/${row.schedule().getId()}|}"
+                                       class="font-medium text-gray-900 hover:text-indigo-700"
+                                       th:text="${row.schedule().getDescription()}">desc</a>
                                 </td>
+                                <td class="px-6 py-3 whitespace-nowrap text-sm text-gray-700" th:text="${row.schedule().getFrequency()}">FREQ</td>
+                                <td class="px-6 py-3 whitespace-nowrap text-sm text-gray-700"
+                                    th:text="${row.schedule().getNextDue() != null ? row.schedule().getNextDue() : '—'}">date</td>
+                                <td class="px-6 py-3 whitespace-nowrap text-sm">
+                                    <span th:if="${row.daysUntilDue() == null}" class="text-gray-400">—</span>
+                                    <span th:if="${row.daysUntilDue() != null and row.daysUntilDue() < 0}"
+                                          class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-red-100 text-red-800"
+                                          th:text="${-row.daysUntilDue()} + ' days overdue'">overdue</span>
+                                    <span th:if="${row.daysUntilDue() != null and row.daysUntilDue() == 0}"
+                                          class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-amber-100 text-amber-800">
+                                        today
+                                    </span>
+                                    <span th:if="${row.daysUntilDue() != null and row.daysUntilDue() > 0}"
+                                          class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-emerald-100 text-emerald-800"
+                                          th:text="'in ' + ${row.daysUntilDue()} + ' days'">in N days</span>
+                                </td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+
+        <!-- Recent Service Records -->
+        <div class="bg-white rounded-lg shadow mb-6">
+            <div class="px-6 py-4 border-b border-gray-200">
+                <h2 class="text-lg font-semibold text-gray-900">Recent service records</h2>
+            </div>
+            <div class="p-6">
+                <p th:if="${#lists.isEmpty(recentRecords)}" class="text-gray-400 text-sm">No service records yet for this property.</p>
+                <div th:unless="${#lists.isEmpty(recentRecords)}" class="overflow-x-auto">
+                    <table class="min-w-full divide-y divide-gray-200">
+                        <thead class="bg-gray-50">
+                            <tr>
+                                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Performed</th>
+                                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Description</th>
+                                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Cost</th>
+                            </tr>
+                        </thead>
+                        <tbody class="bg-white divide-y divide-gray-200">
+                            <tr th:each="r : ${recentRecords}">
+                                <td class="px-6 py-3 whitespace-nowrap text-sm text-gray-700"
+                                    th:text="${r.getPerformedOn() != null ? r.getPerformedOn() : '—'}">date</td>
+                                <td class="px-6 py-3 text-sm text-gray-900"
+                                    th:text="${r.getDescription()}">desc</td>
+                                <td class="px-6 py-3 whitespace-nowrap text-sm text-gray-700"
+                                    th:text="${r.getCost() != null ? '$' + #numbers.formatDecimal(r.getCost(), 1, 2) : '—'}">cost</td>
                             </tr>
                         </tbody>
                     </table>

--- a/src/test/java/com/majordomo/adapter/in/web/herald/SchedulePageFormTest.java
+++ b/src/test/java/com/majordomo/adapter/in/web/herald/SchedulePageFormTest.java
@@ -95,6 +95,24 @@ class SchedulePageFormTest {
         assertThat(body).contains("ANNUAL").contains("WEEKLY");
     }
 
+    /** GET /schedules/new?propertyId=X pre-selects that property in the picker. */
+    @Test
+    @WithMockUser
+    void newFormPreSelectsPropertyFromQueryParam() throws Exception {
+        MvcResult result = mvc.perform(get("/schedules/new")
+                        .param("propertyId", propertyId.toString()))
+                .andExpect(status().isOk())
+                .andExpect(view().name("schedule-form"))
+                .andReturn();
+
+        // Find the option tag bearing the propertyId; it must carry "selected".
+        String body = result.getResponse().getContentAsString();
+        int idx = body.indexOf("value=\"" + propertyId + "\"");
+        assertThat(idx).isPositive();
+        int closeTag = body.indexOf(">", idx);
+        assertThat(body.substring(idx, closeTag)).contains("selected");
+    }
+
     /** GET /schedules/{id}/edit pre-populates the form fields. */
     @Test
     @WithMockUser

--- a/src/test/java/com/majordomo/adapter/in/web/steward/PropertyPageControllerTest.java
+++ b/src/test/java/com/majordomo/adapter/in/web/steward/PropertyPageControllerTest.java
@@ -63,6 +63,9 @@ class PropertyPageControllerTest {
     private com.majordomo.domain.port.out.steward.PropertyRepository propertyRepository;
 
     @MockitoBean
+    private com.majordomo.domain.port.out.herald.ServiceRecordRepository serviceRecordRepository;
+
+    @MockitoBean
     private com.majordomo.application.identity.CurrentOrganizationResolver currentOrg;
 
     @MockitoBean

--- a/src/test/java/com/majordomo/adapter/in/web/steward/PropertyPageDetailPanelsTest.java
+++ b/src/test/java/com/majordomo/adapter/in/web/steward/PropertyPageDetailPanelsTest.java
@@ -1,0 +1,185 @@
+package com.majordomo.adapter.in.web.steward;
+
+import com.majordomo.adapter.in.web.config.OAuth2UserService;
+import com.majordomo.adapter.in.web.config.SecurityConfig;
+import com.majordomo.application.identity.CurrentOrganizationResolver;
+import com.majordomo.domain.model.UuidFactory;
+import com.majordomo.domain.model.herald.Frequency;
+import com.majordomo.domain.model.herald.MaintenanceSchedule;
+import com.majordomo.domain.model.herald.ServiceRecord;
+import com.majordomo.domain.model.identity.User;
+import com.majordomo.domain.model.steward.Property;
+import com.majordomo.domain.port.in.ManageAttachmentUseCase;
+import com.majordomo.domain.port.in.concierge.ManageContactUseCase;
+import com.majordomo.domain.port.in.herald.ManageScheduleUseCase;
+import com.majordomo.domain.port.in.steward.ManagePropertyUseCase;
+import com.majordomo.domain.port.out.herald.ServiceRecordRepository;
+import com.majordomo.domain.port.out.identity.ApiKeyRepository;
+import com.majordomo.domain.port.out.identity.MembershipRepository;
+import com.majordomo.domain.port.out.identity.UserRepository;
+import com.majordomo.domain.port.out.steward.PropertyContactRepository;
+import com.majordomo.domain.port.out.steward.PropertyRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Slice tests for the new "Maintenance schedules" + "Recent service records"
+ * panels added to the property-detail page in #224.
+ */
+@WebMvcTest(PropertyPageController.class)
+@Import(SecurityConfig.class)
+class PropertyPageDetailPanelsTest {
+
+    @Autowired MockMvc mvc;
+
+    @MockitoBean ManagePropertyUseCase propertyUseCase;
+    @MockitoBean ManageScheduleUseCase scheduleUseCase;
+    @MockitoBean ManageContactUseCase contactUseCase;
+    @MockitoBean ManageAttachmentUseCase attachmentUseCase;
+    @MockitoBean PropertyContactRepository propertyContactRepository;
+    @MockitoBean PropertyRepository propertyRepository;
+    @MockitoBean ServiceRecordRepository serviceRecordRepository;
+    @MockitoBean CurrentOrganizationResolver currentOrg;
+    @MockitoBean UserRepository userRepository;
+    @MockitoBean MembershipRepository membershipRepository;
+    @MockitoBean ApiKeyRepository apiKeyRepository;
+    @MockitoBean OAuth2UserService oAuth2UserService;
+
+    private UUID propertyId;
+    private static final UUID ORG_ID = UuidFactory.newId();
+
+    @BeforeEach
+    void seed() {
+        propertyId = UuidFactory.newId();
+        Property property = new Property();
+        property.setId(propertyId);
+        property.setOrganizationId(ORG_ID);
+        property.setName("Cabin");
+        when(propertyUseCase.findById(propertyId)).thenReturn(Optional.of(property));
+        when(propertyUseCase.findByParentId(propertyId)).thenReturn(List.of());
+        when(propertyContactRepository.findByPropertyId(propertyId)).thenReturn(List.of());
+        when(attachmentUseCase.list("property", propertyId)).thenReturn(List.of());
+        when(userRepository.findByUsername("robsartin")).thenReturn(Optional.of(
+                new User(UuidFactory.newId(), "robsartin", "rob@example.com")));
+    }
+
+    /** Schedules panel renders rows with a link to /schedules/{id} and an "Add schedule" button. */
+    @Test
+    @WithMockUser(username = "robsartin")
+    void schedulesPanelRendersRowsAndAddButton() throws Exception {
+        UUID scheduleId = UuidFactory.newId();
+        MaintenanceSchedule s = new MaintenanceSchedule();
+        s.setId(scheduleId);
+        s.setPropertyId(propertyId);
+        s.setDescription("HVAC service");
+        s.setFrequency(Frequency.ANNUAL);
+        s.setNextDue(LocalDate.now().plusDays(30));
+        when(scheduleUseCase.findByPropertyId(propertyId)).thenReturn(List.of(s));
+        when(serviceRecordRepository.findByPropertyId(propertyId)).thenReturn(List.of());
+
+        MvcResult result = mvc.perform(get("/properties/{id}", propertyId))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        String body = result.getResponse().getContentAsString();
+        assertThat(body).contains("HVAC service").contains("ANNUAL");
+        assertThat(body).contains("/schedules/" + scheduleId);
+        assertThat(body).contains("/schedules/new?propertyId=" + propertyId);
+        assertThat(body).contains("in 30 days");
+    }
+
+    /** Schedules panel skips archived schedules. */
+    @Test
+    @WithMockUser(username = "robsartin")
+    void schedulesPanelSkipsArchivedSchedules() throws Exception {
+        MaintenanceSchedule active = scheduleNamed("Active filter change");
+        active.setNextDue(LocalDate.now().plusDays(7));
+        MaintenanceSchedule archived = scheduleNamed("Archived old");
+        archived.setNextDue(LocalDate.now());
+        archived.setArchivedAt(Instant.parse("2025-01-01T00:00:00Z"));
+        when(scheduleUseCase.findByPropertyId(propertyId)).thenReturn(List.of(active, archived));
+        when(serviceRecordRepository.findByPropertyId(propertyId)).thenReturn(List.of());
+
+        MvcResult result = mvc.perform(get("/properties/{id}", propertyId))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        String body = result.getResponse().getContentAsString();
+        assertThat(body).contains("Active filter change").doesNotContain("Archived old");
+    }
+
+    /** Recent records panel renders rows newest-first. */
+    @Test
+    @WithMockUser(username = "robsartin")
+    void recentRecordsPanelRendersNewestFirst() throws Exception {
+        when(scheduleUseCase.findByPropertyId(propertyId)).thenReturn(List.of());
+        when(serviceRecordRepository.findByPropertyId(propertyId)).thenReturn(List.of(
+                record(LocalDate.of(2025, 6, 1), "First service", null),
+                record(LocalDate.of(2026, 4, 1), "Most recent service",
+                        new BigDecimal("199.99"))));
+
+        MvcResult result = mvc.perform(get("/properties/{id}", propertyId))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        String body = result.getResponse().getContentAsString();
+        int newer = body.indexOf("Most recent service");
+        int older = body.indexOf("First service");
+        assertThat(newer).isPositive();
+        assertThat(older).isGreaterThan(newer);
+        assertThat(body).contains("$199.99");
+    }
+
+    /** Recent records panel renders empty state when no records exist. */
+    @Test
+    @WithMockUser(username = "robsartin")
+    void recentRecordsPanelRendersEmptyState() throws Exception {
+        when(scheduleUseCase.findByPropertyId(propertyId)).thenReturn(List.of());
+        when(serviceRecordRepository.findByPropertyId(propertyId)).thenReturn(List.of());
+
+        MvcResult result = mvc.perform(get("/properties/{id}", propertyId))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        assertThat(result.getResponse().getContentAsString())
+                .contains("No service records yet for this property.");
+    }
+
+    private MaintenanceSchedule scheduleNamed(String description) {
+        MaintenanceSchedule s = new MaintenanceSchedule();
+        s.setId(UuidFactory.newId());
+        s.setPropertyId(propertyId);
+        s.setDescription(description);
+        s.setFrequency(Frequency.MONTHLY);
+        return s;
+    }
+
+    private ServiceRecord record(LocalDate performedOn, String description, BigDecimal cost) {
+        ServiceRecord r = new ServiceRecord();
+        r.setId(UuidFactory.newId());
+        r.setPropertyId(propertyId);
+        r.setPerformedOn(performedOn);
+        r.setDescription(description);
+        r.setCost(cost);
+        return r;
+    }
+}

--- a/src/test/java/com/majordomo/adapter/in/web/steward/PropertyPageListTest.java
+++ b/src/test/java/com/majordomo/adapter/in/web/steward/PropertyPageListTest.java
@@ -54,6 +54,7 @@ class PropertyPageListTest {
     @MockitoBean ManageAttachmentUseCase attachmentUseCase;
     @MockitoBean PropertyContactRepository propertyContactRepository;
     @MockitoBean PropertyRepository propertyRepository;
+    @MockitoBean com.majordomo.domain.port.out.herald.ServiceRecordRepository serviceRecordRepository;
     @MockitoBean CurrentOrganizationResolver currentOrg;
     @MockitoBean UserRepository userRepository;
     @MockitoBean MembershipRepository membershipRepository;


### PR DESCRIPTION
## Summary

Second slice of Steward UI parity work proposed in #172. Two enhancements to the existing `/properties/{id}` detail page that unify navigation between Steward and Herald:

1. **Maintenance Schedules panel** — descriptions now link to `/schedules/{id}`, table gains a days-until-due badge column (red overdue, amber today, emerald upcoming, mirroring the `/schedules` list), header gets an **"+ Add schedule"** button linking to `/schedules/new?propertyId={id}`.
2. **Recent service records panel** — shows the most-recent 10 service records across all schedules at this property, sorted newest-first.

`SchedulePageController.newForm` gains a `propertyId` query param that pre-selects the property option in the form's picker.

The REST surface at `/api/properties` and `/api/schedules` is unchanged.

Closes #224

## Test plan

- [x] 4 new tests in `PropertyPageDetailPanelsTest`: schedules panel renders rows + add-button + per-row link, archived schedules filtered, recent records newest-first with cost formatting, recent records empty state.
- [x] 1 new test in `SchedulePageFormTest`: `GET /schedules/new?propertyId=X` pre-selects that option.
- [x] `./mvnw verify` — 484 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)