### PR TITLE
feat(steward): extend property form (description/price/address/parent picker) (closes #229)

### DIFF
--- a/src/main/java/com/majordomo/adapter/in/web/steward/PropertyPageController.java
+++ b/src/main/java/com/majordomo/adapter/in/web/steward/PropertyPageController.java
@@ -256,17 +256,23 @@ public class PropertyPageController {
     /**
      * Updates an existing property from the edit-form post and redirects to detail.
      *
-     * @param id        the UUID of the property to update
-     * @param name      property name (required)
-     * @param category  optional category
-     * @param principal authenticated user
-     * @param model     Thymeleaf model
+     * @param id            the UUID of the property to update
+     * @param name          property name (required)
+     * @param category      optional category
+     * @param description   optional description
+     * @param location      optional address / location
+     * @param purchasePrice optional purchase price (decimal)
+     * @param principal     authenticated user
+     * @param model         Thymeleaf model
      * @return redirect to the property's detail page on success
      */
     @PostMapping("/{id}")
     public String update(@PathVariable UUID id,
                          @RequestParam(required = false) String name,
                          @RequestParam(required = false) String category,
+                         @RequestParam(required = false) String description,
+                         @RequestParam(required = false) String location,
+                         @RequestParam(required = false) String purchasePrice,
                          @AuthenticationPrincipal UserDetails principal,
                          Model model) {
         var ctx = currentOrg.resolve(principal);
@@ -278,12 +284,8 @@ public class PropertyPageController {
                         com.majordomo.domain.model.EntityType.PROPERTY.name(), id));
         organizationAccessService.verifyAccess(existing.getOrganizationId());
         if (name == null || name.isBlank()) {
-            model.addAttribute("editingId", id);
-            model.addAttribute("existing", existing);
-            model.addAttribute("username", ctx.user().getUsername());
-            model.addAttribute("formError", "Name is required.");
-            model.addAttribute("formName", name);
-            model.addAttribute("formCategory", category);
+            populateFormState(model, id, existing, ctx.user().getUsername(),
+                    "Name is required.", name, category, description, location, purchasePrice);
             return "property-form";
         }
         Property updated = new Property();
@@ -291,6 +293,9 @@ public class PropertyPageController {
         updated.setOrganizationId(existing.getOrganizationId());
         updated.setName(name);
         updated.setCategory(category);
+        updated.setDescription(blankToNull(description));
+        updated.setLocation(blankToNull(location));
+        updated.setPurchasePrice(parsePrice(purchasePrice));
         propertyUseCase.update(id, updated);
         return "redirect:/properties/" + id;
     }

--- a/src/main/java/com/majordomo/adapter/in/web/steward/PropertyPageController.java
+++ b/src/main/java/com/majordomo/adapter/in/web/steward/PropertyPageController.java
@@ -216,13 +216,21 @@ public class PropertyPageController {
                     "Name is required.", name, category, description, location, purchasePrice);
             return "property-form";
         }
+        java.math.BigDecimal price;
+        try {
+            price = parsePrice(purchasePrice);
+        } catch (PriceFormatException ex) {
+            populateFormState(model, null, null, ctx.user().getUsername(),
+                    ex.getMessage(), name, category, description, location, purchasePrice);
+            return "property-form";
+        }
         Property property = new Property();
         property.setOrganizationId(ctx.organizationId());
         property.setName(name);
         property.setCategory(category);
         property.setDescription(blankToNull(description));
         property.setLocation(blankToNull(location));
-        property.setPurchasePrice(parsePrice(purchasePrice));
+        property.setPurchasePrice(price);
         Property saved = propertyUseCase.create(property);
         return "redirect:/properties/" + saved.getId();
     }
@@ -235,7 +243,23 @@ public class PropertyPageController {
         if (s == null || s.isBlank()) {
             return null;
         }
-        return new java.math.BigDecimal(s.trim());
+        java.math.BigDecimal value;
+        try {
+            value = new java.math.BigDecimal(s.trim());
+        } catch (NumberFormatException ex) {
+            throw new PriceFormatException("Purchase price must be a number.");
+        }
+        if (value.signum() < 0) {
+            throw new PriceFormatException("Purchase price must be non-negative.");
+        }
+        return value;
+    }
+
+    private static final class PriceFormatException extends RuntimeException {
+        private static final long serialVersionUID = 1L;
+        PriceFormatException(String message) {
+            super(message);
+        }
     }
 
     private static void populateFormState(Model model, UUID editingId, Property existing,
@@ -288,6 +312,14 @@ public class PropertyPageController {
                     "Name is required.", name, category, description, location, purchasePrice);
             return "property-form";
         }
+        java.math.BigDecimal price;
+        try {
+            price = parsePrice(purchasePrice);
+        } catch (PriceFormatException ex) {
+            populateFormState(model, id, existing, ctx.user().getUsername(),
+                    ex.getMessage(), name, category, description, location, purchasePrice);
+            return "property-form";
+        }
         Property updated = new Property();
         updated.setId(id);
         updated.setOrganizationId(existing.getOrganizationId());
@@ -295,7 +327,7 @@ public class PropertyPageController {
         updated.setCategory(category);
         updated.setDescription(blankToNull(description));
         updated.setLocation(blankToNull(location));
-        updated.setPurchasePrice(parsePrice(purchasePrice));
+        updated.setPurchasePrice(price);
         propertyUseCase.update(id, updated);
         return "redirect:/properties/" + id;
     }

--- a/src/main/java/com/majordomo/adapter/in/web/steward/PropertyPageController.java
+++ b/src/main/java/com/majordomo/adapter/in/web/steward/PropertyPageController.java
@@ -184,6 +184,7 @@ public class PropertyPageController {
         model.addAttribute("editingId", null);
         model.addAttribute("existing", null);
         model.addAttribute("username", ctx.user().getUsername());
+        model.addAttribute("parentCandidates", candidateParents(ctx.organizationId(), null));
         return "property-form";
     }
 
@@ -195,6 +196,7 @@ public class PropertyPageController {
      * @param description   optional description
      * @param location      optional address / location
      * @param purchasePrice optional purchase price (decimal)
+     * @param parentId      optional parent property ID
      * @param principal     authenticated user
      * @param model         Thymeleaf model
      * @return redirect to the new property's detail page on success
@@ -205,6 +207,7 @@ public class PropertyPageController {
                          @RequestParam(required = false) String description,
                          @RequestParam(required = false) String location,
                          @RequestParam(required = false) String purchasePrice,
+                         @RequestParam(required = false) String parentId,
                          @AuthenticationPrincipal UserDetails principal,
                          Model model) {
         var ctx = currentOrg.resolve(principal);
@@ -231,12 +234,48 @@ public class PropertyPageController {
         property.setDescription(blankToNull(description));
         property.setLocation(blankToNull(location));
         property.setPurchasePrice(price);
+        property.setParentId(parseUuid(parentId));
         Property saved = propertyUseCase.create(property);
         return "redirect:/properties/" + saved.getId();
     }
 
     private static String blankToNull(String s) {
         return (s == null || s.isBlank()) ? null : s;
+    }
+
+    private static UUID parseUuid(String s) {
+        if (s == null || s.isBlank()) {
+            return null;
+        }
+        return UUID.fromString(s.trim());
+    }
+
+    /**
+     * Returns properties in the given organization that are valid as a parent for
+     * {@code editingId} (or for a new property when {@code editingId} is null).
+     * Excludes the property itself and all of its descendants to prevent cycles.
+     * Sorted by name (case-insensitive).
+     */
+    private List<Property> candidateParents(UUID organizationId, UUID editingId) {
+        java.util.Set<UUID> excluded = new java.util.HashSet<>();
+        if (editingId != null) {
+            excluded.add(editingId);
+            collectDescendantIds(editingId, excluded);
+        }
+        List<Property> all = new ArrayList<>(
+                propertyRepository.findByOrganizationId(organizationId));
+        all.removeIf(p -> p.getArchivedAt() != null || excluded.contains(p.getId()));
+        all.sort(Comparator.comparing(
+                Property::getName, Comparator.nullsLast(String.CASE_INSENSITIVE_ORDER)));
+        return all;
+    }
+
+    private void collectDescendantIds(UUID rootId, java.util.Set<UUID> sink) {
+        for (Property child : propertyUseCase.findByParentId(rootId)) {
+            if (sink.add(child.getId())) {
+                collectDescendantIds(child.getId(), sink);
+            }
+        }
     }
 
     private static java.math.BigDecimal parsePrice(String s) {
@@ -286,6 +325,7 @@ public class PropertyPageController {
      * @param description   optional description
      * @param location      optional address / location
      * @param purchasePrice optional purchase price (decimal)
+     * @param parentId      optional parent property ID
      * @param principal     authenticated user
      * @param model         Thymeleaf model
      * @return redirect to the property's detail page on success
@@ -297,6 +337,7 @@ public class PropertyPageController {
                          @RequestParam(required = false) String description,
                          @RequestParam(required = false) String location,
                          @RequestParam(required = false) String purchasePrice,
+                         @RequestParam(required = false) String parentId,
                          @AuthenticationPrincipal UserDetails principal,
                          Model model) {
         var ctx = currentOrg.resolve(principal);
@@ -328,6 +369,7 @@ public class PropertyPageController {
         updated.setDescription(blankToNull(description));
         updated.setLocation(blankToNull(location));
         updated.setPurchasePrice(price);
+        updated.setParentId(parseUuid(parentId));
         propertyUseCase.update(id, updated);
         return "redirect:/properties/" + id;
     }
@@ -355,6 +397,8 @@ public class PropertyPageController {
         model.addAttribute("editingId", id);
         model.addAttribute("existing", existing);
         model.addAttribute("username", ctx.user().getUsername());
+        model.addAttribute("parentCandidates",
+                candidateParents(existing.getOrganizationId(), id));
         return "property-form";
     }
 

--- a/src/main/java/com/majordomo/adapter/in/web/steward/PropertyPageController.java
+++ b/src/main/java/com/majordomo/adapter/in/web/steward/PropertyPageController.java
@@ -190,15 +190,21 @@ public class PropertyPageController {
     /**
      * Creates a property from the new-form post and redirects to the detail page.
      *
-     * @param name       property name (required)
-     * @param category   optional category
-     * @param principal  authenticated user
-     * @param model      Thymeleaf model
+     * @param name          property name (required)
+     * @param category      optional category
+     * @param description   optional description
+     * @param location      optional address / location
+     * @param purchasePrice optional purchase price (decimal)
+     * @param principal     authenticated user
+     * @param model         Thymeleaf model
      * @return redirect to the new property's detail page on success
      */
     @PostMapping
     public String create(@RequestParam(required = false) String name,
                          @RequestParam(required = false) String category,
+                         @RequestParam(required = false) String description,
+                         @RequestParam(required = false) String location,
+                         @RequestParam(required = false) String purchasePrice,
                          @AuthenticationPrincipal UserDetails principal,
                          Model model) {
         var ctx = currentOrg.resolve(principal);
@@ -206,20 +212,45 @@ public class PropertyPageController {
             return "redirect:/";
         }
         if (name == null || name.isBlank()) {
-            model.addAttribute("editingId", null);
-            model.addAttribute("existing", null);
-            model.addAttribute("username", ctx.user().getUsername());
-            model.addAttribute("formError", "Name is required.");
-            model.addAttribute("formName", name);
-            model.addAttribute("formCategory", category);
+            populateFormState(model, null, null, ctx.user().getUsername(),
+                    "Name is required.", name, category, description, location, purchasePrice);
             return "property-form";
         }
         Property property = new Property();
         property.setOrganizationId(ctx.organizationId());
         property.setName(name);
         property.setCategory(category);
+        property.setDescription(blankToNull(description));
+        property.setLocation(blankToNull(location));
+        property.setPurchasePrice(parsePrice(purchasePrice));
         Property saved = propertyUseCase.create(property);
         return "redirect:/properties/" + saved.getId();
+    }
+
+    private static String blankToNull(String s) {
+        return (s == null || s.isBlank()) ? null : s;
+    }
+
+    private static java.math.BigDecimal parsePrice(String s) {
+        if (s == null || s.isBlank()) {
+            return null;
+        }
+        return new java.math.BigDecimal(s.trim());
+    }
+
+    private static void populateFormState(Model model, UUID editingId, Property existing,
+                                          String username, String formError,
+                                          String name, String category, String description,
+                                          String location, String purchasePrice) {
+        model.addAttribute("editingId", editingId);
+        model.addAttribute("existing", existing);
+        model.addAttribute("username", username);
+        model.addAttribute("formError", formError);
+        model.addAttribute("formName", name);
+        model.addAttribute("formCategory", category);
+        model.addAttribute("formDescription", description);
+        model.addAttribute("formLocation", location);
+        model.addAttribute("formPurchasePrice", purchasePrice);
     }
 
     /**

--- a/src/main/resources/templates/property-form.html
+++ b/src/main/resources/templates/property-form.html
@@ -38,6 +38,31 @@
                                               : (existing != null ? existing.getCategory() : '')}"
                                    class="block rounded border-gray-300 text-sm focus:border-indigo-500 focus:ring-indigo-500 px-2 py-1.5">
                         </div>
+                        <div class="flex flex-col">
+                            <label for="description"
+                                   class="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-1">Description</label>
+                            <textarea id="description" name="description" rows="3"
+                                      th:text="${formDescription != null ? formDescription
+                                                : (existing != null ? existing.getDescription() : '')}"
+                                      class="block rounded border-gray-300 text-sm focus:border-indigo-500 focus:ring-indigo-500 px-2 py-1.5"></textarea>
+                        </div>
+                        <div class="flex flex-col">
+                            <label for="location"
+                                   class="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-1">Address / location</label>
+                            <input id="location" name="location" type="text"
+                                   th:value="${formLocation != null ? formLocation
+                                              : (existing != null ? existing.getLocation() : '')}"
+                                   class="block rounded border-gray-300 text-sm focus:border-indigo-500 focus:ring-indigo-500 px-2 py-1.5">
+                        </div>
+                        <div class="flex flex-col">
+                            <label for="purchasePrice"
+                                   class="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-1">Purchase price</label>
+                            <input id="purchasePrice" name="purchasePrice" type="text" inputmode="decimal"
+                                   th:value="${formPurchasePrice != null ? formPurchasePrice
+                                              : (existing != null and existing.getPurchasePrice() != null
+                                                  ? existing.getPurchasePrice() : '')}"
+                                   class="block rounded border-gray-300 text-sm focus:border-indigo-500 focus:ring-indigo-500 px-2 py-1.5">
+                        </div>
                         <div>
                             <button type="submit"
                                     class="inline-flex items-center rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-indigo-700">

--- a/src/main/resources/templates/property-form.html
+++ b/src/main/resources/templates/property-form.html
@@ -63,6 +63,22 @@
                                                   ? existing.getPurchasePrice() : '')}"
                                    class="block rounded border-gray-300 text-sm focus:border-indigo-500 focus:ring-indigo-500 px-2 py-1.5">
                         </div>
+                        <div class="flex flex-col" th:if="${parentCandidates != null}">
+                            <label for="parentId"
+                                   class="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-1">Parent property</label>
+                            <select id="parentId" name="parentId"
+                                    class="block rounded border-gray-300 text-sm focus:border-indigo-500 focus:ring-indigo-500 px-2 py-1.5">
+                                <option value="">— None —</option>
+                                <option th:each="p : ${parentCandidates}"
+                                        th:value="${p.getId()}"
+                                        th:text="${p.getName()}"
+                                        th:selected="${(formParentId != null and formParentId == p.getId().toString())
+                                                       or (formParentId == null and existing != null
+                                                           and existing.getParentId() != null
+                                                           and existing.getParentId() == p.getId())}">
+                                </option>
+                            </select>
+                        </div>
                         <div>
                             <button type="submit"
                                     class="inline-flex items-center rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-indigo-700">

--- a/src/test/java/com/majordomo/adapter/in/web/steward/PropertyPageFormTest.java
+++ b/src/test/java/com/majordomo/adapter/in/web/steward/PropertyPageFormTest.java
@@ -138,6 +138,9 @@ class PropertyPageFormTest {
         existing.setOrganizationId(ORG_ID);
         existing.setName("Beach House");
         existing.setCategory("vacation");
+        existing.setDescription("Two-bedroom on the dunes.");
+        existing.setLocation("123 Shoreline Rd, Outer Banks, NC");
+        existing.setPurchasePrice(new java.math.BigDecimal("450000.00"));
         when(propertyUseCase.findById(id)).thenReturn(java.util.Optional.of(existing));
 
         org.springframework.test.web.servlet.MvcResult result = mvc.perform(
@@ -150,6 +153,9 @@ class PropertyPageFormTest {
         org.assertj.core.api.Assertions.assertThat(body).contains("Edit property");
         org.assertj.core.api.Assertions.assertThat(body).contains("value=\"Beach House\"");
         org.assertj.core.api.Assertions.assertThat(body).contains("value=\"vacation\"");
+        org.assertj.core.api.Assertions.assertThat(body).contains("Two-bedroom on the dunes.");
+        org.assertj.core.api.Assertions.assertThat(body).contains("value=\"123 Shoreline Rd, Outer Banks, NC\"");
+        org.assertj.core.api.Assertions.assertThat(body).contains("value=\"450000.00\"");
     }
 
     /** Cycle 4b: GET /properties/{id}/edit returns 404 when missing. */

--- a/src/test/java/com/majordomo/adapter/in/web/steward/PropertyPageFormTest.java
+++ b/src/test/java/com/majordomo/adapter/in/web/steward/PropertyPageFormTest.java
@@ -106,6 +106,41 @@ class PropertyPageFormTest {
         org.assertj.core.api.Assertions.assertThat(captor.getValue().getOrganizationId()).isEqualTo(ORG_ID);
     }
 
+    /** Cycle 2 (#229): create persists description, location, purchasePrice. */
+    @Test
+    @WithMockUser
+    void createPersistsExtraFields() throws Exception {
+        UUID newId = UuidFactory.newId();
+        com.majordomo.domain.model.steward.Property saved =
+                new com.majordomo.domain.model.steward.Property();
+        saved.setId(newId);
+        saved.setOrganizationId(ORG_ID);
+        when(propertyUseCase.create(any(com.majordomo.domain.model.steward.Property.class)))
+                .thenReturn(saved);
+
+        mvc.perform(org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+                        .post("/properties")
+                        .with(org.springframework.security.test.web.servlet.request
+                                .SecurityMockMvcRequestPostProcessors.csrf())
+                        .param("name", "Beach House")
+                        .param("category", "vacation")
+                        .param("description", "Two-bedroom on the dunes.")
+                        .param("location", "123 Shoreline Rd")
+                        .param("purchasePrice", "450000.00"))
+                .andExpect(status().is3xxRedirection());
+
+        org.mockito.ArgumentCaptor<com.majordomo.domain.model.steward.Property> captor =
+                org.mockito.ArgumentCaptor.forClass(
+                        com.majordomo.domain.model.steward.Property.class);
+        org.mockito.Mockito.verify(propertyUseCase).create(captor.capture());
+        org.assertj.core.api.Assertions.assertThat(captor.getValue().getDescription())
+                .isEqualTo("Two-bedroom on the dunes.");
+        org.assertj.core.api.Assertions.assertThat(captor.getValue().getLocation())
+                .isEqualTo("123 Shoreline Rd");
+        org.assertj.core.api.Assertions.assertThat(captor.getValue().getPurchasePrice())
+                .isEqualByComparingTo("450000.00");
+    }
+
     /** Cycle 3: POST /properties with blank name re-renders the form with error + field state. */
     @Test
     @WithMockUser

--- a/src/test/java/com/majordomo/adapter/in/web/steward/PropertyPageFormTest.java
+++ b/src/test/java/com/majordomo/adapter/in/web/steward/PropertyPageFormTest.java
@@ -397,4 +397,90 @@ class PropertyPageFormTest {
         org.mockito.Mockito.verify(propertyUseCase, org.mockito.Mockito.never())
                 .update(any(), any());
     }
+
+    /** Cycle 5 (#229): edit form lists candidate parents excluding self and descendants. */
+    @Test
+    @WithMockUser
+    void editFormParentPickerExcludesSelfAndDescendants() throws Exception {
+        UUID rootId = UuidFactory.newId();
+        UUID parentId = UuidFactory.newId();
+        UUID siblingId = UuidFactory.newId();
+        UUID childId = UuidFactory.newId();
+        com.majordomo.domain.model.steward.Property root =
+                new com.majordomo.domain.model.steward.Property();
+        root.setId(rootId);
+        root.setOrganizationId(ORG_ID);
+        root.setName("Root estate");
+        com.majordomo.domain.model.steward.Property unrelated =
+                new com.majordomo.domain.model.steward.Property();
+        unrelated.setId(parentId);
+        unrelated.setOrganizationId(ORG_ID);
+        unrelated.setName("Mountain cabin");
+        com.majordomo.domain.model.steward.Property sibling =
+                new com.majordomo.domain.model.steward.Property();
+        sibling.setId(siblingId);
+        sibling.setOrganizationId(ORG_ID);
+        sibling.setName("Sibling unit");
+        com.majordomo.domain.model.steward.Property child =
+                new com.majordomo.domain.model.steward.Property();
+        child.setId(childId);
+        child.setOrganizationId(ORG_ID);
+        child.setName("Guest cottage");
+        child.setParentId(rootId);
+
+        when(propertyUseCase.findById(rootId)).thenReturn(java.util.Optional.of(root));
+        when(propertyRepository.findByOrganizationId(ORG_ID))
+                .thenReturn(java.util.List.of(root, unrelated, sibling, child));
+        when(propertyUseCase.findByParentId(rootId)).thenReturn(java.util.List.of(child));
+        when(propertyUseCase.findByParentId(childId)).thenReturn(java.util.List.of());
+
+        org.springframework.test.web.servlet.MvcResult result = mvc.perform(
+                get("/properties/{id}/edit", rootId))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        String body = result.getResponse().getContentAsString();
+        // Self and descendants must NOT be selectable as parent.
+        org.assertj.core.api.Assertions.assertThat(body)
+                .doesNotContain("value=\"" + rootId + "\">Root estate")
+                .doesNotContain("value=\"" + childId + "\">Guest cottage");
+        // Unrelated and sibling are valid parent candidates.
+        org.assertj.core.api.Assertions.assertThat(body)
+                .contains("value=\"" + parentId + "\">Mountain cabin")
+                .contains("value=\"" + siblingId + "\">Sibling unit");
+        // Picker is named parentId.
+        org.assertj.core.api.Assertions.assertThat(body).contains("name=\"parentId\"");
+    }
+
+    /** Cycle 5b (#229): update persists parentId. */
+    @Test
+    @WithMockUser
+    void updatePersistsParentId() throws Exception {
+        UUID id = UuidFactory.newId();
+        UUID parentId = UuidFactory.newId();
+        com.majordomo.domain.model.steward.Property existing =
+                new com.majordomo.domain.model.steward.Property();
+        existing.setId(id);
+        existing.setOrganizationId(ORG_ID);
+        existing.setName("Old");
+        when(propertyUseCase.findById(id)).thenReturn(java.util.Optional.of(existing));
+        when(propertyUseCase.update(org.mockito.ArgumentMatchers.eq(id),
+                any(com.majordomo.domain.model.steward.Property.class)))
+                .thenAnswer(inv -> inv.getArgument(1));
+
+        mvc.perform(org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+                        .post("/properties/{id}", id)
+                        .with(org.springframework.security.test.web.servlet.request
+                                .SecurityMockMvcRequestPostProcessors.csrf())
+                        .param("name", "Renamed")
+                        .param("parentId", parentId.toString()))
+                .andExpect(status().is3xxRedirection());
+
+        org.mockito.ArgumentCaptor<com.majordomo.domain.model.steward.Property> captor =
+                org.mockito.ArgumentCaptor.forClass(
+                        com.majordomo.domain.model.steward.Property.class);
+        org.mockito.Mockito.verify(propertyUseCase).update(
+                org.mockito.ArgumentMatchers.eq(id), captor.capture());
+        org.assertj.core.api.Assertions.assertThat(captor.getValue().getParentId()).isEqualTo(parentId);
+    }
 }

--- a/src/test/java/com/majordomo/adapter/in/web/steward/PropertyPageFormTest.java
+++ b/src/test/java/com/majordomo/adapter/in/web/steward/PropertyPageFormTest.java
@@ -238,6 +238,45 @@ class PropertyPageFormTest {
         org.assertj.core.api.Assertions.assertThat(captor.getValue().getCategory()).isEqualTo("new-cat");
     }
 
+    /** Cycle 3 (#229): update persists description, location, purchasePrice. */
+    @Test
+    @WithMockUser
+    void updatePersistsExtraFields() throws Exception {
+        UUID id = UuidFactory.newId();
+        com.majordomo.domain.model.steward.Property existing =
+                new com.majordomo.domain.model.steward.Property();
+        existing.setId(id);
+        existing.setOrganizationId(ORG_ID);
+        existing.setName("Old");
+        when(propertyUseCase.findById(id)).thenReturn(java.util.Optional.of(existing));
+        when(propertyUseCase.update(org.mockito.ArgumentMatchers.eq(id),
+                any(com.majordomo.domain.model.steward.Property.class)))
+                .thenAnswer(inv -> inv.getArgument(1));
+
+        mvc.perform(org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+                        .post("/properties/{id}", id)
+                        .with(org.springframework.security.test.web.servlet.request
+                                .SecurityMockMvcRequestPostProcessors.csrf())
+                        .param("name", "New name")
+                        .param("category", "new-cat")
+                        .param("description", "Renovated kitchen.")
+                        .param("location", "456 Lake Ln")
+                        .param("purchasePrice", "525000.50"))
+                .andExpect(status().is3xxRedirection());
+
+        org.mockito.ArgumentCaptor<com.majordomo.domain.model.steward.Property> captor =
+                org.mockito.ArgumentCaptor.forClass(
+                        com.majordomo.domain.model.steward.Property.class);
+        org.mockito.Mockito.verify(propertyUseCase).update(
+                org.mockito.ArgumentMatchers.eq(id), captor.capture());
+        org.assertj.core.api.Assertions.assertThat(captor.getValue().getDescription())
+                .isEqualTo("Renovated kitchen.");
+        org.assertj.core.api.Assertions.assertThat(captor.getValue().getLocation())
+                .isEqualTo("456 Lake Ln");
+        org.assertj.core.api.Assertions.assertThat(captor.getValue().getPurchasePrice())
+                .isEqualByComparingTo("525000.50");
+    }
+
     /** Cycle 6: POST /properties/{id} with blank name re-renders the edit form with error. */
     @Test
     @WithMockUser

--- a/src/test/java/com/majordomo/adapter/in/web/steward/PropertyPageFormTest.java
+++ b/src/test/java/com/majordomo/adapter/in/web/steward/PropertyPageFormTest.java
@@ -31,6 +31,7 @@ import java.util.UUID;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
 
@@ -275,6 +276,48 @@ class PropertyPageFormTest {
                 .isEqualTo("456 Lake Ln");
         org.assertj.core.api.Assertions.assertThat(captor.getValue().getPurchasePrice())
                 .isEqualByComparingTo("525000.50");
+    }
+
+    /** Cycle 4 (#229): negative purchasePrice on create re-renders the form with error + state. */
+    @Test
+    @WithMockUser
+    void createWithNegativePriceRendersFormWithError() throws Exception {
+        org.springframework.test.web.servlet.MvcResult result = mvc.perform(
+                org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post("/properties")
+                        .with(org.springframework.security.test.web.servlet.request
+                                .SecurityMockMvcRequestPostProcessors.csrf())
+                        .param("name", "Beach House")
+                        .param("category", "vacation")
+                        .param("description", "Two-bedroom on the dunes.")
+                        .param("location", "123 Shoreline Rd")
+                        .param("purchasePrice", "-1.00"))
+                .andExpect(status().isOk())
+                .andExpect(view().name("property-form"))
+                .andReturn();
+
+        String body = result.getResponse().getContentAsString();
+        org.assertj.core.api.Assertions.assertThat(body).contains("Purchase price must be non-negative.");
+        // Other field state echoed.
+        org.assertj.core.api.Assertions.assertThat(body).contains("value=\"Beach House\"");
+        org.assertj.core.api.Assertions.assertThat(body).contains("value=\"123 Shoreline Rd\"");
+        org.assertj.core.api.Assertions.assertThat(body).contains("value=\"-1.00\"");
+        org.mockito.Mockito.verify(propertyUseCase, org.mockito.Mockito.never()).create(any());
+    }
+
+    /** Cycle 4b (#229): non-numeric purchasePrice on create re-renders with error. */
+    @Test
+    @WithMockUser
+    void createWithNonNumericPriceRendersFormWithError() throws Exception {
+        mvc.perform(org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post("/properties")
+                        .with(org.springframework.security.test.web.servlet.request
+                                .SecurityMockMvcRequestPostProcessors.csrf())
+                        .param("name", "Beach House")
+                        .param("purchasePrice", "abc"))
+                .andExpect(status().isOk())
+                .andExpect(content().string(org.hamcrest.Matchers.containsString(
+                        "Purchase price must be a number.")));
+
+        org.mockito.Mockito.verify(propertyUseCase, org.mockito.Mockito.never()).create(any());
     }
 
     /** Cycle 6: POST /properties/{id} with blank name re-renders the edit form with error. */


### PR DESCRIPTION
## Summary
- Form gains optional `description` (textarea), `location` (address), and `purchasePrice` (decimal) fields, both create and update bind them.
- New parent-property picker (`<select name=\"parentId\">`) rendered with the user's properties, excluding the editing property and all of its descendants to prevent cycles. Empty option means \"no parent\".
- Inline validation: bad `purchasePrice` (negative or non-numeric) re-renders with error and preserves field state.
- Pre-populate on edit echoes all four extra fields and current parent selection.

## Test plan
- [x] `./mvnw verify -DskipITs` green (499 tests, 0 failures, checkstyle clean)
- [x] Slice tests added: edit pre-populate (extra fields), create persists extra fields, update persists extra fields, negative price re-renders + state preserved, non-numeric price re-renders, parent picker excludes self + descendants, update persists parentId.

## Notes
- `Property` aggregate already exposed `description`, `location`, `purchasePrice`, `parentId` — no model changes.
- Cycle prevention done in the controller via `findByParentId` walks; small subtree, no need for a graph query.

🤖 Generated with [Claude Code](https://claude.com/claude-code)