### PR TITLE
feat(concierge): contact list UI at /contacts (closes #231)

### DIFF
--- a/src/main/java/com/majordomo/adapter/in/web/concierge/ContactPageController.java
+++ b/src/main/java/com/majordomo/adapter/in/web/concierge/ContactPageController.java
@@ -1,0 +1,124 @@
+package com.majordomo.adapter.in.web.concierge;
+
+import com.majordomo.application.identity.CurrentOrganizationResolver;
+import com.majordomo.domain.model.concierge.Contact;
+import com.majordomo.domain.port.in.concierge.ManageContactUseCase;
+import com.majordomo.domain.port.out.concierge.ContactRepository;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Serves the Concierge web pages for contacts. Sibling to the REST
+ * {@code ContactController} at {@code /api/contacts}, which is untouched.
+ */
+@Controller
+@RequestMapping("/contacts")
+public class ContactPageController {
+
+    private final ManageContactUseCase contactUseCase;
+    private final ContactRepository contactRepository;
+    private final CurrentOrganizationResolver currentOrg;
+
+    /**
+     * Constructs the contact page controller.
+     *
+     * @param contactUseCase    inbound port for contact management
+     * @param contactRepository outbound port for contact reads (used by list view)
+     * @param currentOrg        resolves the authenticated user's organization
+     */
+    public ContactPageController(ManageContactUseCase contactUseCase,
+                                 ContactRepository contactRepository,
+                                 CurrentOrganizationResolver currentOrg) {
+        this.contactUseCase = contactUseCase;
+        this.contactRepository = contactRepository;
+        this.currentOrg = currentOrg;
+    }
+
+    /**
+     * Renders the contact list page for the user's organization, with optional
+     * organization-filter and free-text query.
+     *
+     * @param organization optional exact-match organization filter
+     * @param q            optional case-insensitive query (name + organization + emails)
+     * @param principal    authenticated user
+     * @param model        Thymeleaf model
+     * @return the {@code contacts} template
+     */
+    @GetMapping
+    public String list(@RequestParam(required = false) String organization,
+                       @RequestParam(required = false) String q,
+                       @AuthenticationPrincipal UserDetails principal,
+                       Model model) {
+        var ctx = currentOrg.resolve(principal);
+        if (ctx.organizationId() == null) {
+            return "redirect:/";
+        }
+        UUID orgId = ctx.organizationId();
+        List<Contact> raw = new ArrayList<>(contactRepository.findByOrganizationId(orgId));
+
+        String organizationFilter =
+                (organization == null || organization.isBlank()) ? null : organization.trim();
+        String qLower = (q == null || q.isBlank()) ? null : q.trim().toLowerCase();
+
+        List<Contact> rows = new ArrayList<>();
+        for (Contact c : raw) {
+            if (c.getArchivedAt() != null) {
+                continue;
+            }
+            if (organizationFilter != null
+                    && !organizationFilter.equalsIgnoreCase(c.getOrganization())) {
+                continue;
+            }
+            if (qLower != null && !matchesQuery(c, qLower)) {
+                continue;
+            }
+            rows.add(c);
+        }
+        rows.sort(Comparator.comparing(Contact::getFormattedName,
+                Comparator.nullsLast(String.CASE_INSENSITIVE_ORDER)));
+
+        // Distinct organizations (non-blank) for the filter dropdown.
+        List<String> organizations = raw.stream()
+                .filter(c -> c.getArchivedAt() == null)
+                .map(Contact::getOrganization)
+                .filter(o -> o != null && !o.isBlank())
+                .distinct()
+                .sorted(String.CASE_INSENSITIVE_ORDER)
+                .toList();
+
+        model.addAttribute("rows", rows);
+        model.addAttribute("organizations", organizations);
+        model.addAttribute("organization", organization);
+        model.addAttribute("q", q);
+        model.addAttribute("username", ctx.user().getUsername());
+        return "contacts";
+    }
+
+    private static boolean matchesQuery(Contact c, String qLower) {
+        if (c.getFormattedName() != null && c.getFormattedName().toLowerCase().contains(qLower)) {
+            return true;
+        }
+        if (c.getOrganization() != null && c.getOrganization().toLowerCase().contains(qLower)) {
+            return true;
+        }
+        if (c.getEmails() != null) {
+            for (String e : c.getEmails()) {
+                if (e != null && e.toLowerCase().contains(qLower)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+}

--- a/src/main/resources/templates/contacts.html
+++ b/src/main/resources/templates/contacts.html
@@ -1,0 +1,97 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Contacts - Majordomo</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-gray-100 min-h-screen">
+
+    <div th:replace="~{fragments/header :: header}"></div>
+
+    <div class="flex min-h-screen">
+        <div th:replace="~{fragments/sidebar :: sidebar('contacts')}"></div>
+
+        <main class="flex-1 p-6">
+
+            <div class="flex items-baseline justify-between mb-6">
+                <h1 class="text-2xl font-bold text-gray-900">Contacts</h1>
+                <div class="flex items-center gap-4">
+                    <span class="text-sm text-gray-500"
+                          th:text="${#lists.size(rows)} + ' contacts'">0 contacts</span>
+                </div>
+            </div>
+
+            <!-- Filter strip -->
+            <div class="bg-white rounded-lg shadow p-4 mb-6">
+                <form method="get" th:action="@{/contacts}" class="flex flex-wrap items-end gap-4">
+                    <div class="flex flex-col">
+                        <label for="q" class="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-1">Search</label>
+                        <input id="q" name="q" type="text" th:value="${q}"
+                               class="block rounded border-gray-300 text-sm focus:border-indigo-500 focus:ring-indigo-500 px-2 py-1.5"
+                               placeholder="name, organization, email">
+                    </div>
+                    <div class="flex flex-col">
+                        <label for="organization" class="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-1">Organization</label>
+                        <select id="organization" name="organization"
+                                class="block rounded border-gray-300 text-sm focus:border-indigo-500 focus:ring-indigo-500 px-2 py-1.5">
+                            <option value="">— Any —</option>
+                            <option th:each="o : ${organizations}"
+                                    th:value="${o}" th:text="${o}"
+                                    th:selected="${organization != null and organization == o}">
+                            </option>
+                        </select>
+                    </div>
+                    <div class="flex gap-2">
+                        <button type="submit"
+                                class="inline-flex items-center rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-indigo-700">
+                            Filter
+                        </button>
+                        <a th:href="@{/contacts}"
+                           class="inline-flex items-center rounded-md bg-white border border-gray-300 px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50">
+                            Reset
+                        </a>
+                    </div>
+                </form>
+            </div>
+
+            <!-- List -->
+            <div class="bg-white rounded-lg shadow overflow-hidden">
+                <div th:if="${#lists.isEmpty(rows)}" class="px-6 py-12 text-center text-gray-500">
+                    No contacts.
+                </div>
+                <table th:unless="${#lists.isEmpty(rows)}" class="min-w-full divide-y divide-gray-200">
+                    <thead class="bg-gray-50">
+                        <tr>
+                            <th class="px-6 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider">Name</th>
+                            <th class="px-6 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider">Organization</th>
+                            <th class="px-6 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider">Title</th>
+                            <th class="px-6 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider">Email</th>
+                            <th class="px-6 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider">Phone</th>
+                        </tr>
+                    </thead>
+                    <tbody class="bg-white divide-y divide-gray-100">
+                        <tr th:each="c : ${rows}">
+                            <td class="px-6 py-3 whitespace-nowrap text-sm">
+                                <a th:href="@{|/contacts/${c.getId()}|}"
+                                   th:text="${c.getFormattedName()}"
+                                   class="text-indigo-600 hover:text-indigo-800 font-medium">Name</a>
+                            </td>
+                            <td class="px-6 py-3 whitespace-nowrap text-sm text-gray-700"
+                                th:text="${c.getOrganization()}">Org</td>
+                            <td class="px-6 py-3 whitespace-nowrap text-sm text-gray-700"
+                                th:text="${c.getTitle()}">Title</td>
+                            <td class="px-6 py-3 whitespace-nowrap text-sm text-gray-700"
+                                th:text="${(c.getEmails() != null and !#lists.isEmpty(c.getEmails())) ? c.getEmails().get(0) : ''}">Email</td>
+                            <td class="px-6 py-3 whitespace-nowrap text-sm text-gray-700"
+                                th:text="${(c.getTelephones() != null and !#lists.isEmpty(c.getTelephones())) ? c.getTelephones().get(0) : ''}">Phone</td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+
+        </main>
+    </div>
+</body>
+</html>

--- a/src/test/java/com/majordomo/adapter/in/web/concierge/ContactPageListTest.java
+++ b/src/test/java/com/majordomo/adapter/in/web/concierge/ContactPageListTest.java
@@ -1,0 +1,149 @@
+package com.majordomo.adapter.in.web.concierge;
+
+import com.majordomo.adapter.in.web.config.OAuth2UserService;
+import com.majordomo.adapter.in.web.config.SecurityConfig;
+import com.majordomo.application.identity.CurrentOrganizationResolver;
+import com.majordomo.domain.model.UuidFactory;
+import com.majordomo.domain.model.concierge.Contact;
+import com.majordomo.domain.model.identity.User;
+import com.majordomo.domain.port.in.concierge.ManageContactUseCase;
+import com.majordomo.domain.port.out.concierge.ContactRepository;
+import com.majordomo.domain.port.out.identity.ApiKeyRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
+
+/** Slice tests for the {@code /contacts} list page (#231). */
+@WebMvcTest(ContactPageController.class)
+@Import(SecurityConfig.class)
+class ContactPageListTest {
+
+    @Autowired MockMvc mvc;
+
+    @MockitoBean ManageContactUseCase contactUseCase;
+    @MockitoBean ContactRepository contactRepository;
+    @MockitoBean CurrentOrganizationResolver currentOrg;
+    @MockitoBean ApiKeyRepository apiKeyRepository;
+    @MockitoBean OAuth2UserService oAuth2UserService;
+
+    private static final UUID ORG_ID = UuidFactory.newId();
+
+    @BeforeEach
+    void seedAuth() {
+        User user = new User(UuidFactory.newId(), "robsartin", "rob@example.com");
+        when(currentOrg.resolve(any(UserDetails.class)))
+                .thenReturn(new CurrentOrganizationResolver.Resolved(user, ORG_ID));
+    }
+
+    /** Cycle 1: GET /contacts returns 200 + contacts view, lists rows. */
+    @Test
+    @WithMockUser
+    void listRendersContactsForOrg() throws Exception {
+        Contact alice = contact("Alice Example", "Acme", "alice@acme.example", "+15555550100");
+        Contact bob = contact("Bob Example", "Globex", "bob@globex.example", "+15555550200");
+        when(contactRepository.findByOrganizationId(ORG_ID)).thenReturn(List.of(alice, bob));
+
+        MvcResult result = mvc.perform(get("/contacts"))
+                .andExpect(status().isOk())
+                .andExpect(view().name("contacts"))
+                .andReturn();
+
+        String body = result.getResponse().getContentAsString();
+        assertThat(body)
+                .contains("Alice Example").contains("Acme").contains("alice@acme.example")
+                .contains("Bob Example").contains("Globex").contains("bob@globex.example");
+    }
+
+    /** Cycle 2: q query narrows results across name + organization + emails. */
+    @Test
+    @WithMockUser
+    void listFilteredByQ() throws Exception {
+        Contact alice = contact("Alice Example", "Acme", "alice@acme.example", "+15555550100");
+        Contact bob = contact("Bob Example", "Globex", "bob@globex.example", "+15555550200");
+        when(contactRepository.findByOrganizationId(ORG_ID)).thenReturn(List.of(alice, bob));
+
+        MvcResult result = mvc.perform(get("/contacts").param("q", "globex"))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        String body = result.getResponse().getContentAsString();
+        assertThat(body).contains("Bob Example").doesNotContain("Alice Example");
+    }
+
+    /** Cycle 2b: organization filter narrows to that organization's contacts only. */
+    @Test
+    @WithMockUser
+    void listFilteredByOrganization() throws Exception {
+        Contact alice = contact("Alice Example", "Acme", "alice@acme.example", "+15555550100");
+        Contact bob = contact("Bob Example", "Globex", "bob@globex.example", "+15555550200");
+        when(contactRepository.findByOrganizationId(ORG_ID)).thenReturn(List.of(alice, bob));
+
+        MvcResult result = mvc.perform(get("/contacts").param("organization", "Acme"))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        String body = result.getResponse().getContentAsString();
+        assertThat(body).contains("Alice Example").doesNotContain("Bob Example");
+    }
+
+    /** Cycle 3: archived contacts are excluded. */
+    @Test
+    @WithMockUser
+    void archivedContactsExcluded() throws Exception {
+        Contact alice = contact("Alice Example", "Acme", "alice@acme.example", "+15555550100");
+        Contact archived = contact("Old Contact", "Legacy", "old@legacy.example", "+15555550300");
+        archived.setArchivedAt(Instant.now());
+        when(contactRepository.findByOrganizationId(ORG_ID)).thenReturn(List.of(alice, archived));
+
+        MvcResult result = mvc.perform(get("/contacts"))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        String body = result.getResponse().getContentAsString();
+        assertThat(body).contains("Alice Example").doesNotContain("Old Contact");
+    }
+
+    /** Cycle 3b: empty state when no contacts. */
+    @Test
+    @WithMockUser
+    void emptyStateWhenNoContacts() throws Exception {
+        when(contactRepository.findByOrganizationId(ORG_ID)).thenReturn(List.of());
+
+        MvcResult result = mvc.perform(get("/contacts"))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        String body = result.getResponse().getContentAsString();
+        assertThat(body).contains("No contacts");
+    }
+
+    private static Contact contact(String formattedName, String organization,
+                                   String email, String phone) {
+        Contact c = new Contact();
+        c.setId(UuidFactory.newId());
+        c.setOrganizationId(ORG_ID);
+        c.setFormattedName(formattedName);
+        c.setOrganization(organization);
+        c.setEmails(List.of(email));
+        c.setTelephones(List.of(phone));
+        return c;
+    }
+}


### PR DESCRIPTION
## Summary
- New `ContactPageController` serves `/contacts` as a Thymeleaf view, sibling to the REST controller at `/api/contacts` (untouched).
- Tailwind table with columns: name, organization, title, email (first), phone (first).
- Filter strip: free-text `q` (matches name + organization + emails) + `organization` dropdown sourced from distinct values.
- Archived contacts excluded; sorted by `formattedName` (case-insensitive, nulls last); empty-state copy when none.

## Test plan
- [x] `./mvnw verify -DskipITs` green (504 tests, 0 failures, checkstyle clean)
- [x] Slice tests: list render, q filter, organization filter, archived excluded, empty state

🤖 Generated with [Claude Code](https://claude.com/claude-code)