### PR TITLE
feat(concierge): contact detail page at /contacts/{id} (closes #232)

### DIFF
--- a/src/main/java/com/majordomo/adapter/in/web/concierge/ContactPageController.java
+++ b/src/main/java/com/majordomo/adapter/in/web/concierge/ContactPageController.java
@@ -1,15 +1,22 @@
 package com.majordomo.adapter.in.web.concierge;
 
 import com.majordomo.application.identity.CurrentOrganizationResolver;
+import com.majordomo.application.identity.OrganizationAccessService;
+import com.majordomo.domain.model.EntityNotFoundException;
+import com.majordomo.domain.model.EntityType;
 import com.majordomo.domain.model.concierge.Contact;
+import com.majordomo.domain.model.steward.Property;
 import com.majordomo.domain.port.in.concierge.ManageContactUseCase;
+import com.majordomo.domain.port.in.steward.ManagePropertyUseCase;
 import com.majordomo.domain.port.out.concierge.ContactRepository;
+import com.majordomo.domain.port.out.steward.PropertyContactRepository;
 
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
@@ -28,21 +35,33 @@ public class ContactPageController {
 
     private final ManageContactUseCase contactUseCase;
     private final ContactRepository contactRepository;
+    private final ManagePropertyUseCase propertyUseCase;
+    private final PropertyContactRepository propertyContactRepository;
     private final CurrentOrganizationResolver currentOrg;
+    private final OrganizationAccessService organizationAccessService;
 
     /**
      * Constructs the contact page controller.
      *
-     * @param contactUseCase    inbound port for contact management
-     * @param contactRepository outbound port for contact reads (used by list view)
-     * @param currentOrg        resolves the authenticated user's organization
+     * @param contactUseCase            inbound port for contact management
+     * @param contactRepository         outbound port for contact reads (used by list view)
+     * @param propertyUseCase           inbound port for property lookups
+     * @param propertyContactRepository outbound port for property–contact associations
+     * @param currentOrg                resolves the authenticated user's organization
+     * @param organizationAccessService verifies caller has access to a given organization
      */
     public ContactPageController(ManageContactUseCase contactUseCase,
                                  ContactRepository contactRepository,
-                                 CurrentOrganizationResolver currentOrg) {
+                                 ManagePropertyUseCase propertyUseCase,
+                                 PropertyContactRepository propertyContactRepository,
+                                 CurrentOrganizationResolver currentOrg,
+                                 OrganizationAccessService organizationAccessService) {
         this.contactUseCase = contactUseCase;
         this.contactRepository = contactRepository;
+        this.propertyUseCase = propertyUseCase;
+        this.propertyContactRepository = propertyContactRepository;
         this.currentOrg = currentOrg;
+        this.organizationAccessService = organizationAccessService;
     }
 
     /**
@@ -103,6 +122,40 @@ public class ContactPageController {
         model.addAttribute("q", q);
         model.addAttribute("username", ctx.user().getUsername());
         return "contacts";
+    }
+
+    /**
+     * Renders the contact detail page.
+     *
+     * @param id        contact UUID
+     * @param principal authenticated user
+     * @param model     Thymeleaf model
+     * @return the {@code contact-detail} template
+     */
+    @GetMapping("/{id}")
+    public String detail(@PathVariable UUID id,
+                         @AuthenticationPrincipal UserDetails principal,
+                         Model model) {
+        var ctx = currentOrg.resolve(principal);
+        if (ctx.organizationId() == null) {
+            return "redirect:/";
+        }
+        Contact contact = contactRepository.findById(id)
+                .filter(c -> c.getArchivedAt() == null)
+                .orElseThrow(() -> new EntityNotFoundException(EntityType.CONTACT.name(), id));
+        organizationAccessService.verifyAccess(contact.getOrganizationId());
+
+        List<Property> linkedProperties = propertyContactRepository.findByContactId(id).stream()
+                .map(pc -> propertyUseCase.findById(pc.getPropertyId()).orElse(null))
+                .filter(p -> p != null)
+                .sorted(Comparator.comparing(Property::getName,
+                        Comparator.nullsLast(String.CASE_INSENSITIVE_ORDER)))
+                .toList();
+
+        model.addAttribute("contact", contact);
+        model.addAttribute("linkedProperties", linkedProperties);
+        model.addAttribute("username", ctx.user().getUsername());
+        return "contact-detail";
     }
 
     private static boolean matchesQuery(Contact c, String qLower) {

--- a/src/main/resources/templates/contact-detail.html
+++ b/src/main/resources/templates/contact-detail.html
@@ -1,0 +1,150 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title th:text="${contact.formattedName} + ' - Majordomo'">Contact</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-gray-100 min-h-screen">
+
+    <div th:replace="~{fragments/header :: header}"></div>
+
+    <div class="flex min-h-screen">
+        <div th:replace="~{fragments/sidebar :: sidebar('contacts')}"></div>
+
+        <main class="flex-1 p-6">
+
+            <nav class="text-sm text-gray-500 mb-4">
+                <a th:href="@{/contacts}" class="hover:text-indigo-600">Contacts</a>
+                <span class="mx-2">/</span>
+                <span th:text="${contact.formattedName}" class="text-gray-700">Name</span>
+            </nav>
+
+            <!-- Header card -->
+            <div class="bg-white rounded-lg shadow mb-6">
+                <div class="px-6 py-4 border-b border-gray-200 flex items-start justify-between">
+                    <div>
+                        <h1 class="text-2xl font-bold text-gray-900" th:text="${contact.formattedName}">Name</h1>
+                        <p class="text-sm text-gray-600"
+                           th:if="${contact.organization != null or contact.title != null}">
+                            <span th:text="${contact.title}">Title</span>
+                            <span th:if="${contact.title != null and contact.organization != null}"> · </span>
+                            <span th:text="${contact.organization}">Organization</span>
+                        </p>
+                    </div>
+                    <div class="flex items-center gap-3">
+                        <a th:href="@{|/contacts/${contact.id}/vcard|}"
+                           class="inline-flex items-center rounded-md bg-white border border-gray-300 px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50">
+                            Download vCard
+                        </a>
+                        <a th:href="@{|/contacts/${contact.id}/edit|}"
+                           class="inline-flex items-center rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-indigo-700">
+                            Edit
+                        </a>
+                    </div>
+                </div>
+            </div>
+
+            <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
+
+                <!-- Emails -->
+                <div class="bg-white rounded-lg shadow">
+                    <div class="px-6 py-3 border-b border-gray-200">
+                        <h2 class="text-sm font-semibold text-gray-700 uppercase tracking-wider">Email</h2>
+                    </div>
+                    <ul class="p-6 space-y-1 text-sm text-gray-700">
+                        <li th:each="e : ${contact.emails}" th:text="${e}">email</li>
+                        <li th:if="${contact.emails == null or #lists.isEmpty(contact.emails)}"
+                            class="text-gray-400">None</li>
+                    </ul>
+                </div>
+
+                <!-- Phones -->
+                <div class="bg-white rounded-lg shadow">
+                    <div class="px-6 py-3 border-b border-gray-200">
+                        <h2 class="text-sm font-semibold text-gray-700 uppercase tracking-wider">Phone</h2>
+                    </div>
+                    <ul class="p-6 space-y-1 text-sm text-gray-700">
+                        <li th:each="p : ${contact.telephones}" th:text="${p}">phone</li>
+                        <li th:if="${contact.telephones == null or #lists.isEmpty(contact.telephones)}"
+                            class="text-gray-400">None</li>
+                    </ul>
+                </div>
+
+                <!-- URLs -->
+                <div class="bg-white rounded-lg shadow">
+                    <div class="px-6 py-3 border-b border-gray-200">
+                        <h2 class="text-sm font-semibold text-gray-700 uppercase tracking-wider">Links</h2>
+                    </div>
+                    <ul class="p-6 space-y-1 text-sm text-gray-700">
+                        <li th:each="u : ${contact.urls}">
+                            <a th:href="${u}" th:text="${u}" target="_blank" rel="noopener"
+                               class="text-indigo-600 hover:text-indigo-800">url</a>
+                        </li>
+                        <li th:if="${contact.urls == null or #lists.isEmpty(contact.urls)}"
+                            class="text-gray-400">None</li>
+                    </ul>
+                </div>
+
+                <!-- Nicknames -->
+                <div class="bg-white rounded-lg shadow">
+                    <div class="px-6 py-3 border-b border-gray-200">
+                        <h2 class="text-sm font-semibold text-gray-700 uppercase tracking-wider">Nicknames</h2>
+                    </div>
+                    <ul class="p-6 space-y-1 text-sm text-gray-700">
+                        <li th:each="n : ${contact.nicknames}" th:text="${n}">nick</li>
+                        <li th:if="${contact.nicknames == null or #lists.isEmpty(contact.nicknames)}"
+                            class="text-gray-400">None</li>
+                    </ul>
+                </div>
+
+                <!-- Addresses -->
+                <div class="bg-white rounded-lg shadow lg:col-span-2">
+                    <div class="px-6 py-3 border-b border-gray-200">
+                        <h2 class="text-sm font-semibold text-gray-700 uppercase tracking-wider">Addresses</h2>
+                    </div>
+                    <ul class="p-6 space-y-3 text-sm text-gray-700">
+                        <li th:each="a : ${contact.addresses}">
+                            <span th:if="${a.label() != null}"
+                                  class="inline-block bg-gray-100 text-gray-700 text-xs px-2 py-0.5 rounded mr-2"
+                                  th:text="${a.label()}">label</span>
+                            <span th:text="${a.street()}">street</span>,
+                            <span th:text="${a.city()}">city</span>,
+                            <span th:text="${a.state()}">state</span>
+                            <span th:text="${a.postalCode()}">zip</span>
+                            <span th:text="${a.country()}">country</span>
+                        </li>
+                        <li th:if="${contact.addresses == null or #lists.isEmpty(contact.addresses)}"
+                            class="text-gray-400">None</li>
+                    </ul>
+                </div>
+
+                <!-- Notes -->
+                <div class="bg-white rounded-lg shadow lg:col-span-2" th:if="${contact.notes != null and !contact.notes.isBlank()}">
+                    <div class="px-6 py-3 border-b border-gray-200">
+                        <h2 class="text-sm font-semibold text-gray-700 uppercase tracking-wider">Notes</h2>
+                    </div>
+                    <p class="p-6 text-sm text-gray-700 whitespace-pre-line" th:text="${contact.notes}">notes</p>
+                </div>
+
+                <!-- Linked properties -->
+                <div class="bg-white rounded-lg shadow lg:col-span-2">
+                    <div class="px-6 py-3 border-b border-gray-200">
+                        <h2 class="text-sm font-semibold text-gray-700 uppercase tracking-wider">Linked properties</h2>
+                    </div>
+                    <ul class="p-6 space-y-1 text-sm">
+                        <li th:each="p : ${linkedProperties}">
+                            <a th:href="@{|/properties/${p.id}|}" th:text="${p.name}"
+                               class="text-indigo-600 hover:text-indigo-800">property</a>
+                        </li>
+                        <li th:if="${#lists.isEmpty(linkedProperties)}" class="text-gray-400">None</li>
+                    </ul>
+                </div>
+
+            </div>
+
+        </main>
+    </div>
+</body>
+</html>

--- a/src/test/java/com/majordomo/adapter/in/web/concierge/ContactPageDetailTest.java
+++ b/src/test/java/com/majordomo/adapter/in/web/concierge/ContactPageDetailTest.java
@@ -1,0 +1,197 @@
+package com.majordomo.adapter.in.web.concierge;
+
+import com.majordomo.adapter.in.web.config.OAuth2UserService;
+import com.majordomo.adapter.in.web.config.SecurityConfig;
+import com.majordomo.application.identity.CurrentOrganizationResolver;
+import com.majordomo.application.identity.OrganizationAccessService;
+import com.majordomo.domain.model.UuidFactory;
+import com.majordomo.domain.model.concierge.Address;
+import com.majordomo.domain.model.concierge.Contact;
+import com.majordomo.domain.model.identity.User;
+import com.majordomo.domain.model.steward.Property;
+import com.majordomo.domain.model.steward.PropertyContact;
+import com.majordomo.domain.port.in.concierge.ManageContactUseCase;
+import com.majordomo.domain.port.in.steward.ManagePropertyUseCase;
+import com.majordomo.domain.port.out.concierge.ContactRepository;
+import com.majordomo.domain.port.out.identity.ApiKeyRepository;
+import com.majordomo.domain.port.out.steward.PropertyContactRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
+
+/** Slice tests for the {@code /contacts/{id}} detail page (#232). */
+@WebMvcTest(ContactPageController.class)
+@Import(SecurityConfig.class)
+class ContactPageDetailTest {
+
+    @Autowired MockMvc mvc;
+
+    @MockitoBean ManageContactUseCase contactUseCase;
+    @MockitoBean ContactRepository contactRepository;
+    @MockitoBean ManagePropertyUseCase propertyUseCase;
+    @MockitoBean PropertyContactRepository propertyContactRepository;
+    @MockitoBean CurrentOrganizationResolver currentOrg;
+    @MockitoBean OrganizationAccessService organizationAccessService;
+    @MockitoBean ApiKeyRepository apiKeyRepository;
+    @MockitoBean OAuth2UserService oAuth2UserService;
+
+    private static final UUID ORG_ID = UuidFactory.newId();
+
+    @BeforeEach
+    void seedAuth() {
+        User user = new User(UuidFactory.newId(), "robsartin", "rob@example.com");
+        when(currentOrg.resolve(any(UserDetails.class)))
+                .thenReturn(new CurrentOrganizationResolver.Resolved(user, ORG_ID));
+    }
+
+    /** Cycle 1: GET /contacts/{id} renders header + panels. */
+    @Test
+    @WithMockUser
+    void detailRendersContactWithPanels() throws Exception {
+        UUID id = UuidFactory.newId();
+        Contact c = new Contact();
+        c.setId(id);
+        c.setOrganizationId(ORG_ID);
+        c.setFormattedName("Alice Example");
+        c.setOrganization("Acme Corp");
+        c.setTitle("Lead Engineer");
+        c.setEmails(List.of("alice@acme.example", "alice.alt@acme.example"));
+        c.setTelephones(List.of("+15555550100"));
+        c.setUrls(List.of("https://acme.example"));
+        c.setNicknames(List.of("Ace"));
+        c.setNotes("Met at conference 2025.");
+        c.setAddresses(List.of(new Address(
+                UuidFactory.newId(), id, "WORK",
+                "100 Main St", "Springfield", "IL", "62701", "USA")));
+        when(contactRepository.findById(id)).thenReturn(Optional.of(c));
+        when(propertyContactRepository.findByContactId(id)).thenReturn(List.of());
+
+        MvcResult result = mvc.perform(get("/contacts/{id}", id))
+                .andExpect(status().isOk())
+                .andExpect(view().name("contact-detail"))
+                .andReturn();
+
+        String body = result.getResponse().getContentAsString();
+        assertThat(body)
+                .contains("Alice Example")
+                .contains("Acme Corp")
+                .contains("Lead Engineer")
+                .contains("alice@acme.example")
+                .contains("alice.alt@acme.example")
+                .contains("+15555550100")
+                .contains("https://acme.example")
+                .contains("Ace")
+                .contains("Met at conference 2025.")
+                .contains("100 Main St")
+                .contains("Springfield");
+    }
+
+    /** Cycle 2: 404 when contact missing. */
+    @Test
+    @WithMockUser
+    void detailReturns404WhenMissing() throws Exception {
+        UUID id = UuidFactory.newId();
+        when(contactRepository.findById(id)).thenReturn(Optional.empty());
+
+        mvc.perform(get("/contacts/{id}", id))
+                .andExpect(status().isNotFound());
+    }
+
+    /** Cycle 2b: 404 when contact archived. */
+    @Test
+    @WithMockUser
+    void detailReturns404WhenArchived() throws Exception {
+        UUID id = UuidFactory.newId();
+        Contact archived = new Contact();
+        archived.setId(id);
+        archived.setOrganizationId(ORG_ID);
+        archived.setFormattedName("Old");
+        archived.setArchivedAt(Instant.now());
+        when(contactRepository.findById(id)).thenReturn(Optional.of(archived));
+
+        mvc.perform(get("/contacts/{id}", id))
+                .andExpect(status().isNotFound());
+    }
+
+    /** Cycle 3: 403 when contact belongs to another org. */
+    @Test
+    @WithMockUser
+    void detailReturns403WhenCrossOrg() throws Exception {
+        UUID id = UuidFactory.newId();
+        UUID otherOrg = UuidFactory.newId();
+        Contact foreign = new Contact();
+        foreign.setId(id);
+        foreign.setOrganizationId(otherOrg);
+        foreign.setFormattedName("Cross-org");
+        when(contactRepository.findById(id)).thenReturn(Optional.of(foreign));
+        doThrow(new AccessDeniedException("denied"))
+                .when(organizationAccessService).verifyAccess(otherOrg);
+
+        mvc.perform(get("/contacts/{id}", id))
+                .andExpect(status().isForbidden());
+    }
+
+    /** Cycle 4: linked properties panel renders associated properties. */
+    @Test
+    @WithMockUser
+    void detailLinkedPropertiesPanel() throws Exception {
+        UUID id = UuidFactory.newId();
+        UUID propA = UuidFactory.newId();
+        UUID propB = UuidFactory.newId();
+        Contact c = new Contact();
+        c.setId(id);
+        c.setOrganizationId(ORG_ID);
+        c.setFormattedName("Linked Larry");
+        when(contactRepository.findById(id)).thenReturn(Optional.of(c));
+        when(propertyContactRepository.findByContactId(id)).thenReturn(List.of(
+                propertyContact(id, propA),
+                propertyContact(id, propB)));
+        Property a = new Property();
+        a.setId(propA);
+        a.setOrganizationId(ORG_ID);
+        a.setName("Beach House");
+        Property b = new Property();
+        b.setId(propB);
+        b.setOrganizationId(ORG_ID);
+        b.setName("Mountain Cabin");
+        when(propertyUseCase.findById(propA)).thenReturn(Optional.of(a));
+        when(propertyUseCase.findById(propB)).thenReturn(Optional.of(b));
+
+        MvcResult result = mvc.perform(get("/contacts/{id}", id))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        String body = result.getResponse().getContentAsString();
+        assertThat(body).contains("Beach House").contains("Mountain Cabin");
+        assertThat(body).contains("/properties/" + propA).contains("/properties/" + propB);
+    }
+
+    private static PropertyContact propertyContact(UUID contactId, UUID propertyId) {
+        PropertyContact pc = new PropertyContact();
+        pc.setId(UuidFactory.newId());
+        pc.setContactId(contactId);
+        pc.setPropertyId(propertyId);
+        return pc;
+    }
+}

--- a/src/test/java/com/majordomo/adapter/in/web/concierge/ContactPageListTest.java
+++ b/src/test/java/com/majordomo/adapter/in/web/concierge/ContactPageListTest.java
@@ -40,7 +40,10 @@ class ContactPageListTest {
 
     @MockitoBean ManageContactUseCase contactUseCase;
     @MockitoBean ContactRepository contactRepository;
+    @MockitoBean com.majordomo.domain.port.in.steward.ManagePropertyUseCase propertyUseCase;
+    @MockitoBean com.majordomo.domain.port.out.steward.PropertyContactRepository propertyContactRepository;
     @MockitoBean CurrentOrganizationResolver currentOrg;
+    @MockitoBean com.majordomo.application.identity.OrganizationAccessService organizationAccessService;
     @MockitoBean ApiKeyRepository apiKeyRepository;
     @MockitoBean OAuth2UserService oAuth2UserService;
 


### PR DESCRIPTION
## Summary
- Detail handler renders `contact-detail` with header (formatted name + organization/title), Edit button, vCard download link, and panels for emails, phones, URLs, nicknames, addresses, notes, and linked properties (sourced via `PropertyContactRepository.findByContactId`, hydrated via `ManagePropertyUseCase`).
- Soft-deleted contacts → 404; cross-org → 403 via `OrganizationAccessService`; missing → 404 via `EntityNotFoundException`.
- The list slice test was updated to declare the new mock beans (`ManagePropertyUseCase`, `PropertyContactRepository`, `OrganizationAccessService`).

## Test plan
- [x] `./mvnw verify -DskipITs` green (509 tests, 0 failures, checkstyle clean)
- [x] Slice tests added: detail renders panels, missing → 404, archived → 404, cross-org → 403, linked-properties panel hydrates

🤖 Generated with [Claude Code](https://claude.com/claude-code)