### PR TITLE
feat(concierge): contact add/edit forms (closes #233)

### DIFF
--- a/src/main/java/com/majordomo/adapter/in/web/concierge/ContactPageController.java
+++ b/src/main/java/com/majordomo/adapter/in/web/concierge/ContactPageController.java
@@ -17,6 +17,7 @@ import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
@@ -156,6 +157,237 @@ public class ContactPageController {
         model.addAttribute("linkedProperties", linkedProperties);
         model.addAttribute("username", ctx.user().getUsername());
         return "contact-detail";
+    }
+
+    /**
+     * Renders the new-contact form.
+     *
+     * @param principal authenticated user
+     * @param model     Thymeleaf model
+     * @return the {@code contact-form} template
+     */
+    @GetMapping("/new")
+    public String newForm(@AuthenticationPrincipal UserDetails principal, Model model) {
+        var ctx = currentOrg.resolve(principal);
+        if (ctx.organizationId() == null) {
+            return "redirect:/";
+        }
+        model.addAttribute("editingId", null);
+        model.addAttribute("existing", null);
+        model.addAttribute("username", ctx.user().getUsername());
+        return "contact-form";
+    }
+
+    /**
+     * Creates a contact from the new-form post and redirects to detail.
+     *
+     * @param formattedName required formatted display name
+     * @param givenName     optional given name
+     * @param familyName    optional family name
+     * @param organization  optional organization
+     * @param title         optional title
+     * @param notes         optional free-form notes
+     * @param emails        newline-separated email addresses
+     * @param telephones    newline-separated telephone numbers
+     * @param urls          newline-separated URLs
+     * @param nicknames     newline-separated nicknames
+     * @param principal     authenticated user
+     * @param model         Thymeleaf model
+     * @return redirect to the new contact's detail page on success
+     */
+    @PostMapping
+    public String create(@RequestParam(required = false) String formattedName,
+                         @RequestParam(required = false) String givenName,
+                         @RequestParam(required = false) String familyName,
+                         @RequestParam(required = false) String organization,
+                         @RequestParam(required = false) String title,
+                         @RequestParam(required = false) String notes,
+                         @RequestParam(required = false) String emails,
+                         @RequestParam(required = false) String telephones,
+                         @RequestParam(required = false) String urls,
+                         @RequestParam(required = false) String nicknames,
+                         @AuthenticationPrincipal UserDetails principal,
+                         Model model) {
+        var ctx = currentOrg.resolve(principal);
+        if (ctx.organizationId() == null) {
+            return "redirect:/";
+        }
+        if (formattedName == null || formattedName.isBlank()) {
+            populateFormState(model, null, null, ctx.user().getUsername(),
+                    "Formatted name is required.", formattedName, givenName, familyName,
+                    organization, title, notes, emails, telephones, urls, nicknames);
+            return "contact-form";
+        }
+        List<String> emailList = splitLines(emails);
+        String emailError = validateEmails(emailList);
+        if (emailError != null) {
+            populateFormState(model, null, null, ctx.user().getUsername(), emailError,
+                    formattedName, givenName, familyName, organization, title, notes,
+                    emails, telephones, urls, nicknames);
+            return "contact-form";
+        }
+        Contact contact = new Contact();
+        contact.setOrganizationId(ctx.organizationId());
+        contact.setFormattedName(formattedName);
+        contact.setGivenName(blankToNull(givenName));
+        contact.setFamilyName(blankToNull(familyName));
+        contact.setOrganization(blankToNull(organization));
+        contact.setTitle(blankToNull(title));
+        contact.setNotes(blankToNull(notes));
+        contact.setEmails(emailList);
+        contact.setTelephones(splitLines(telephones));
+        contact.setUrls(splitLines(urls));
+        contact.setNicknames(splitLines(nicknames));
+        Contact saved = contactUseCase.create(contact);
+        return "redirect:/contacts/" + saved.getId();
+    }
+
+    /**
+     * Renders the edit-contact form, pre-populated.
+     *
+     * @param id        the contact's UUID
+     * @param principal authenticated user
+     * @param model     Thymeleaf model
+     * @return the {@code contact-form} template
+     */
+    @GetMapping("/{id}/edit")
+    public String editForm(@PathVariable UUID id,
+                           @AuthenticationPrincipal UserDetails principal,
+                           Model model) {
+        var ctx = currentOrg.resolve(principal);
+        if (ctx.organizationId() == null) {
+            return "redirect:/";
+        }
+        Contact existing = contactRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(EntityType.CONTACT.name(), id));
+        organizationAccessService.verifyAccess(existing.getOrganizationId());
+        model.addAttribute("editingId", id);
+        model.addAttribute("existing", existing);
+        model.addAttribute("username", ctx.user().getUsername());
+        return "contact-form";
+    }
+
+    /**
+     * Updates an existing contact from the edit-form post and redirects to detail.
+     *
+     * @param id            the contact's UUID
+     * @param formattedName required formatted display name
+     * @param givenName     optional given name
+     * @param familyName    optional family name
+     * @param organization  optional organization
+     * @param title         optional title
+     * @param notes         optional notes
+     * @param emails        newline-separated email addresses
+     * @param telephones    newline-separated telephone numbers
+     * @param urls          newline-separated URLs
+     * @param nicknames     newline-separated nicknames
+     * @param principal     authenticated user
+     * @param model         Thymeleaf model
+     * @return redirect to the contact's detail page on success
+     */
+    @PostMapping("/{id}")
+    public String update(@PathVariable UUID id,
+                         @RequestParam(required = false) String formattedName,
+                         @RequestParam(required = false) String givenName,
+                         @RequestParam(required = false) String familyName,
+                         @RequestParam(required = false) String organization,
+                         @RequestParam(required = false) String title,
+                         @RequestParam(required = false) String notes,
+                         @RequestParam(required = false) String emails,
+                         @RequestParam(required = false) String telephones,
+                         @RequestParam(required = false) String urls,
+                         @RequestParam(required = false) String nicknames,
+                         @AuthenticationPrincipal UserDetails principal,
+                         Model model) {
+        var ctx = currentOrg.resolve(principal);
+        if (ctx.organizationId() == null) {
+            return "redirect:/";
+        }
+        Contact existing = contactRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(EntityType.CONTACT.name(), id));
+        organizationAccessService.verifyAccess(existing.getOrganizationId());
+        if (formattedName == null || formattedName.isBlank()) {
+            populateFormState(model, id, existing, ctx.user().getUsername(),
+                    "Formatted name is required.", formattedName, givenName, familyName,
+                    organization, title, notes, emails, telephones, urls, nicknames);
+            return "contact-form";
+        }
+        List<String> emailList = splitLines(emails);
+        String emailError = validateEmails(emailList);
+        if (emailError != null) {
+            populateFormState(model, id, existing, ctx.user().getUsername(), emailError,
+                    formattedName, givenName, familyName, organization, title, notes,
+                    emails, telephones, urls, nicknames);
+            return "contact-form";
+        }
+        Contact updated = new Contact();
+        updated.setId(id);
+        updated.setOrganizationId(existing.getOrganizationId());
+        updated.setFormattedName(formattedName);
+        updated.setGivenName(blankToNull(givenName));
+        updated.setFamilyName(blankToNull(familyName));
+        updated.setOrganization(blankToNull(organization));
+        updated.setTitle(blankToNull(title));
+        updated.setNotes(blankToNull(notes));
+        updated.setEmails(emailList);
+        updated.setTelephones(splitLines(telephones));
+        updated.setUrls(splitLines(urls));
+        updated.setNicknames(splitLines(nicknames));
+        contactUseCase.update(id, updated);
+        return "redirect:/contacts/" + id;
+    }
+
+    private static String blankToNull(String s) {
+        return (s == null || s.isBlank()) ? null : s;
+    }
+
+    private static List<String> splitLines(String raw) {
+        if (raw == null || raw.isBlank()) {
+            return List.of();
+        }
+        List<String> lines = new ArrayList<>();
+        for (String line : raw.split("\\r?\\n")) {
+            String trimmed = line.trim();
+            if (!trimmed.isEmpty()) {
+                lines.add(trimmed);
+            }
+        }
+        return lines;
+    }
+
+    /** Returns null if all emails parse, or an error message naming the first bad line. */
+    private static String validateEmails(List<String> emails) {
+        for (String e : emails) {
+            if (!EMAIL_PATTERN.matcher(e).matches()) {
+                return "Invalid email: " + e;
+            }
+        }
+        return null;
+    }
+
+    private static final java.util.regex.Pattern EMAIL_PATTERN =
+            java.util.regex.Pattern.compile("^[^\\s@]+@[^\\s@]+\\.[^\\s@]+$");
+
+    private static void populateFormState(Model model, UUID editingId, Contact existing,
+                                          String username, String formError,
+                                          String formattedName, String givenName, String familyName,
+                                          String organization, String title, String notes,
+                                          String emails, String telephones, String urls,
+                                          String nicknames) {
+        model.addAttribute("editingId", editingId);
+        model.addAttribute("existing", existing);
+        model.addAttribute("username", username);
+        model.addAttribute("formError", formError);
+        model.addAttribute("formFormattedName", formattedName);
+        model.addAttribute("formGivenName", givenName);
+        model.addAttribute("formFamilyName", familyName);
+        model.addAttribute("formOrganization", organization);
+        model.addAttribute("formTitle", title);
+        model.addAttribute("formNotes", notes);
+        model.addAttribute("formEmails", emails);
+        model.addAttribute("formTelephones", telephones);
+        model.addAttribute("formUrls", urls);
+        model.addAttribute("formNicknames", nicknames);
     }
 
     private static boolean matchesQuery(Contact c, String qLower) {

--- a/src/main/java/com/majordomo/adapter/in/web/concierge/ContactPageController.java
+++ b/src/main/java/com/majordomo/adapter/in/web/concierge/ContactPageController.java
@@ -358,15 +358,23 @@ public class ContactPageController {
     /** Returns null if all emails parse, or an error message naming the first bad line. */
     private static String validateEmails(List<String> emails) {
         for (String e : emails) {
-            if (!EMAIL_PATTERN.matcher(e).matches()) {
+            if (e.length() > MAX_EMAIL_LENGTH || !EMAIL_PATTERN.matcher(e).matches()) {
                 return "Invalid email: " + e;
             }
         }
         return null;
     }
 
+    /** RFC 5321 caps an address path at 254 characters; cap before regex matching. */
+    private static final int MAX_EMAIL_LENGTH = 254;
+
+    /**
+     * Domain segments are unambiguous because the character classes exclude `.`,
+     * so each `+` can only match within one label and there's no backtracking
+     * overlap between segments. Local part still excludes whitespace and `@`.
+     */
     private static final java.util.regex.Pattern EMAIL_PATTERN =
-            java.util.regex.Pattern.compile("^[^\\s@]+@[^\\s@]+\\.[^\\s@]+$");
+            java.util.regex.Pattern.compile("^[^\\s@]+@[^\\s@.]+(\\.[^\\s@.]+)+$");
 
     private static void populateFormState(Model model, UUID editingId, Contact existing,
                                           String username, String formError,

--- a/src/main/resources/templates/contact-form.html
+++ b/src/main/resources/templates/contact-form.html
@@ -1,0 +1,129 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title th:text="${editingId != null ? 'Edit contact' : 'New contact'} + ' - Majordomo'">Contact form</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-gray-100 min-h-screen">
+    <div th:replace="~{fragments/header :: header}"></div>
+    <div class="flex min-h-screen">
+        <div th:replace="~{fragments/sidebar :: sidebar('contacts')}"></div>
+        <main class="flex-1 p-6">
+            <div class="bg-white rounded-lg shadow">
+                <div class="px-6 py-4 border-b border-gray-200">
+                    <h1 class="text-xl font-semibold text-gray-900"
+                        th:text="${editingId != null ? 'Edit contact' : 'New contact'}">Title</h1>
+                </div>
+                <div class="p-6 space-y-4">
+                    <div th:if="${formError}"
+                         class="rounded-md bg-red-50 border border-red-200 px-4 py-3 text-sm text-red-700"
+                         th:text="${formError}">Error</div>
+                    <form method="post"
+                          th:action="${editingId != null ? '/contacts/' + editingId : '/contacts'}"
+                          class="space-y-4">
+
+                        <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                            <div class="flex flex-col sm:col-span-2">
+                                <label for="formattedName"
+                                       class="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-1">Display name</label>
+                                <input id="formattedName" name="formattedName" type="text" required
+                                       th:value="${formFormattedName != null ? formFormattedName
+                                                  : (existing != null ? existing.getFormattedName() : '')}"
+                                       class="block rounded border-gray-300 text-sm focus:border-indigo-500 focus:ring-indigo-500 px-2 py-1.5">
+                            </div>
+                            <div class="flex flex-col">
+                                <label for="givenName"
+                                       class="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-1">Given name</label>
+                                <input id="givenName" name="givenName" type="text"
+                                       th:value="${formGivenName != null ? formGivenName
+                                                  : (existing != null ? existing.getGivenName() : '')}"
+                                       class="block rounded border-gray-300 text-sm focus:border-indigo-500 focus:ring-indigo-500 px-2 py-1.5">
+                            </div>
+                            <div class="flex flex-col">
+                                <label for="familyName"
+                                       class="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-1">Family name</label>
+                                <input id="familyName" name="familyName" type="text"
+                                       th:value="${formFamilyName != null ? formFamilyName
+                                                  : (existing != null ? existing.getFamilyName() : '')}"
+                                       class="block rounded border-gray-300 text-sm focus:border-indigo-500 focus:ring-indigo-500 px-2 py-1.5">
+                            </div>
+                            <div class="flex flex-col">
+                                <label for="organization"
+                                       class="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-1">Organization</label>
+                                <input id="organization" name="organization" type="text"
+                                       th:value="${formOrganization != null ? formOrganization
+                                                  : (existing != null ? existing.getOrganization() : '')}"
+                                       class="block rounded border-gray-300 text-sm focus:border-indigo-500 focus:ring-indigo-500 px-2 py-1.5">
+                            </div>
+                            <div class="flex flex-col">
+                                <label for="title"
+                                       class="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-1">Title</label>
+                                <input id="title" name="title" type="text"
+                                       th:value="${formTitle != null ? formTitle
+                                                  : (existing != null ? existing.getTitle() : '')}"
+                                       class="block rounded border-gray-300 text-sm focus:border-indigo-500 focus:ring-indigo-500 px-2 py-1.5">
+                            </div>
+                        </div>
+
+                        <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                            <div class="flex flex-col">
+                                <label for="emails"
+                                       class="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-1">Emails (one per line)</label>
+                                <textarea id="emails" name="emails" rows="3"
+                                          th:text="${formEmails != null ? formEmails
+                                                    : (existing != null and existing.getEmails() != null
+                                                        ? #strings.listJoin(existing.getEmails(), '&#10;') : '')}"
+                                          class="block rounded border-gray-300 text-sm font-mono focus:border-indigo-500 focus:ring-indigo-500 px-2 py-1.5"></textarea>
+                            </div>
+                            <div class="flex flex-col">
+                                <label for="telephones"
+                                       class="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-1">Phones (one per line)</label>
+                                <textarea id="telephones" name="telephones" rows="3"
+                                          th:text="${formTelephones != null ? formTelephones
+                                                    : (existing != null and existing.getTelephones() != null
+                                                        ? #strings.listJoin(existing.getTelephones(), '&#10;') : '')}"
+                                          class="block rounded border-gray-300 text-sm font-mono focus:border-indigo-500 focus:ring-indigo-500 px-2 py-1.5"></textarea>
+                            </div>
+                            <div class="flex flex-col">
+                                <label for="urls"
+                                       class="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-1">URLs (one per line)</label>
+                                <textarea id="urls" name="urls" rows="3"
+                                          th:text="${formUrls != null ? formUrls
+                                                    : (existing != null and existing.getUrls() != null
+                                                        ? #strings.listJoin(existing.getUrls(), '&#10;') : '')}"
+                                          class="block rounded border-gray-300 text-sm font-mono focus:border-indigo-500 focus:ring-indigo-500 px-2 py-1.5"></textarea>
+                            </div>
+                            <div class="flex flex-col">
+                                <label for="nicknames"
+                                       class="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-1">Nicknames (one per line)</label>
+                                <textarea id="nicknames" name="nicknames" rows="3"
+                                          th:text="${formNicknames != null ? formNicknames
+                                                    : (existing != null and existing.getNicknames() != null
+                                                        ? #strings.listJoin(existing.getNicknames(), '&#10;') : '')}"
+                                          class="block rounded border-gray-300 text-sm font-mono focus:border-indigo-500 focus:ring-indigo-500 px-2 py-1.5"></textarea>
+                            </div>
+                        </div>
+
+                        <div class="flex flex-col">
+                            <label for="notes"
+                                   class="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-1">Notes</label>
+                            <textarea id="notes" name="notes" rows="3"
+                                      th:text="${formNotes != null ? formNotes
+                                                : (existing != null ? existing.getNotes() : '')}"
+                                      class="block rounded border-gray-300 text-sm focus:border-indigo-500 focus:ring-indigo-500 px-2 py-1.5"></textarea>
+                        </div>
+
+                        <div>
+                            <button type="submit"
+                                    class="inline-flex items-center rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-indigo-700">
+                                <span th:text="${editingId != null ? 'Save changes' : 'Create contact'}">Submit</span>
+                            </button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </main>
+    </div>
+</body>
+</html>

--- a/src/main/resources/templates/contacts.html
+++ b/src/main/resources/templates/contacts.html
@@ -20,6 +20,10 @@
                 <div class="flex items-center gap-4">
                     <span class="text-sm text-gray-500"
                           th:text="${#lists.size(rows)} + ' contacts'">0 contacts</span>
+                    <a th:href="@{/contacts/new}"
+                       class="inline-flex items-center rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-indigo-700">
+                        + New contact
+                    </a>
                 </div>
             </div>
 

--- a/src/test/java/com/majordomo/adapter/in/web/concierge/ContactPageFormTest.java
+++ b/src/test/java/com/majordomo/adapter/in/web/concierge/ContactPageFormTest.java
@@ -1,0 +1,260 @@
+package com.majordomo.adapter.in.web.concierge;
+
+import com.majordomo.adapter.in.web.config.OAuth2UserService;
+import com.majordomo.adapter.in.web.config.SecurityConfig;
+import com.majordomo.application.identity.CurrentOrganizationResolver;
+import com.majordomo.application.identity.OrganizationAccessService;
+import com.majordomo.domain.model.UuidFactory;
+import com.majordomo.domain.model.concierge.Contact;
+import com.majordomo.domain.model.identity.User;
+import com.majordomo.domain.port.in.concierge.ManageContactUseCase;
+import com.majordomo.domain.port.in.steward.ManagePropertyUseCase;
+import com.majordomo.domain.port.out.concierge.ContactRepository;
+import com.majordomo.domain.port.out.identity.ApiKeyRepository;
+import com.majordomo.domain.port.out.steward.PropertyContactRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
+
+/** Slice tests for the {@code /contacts} add/edit forms (#233). */
+@WebMvcTest(ContactPageController.class)
+@Import(SecurityConfig.class)
+class ContactPageFormTest {
+
+    @Autowired MockMvc mvc;
+
+    @MockitoBean ManageContactUseCase contactUseCase;
+    @MockitoBean ContactRepository contactRepository;
+    @MockitoBean ManagePropertyUseCase propertyUseCase;
+    @MockitoBean PropertyContactRepository propertyContactRepository;
+    @MockitoBean CurrentOrganizationResolver currentOrg;
+    @MockitoBean OrganizationAccessService organizationAccessService;
+    @MockitoBean ApiKeyRepository apiKeyRepository;
+    @MockitoBean OAuth2UserService oAuth2UserService;
+
+    private static final UUID ORG_ID = UuidFactory.newId();
+
+    @BeforeEach
+    void seedAuth() {
+        User user = new User(UuidFactory.newId(), "robsartin", "rob@example.com");
+        when(currentOrg.resolve(any(UserDetails.class)))
+                .thenReturn(new CurrentOrganizationResolver.Resolved(user, ORG_ID));
+    }
+
+    /** Cycle 1: GET /contacts/new returns 200 + contact-form view. */
+    @Test
+    @WithMockUser
+    void newFormRenders() throws Exception {
+        mvc.perform(get("/contacts/new"))
+                .andExpect(status().isOk())
+                .andExpect(view().name("contact-form"));
+    }
+
+    /** Cycle 1: POST /contacts persists all simple + multi-value fields. */
+    @Test
+    @WithMockUser
+    void createPersistsAndRedirectsToDetail() throws Exception {
+        UUID newId = UuidFactory.newId();
+        Contact saved = new Contact();
+        saved.setId(newId);
+        saved.setOrganizationId(ORG_ID);
+        when(contactUseCase.create(any(Contact.class))).thenReturn(saved);
+
+        mvc.perform(post("/contacts")
+                        .with(csrf())
+                        .param("formattedName", "Alice Example")
+                        .param("givenName", "Alice")
+                        .param("familyName", "Example")
+                        .param("organization", "Acme")
+                        .param("title", "Lead Engineer")
+                        .param("notes", "Met at conference.")
+                        .param("emails", "alice@acme.example\nalice.alt@acme.example")
+                        .param("telephones", "+15555550100")
+                        .param("urls", "https://acme.example")
+                        .param("nicknames", "Ace"))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(view().name("redirect:/contacts/" + newId));
+
+        ArgumentCaptor<Contact> captor = ArgumentCaptor.forClass(Contact.class);
+        verify(contactUseCase).create(captor.capture());
+        Contact c = captor.getValue();
+        assertThat(c.getOrganizationId()).isEqualTo(ORG_ID);
+        assertThat(c.getFormattedName()).isEqualTo("Alice Example");
+        assertThat(c.getGivenName()).isEqualTo("Alice");
+        assertThat(c.getFamilyName()).isEqualTo("Example");
+        assertThat(c.getOrganization()).isEqualTo("Acme");
+        assertThat(c.getTitle()).isEqualTo("Lead Engineer");
+        assertThat(c.getNotes()).isEqualTo("Met at conference.");
+        assertThat(c.getEmails()).containsExactly("alice@acme.example", "alice.alt@acme.example");
+        assertThat(c.getTelephones()).containsExactly("+15555550100");
+        assertThat(c.getUrls()).containsExactly("https://acme.example");
+        assertThat(c.getNicknames()).containsExactly("Ace");
+    }
+
+    /** Cycle 2: POST /contacts with blank formattedName re-renders with error + state. */
+    @Test
+    @WithMockUser
+    void createWithBlankNameRendersFormWithError() throws Exception {
+        MvcResult result = mvc.perform(post("/contacts")
+                        .with(csrf())
+                        .param("formattedName", "")
+                        .param("organization", "Acme")
+                        .param("emails", "alice@acme.example"))
+                .andExpect(status().isOk())
+                .andExpect(view().name("contact-form"))
+                .andReturn();
+
+        String body = result.getResponse().getContentAsString();
+        assertThat(body).contains("Formatted name is required.");
+        assertThat(body).contains("value=\"Acme\"");
+        // Multi-line emails echo back as the textarea content.
+        assertThat(body).contains("alice@acme.example");
+        verify(contactUseCase, never()).create(any());
+    }
+
+    /** Cycle 3: GET /contacts/{id}/edit pre-populates the form. */
+    @Test
+    @WithMockUser
+    void editFormPrePopulates() throws Exception {
+        UUID id = UuidFactory.newId();
+        Contact existing = new Contact();
+        existing.setId(id);
+        existing.setOrganizationId(ORG_ID);
+        existing.setFormattedName("Alice Example");
+        existing.setOrganization("Acme");
+        existing.setEmails(List.of("alice@acme.example", "alice.alt@acme.example"));
+        existing.setTelephones(List.of("+15555550100"));
+        when(contactRepository.findById(id)).thenReturn(Optional.of(existing));
+
+        MvcResult result = mvc.perform(get("/contacts/{id}/edit", id))
+                .andExpect(status().isOk())
+                .andExpect(view().name("contact-form"))
+                .andReturn();
+
+        String body = result.getResponse().getContentAsString();
+        assertThat(body)
+                .contains("Edit contact")
+                .contains("value=\"Alice Example\"")
+                .contains("value=\"Acme\"")
+                .contains("alice@acme.example")
+                .contains("alice.alt@acme.example")
+                .contains("+15555550100");
+    }
+
+    /** Cycle 3: POST /contacts/{id} persists all fields and redirects. */
+    @Test
+    @WithMockUser
+    void updatePersistsAndRedirectsToDetail() throws Exception {
+        UUID id = UuidFactory.newId();
+        Contact existing = new Contact();
+        existing.setId(id);
+        existing.setOrganizationId(ORG_ID);
+        existing.setFormattedName("Old Name");
+        when(contactRepository.findById(id)).thenReturn(Optional.of(existing));
+        when(contactUseCase.update(eq(id), any(Contact.class))).thenAnswer(inv -> inv.getArgument(1));
+
+        mvc.perform(post("/contacts/{id}", id)
+                        .with(csrf())
+                        .param("formattedName", "New Name")
+                        .param("givenName", "New")
+                        .param("familyName", "Name")
+                        .param("organization", "Globex")
+                        .param("title", "VP")
+                        .param("emails", "new@globex.example")
+                        .param("telephones", "+15555550999")
+                        .param("urls", "https://globex.example")
+                        .param("nicknames", "Newt"))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(view().name("redirect:/contacts/" + id));
+
+        ArgumentCaptor<Contact> captor = ArgumentCaptor.forClass(Contact.class);
+        verify(contactUseCase).update(eq(id), captor.capture());
+        Contact c = captor.getValue();
+        assertThat(c.getFormattedName()).isEqualTo("New Name");
+        assertThat(c.getOrganization()).isEqualTo("Globex");
+        assertThat(c.getEmails()).containsExactly("new@globex.example");
+        assertThat(c.getNicknames()).containsExactly("Newt");
+    }
+
+    /** Cycle 4: bad email line on create re-renders form with error + state. */
+    @Test
+    @WithMockUser
+    void createWithBadEmailRendersFormWithError() throws Exception {
+        mvc.perform(post("/contacts")
+                        .with(csrf())
+                        .param("formattedName", "Alice Example")
+                        .param("emails", "alice@acme.example\nnot-an-email"))
+                .andExpect(status().isOk())
+                .andExpect(content().string(org.hamcrest.Matchers.containsString(
+                        "Invalid email: not-an-email")));
+
+        verify(contactUseCase, never()).create(any());
+    }
+
+    /** Cycle 5: GET /contacts/{id}/edit returns 403 cross-org. */
+    @Test
+    @WithMockUser
+    void editFormReturns403WhenCrossOrg() throws Exception {
+        UUID id = UuidFactory.newId();
+        UUID otherOrg = UuidFactory.newId();
+        Contact foreign = new Contact();
+        foreign.setId(id);
+        foreign.setOrganizationId(otherOrg);
+        foreign.setFormattedName("Cross-org");
+        when(contactRepository.findById(id)).thenReturn(Optional.of(foreign));
+        doThrow(new AccessDeniedException("denied"))
+                .when(organizationAccessService).verifyAccess(otherOrg);
+
+        mvc.perform(get("/contacts/{id}/edit", id))
+                .andExpect(status().isForbidden());
+    }
+
+    /** Cycle 5: POST /contacts/{id} returns 403 cross-org. */
+    @Test
+    @WithMockUser
+    void updateReturns403WhenCrossOrg() throws Exception {
+        UUID id = UuidFactory.newId();
+        UUID otherOrg = UuidFactory.newId();
+        Contact foreign = new Contact();
+        foreign.setId(id);
+        foreign.setOrganizationId(otherOrg);
+        foreign.setFormattedName("Cross-org");
+        when(contactRepository.findById(id)).thenReturn(Optional.of(foreign));
+        doThrow(new AccessDeniedException("denied"))
+                .when(organizationAccessService).verifyAccess(otherOrg);
+
+        mvc.perform(post("/contacts/{id}", id)
+                        .with(csrf())
+                        .param("formattedName", "anything"))
+                .andExpect(status().isForbidden());
+
+        verify(contactUseCase, never()).update(any(), any());
+    }
+}


### PR DESCRIPTION
## Summary
- `/contacts/new` and `/contacts/{id}/edit` Thymeleaf forms — mode-aware title/button.
- Single-line inputs for formatted name (required), given/family names, organization, title.
- Multi-line textareas (one value per line) for emails, phones, URLs, nicknames; long textarea for notes.
- `POST /contacts` creates and redirects to detail; `POST /contacts/{id}` updates and redirects.
- Cross-org access verified via `OrganizationAccessService` on edit + update.
- Validation: blank `formattedName` → re-render with error + field state. Bad email line → re-render with `Invalid email: <line>` + state.
- "+ New contact" link on the list page header. (Detail-page "Edit" button shipped with #232.)

## Test plan
- [x] `./mvnw verify -DskipITs` green (517 tests, 0 failures, checkstyle clean)
- [x] Slice tests added: form render, create persists all simple + multi-value fields, blank-name re-render, edit pre-populate, update persists all fields, bad-email re-render, 403 cross-org on edit + update.

## Notes
- Address editing is intentionally deferred: addresses are records with their own structure, and a v1 add/edit textarea would lose the typed fields. Suggest a follow-up issue for an addresses sub-form. Let me know if you want me to file it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)