### PR TITLE
feat(ledger): spend dashboard UI at /ledger (closes #237)

### DIFF
--- a/src/main/java/com/majordomo/adapter/in/web/ledger/LedgerPageController.java
+++ b/src/main/java/com/majordomo/adapter/in/web/ledger/LedgerPageController.java
@@ -1,0 +1,96 @@
+package com.majordomo.adapter.in.web.ledger;
+
+import com.majordomo.application.identity.CurrentOrganizationResolver;
+import com.majordomo.domain.model.ledger.SpendSummary;
+import com.majordomo.domain.model.steward.Property;
+import com.majordomo.domain.port.in.ledger.QuerySpendUseCase;
+import com.majordomo.domain.port.out.steward.PropertyRepository;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Serves the Ledger spend-dashboard web page. Sibling to the REST
+ * {@code LedgerController} at {@code /api/ledger}, which is untouched.
+ */
+@Controller
+@RequestMapping("/ledger")
+public class LedgerPageController {
+
+    private final QuerySpendUseCase spendUseCase;
+    private final PropertyRepository propertyRepository;
+    private final CurrentOrganizationResolver currentOrg;
+
+    /**
+     * One row in the per-property spend table.
+     *
+     * @param property the property
+     * @param summary  the property's spend summary
+     */
+    public record PropertySpendRow(Property property, SpendSummary summary) { }
+
+    /**
+     * Constructs the ledger page controller.
+     *
+     * @param spendUseCase       inbound port for spend queries
+     * @param propertyRepository outbound port for property reads
+     * @param currentOrg         resolves the authenticated user's organization
+     */
+    public LedgerPageController(QuerySpendUseCase spendUseCase,
+                                PropertyRepository propertyRepository,
+                                CurrentOrganizationResolver currentOrg) {
+        this.spendUseCase = spendUseCase;
+        this.propertyRepository = propertyRepository;
+        this.currentOrg = currentOrg;
+    }
+
+    /**
+     * Renders the spend dashboard for the user's organization.
+     *
+     * @param principal authenticated user
+     * @param model     Thymeleaf model
+     * @return the {@code ledger} template, or a redirect home if no org
+     */
+    @GetMapping
+    public String dashboard(@AuthenticationPrincipal UserDetails principal, Model model) {
+        var ctx = currentOrg.resolve(principal);
+        if (ctx.organizationId() == null) {
+            return "redirect:/";
+        }
+        UUID orgId = ctx.organizationId();
+
+        SpendSummary orgSpend = spendUseCase.spendForOrganization(orgId);
+        BigDecimal projected = spendUseCase.projectedAnnualSpend(orgId);
+
+        List<PropertySpendRow> rows = new ArrayList<>();
+        for (Property p : propertyRepository.findByOrganizationId(orgId)) {
+            if (p.getArchivedAt() != null) {
+                continue;
+            }
+            rows.add(new PropertySpendRow(p, spendUseCase.spendForProperty(p.getId())));
+        }
+        rows.sort(Comparator.comparing(
+                (PropertySpendRow r) -> nullToZero(r.summary().totalCost()),
+                Comparator.reverseOrder()));
+
+        model.addAttribute("orgSpend", orgSpend);
+        model.addAttribute("projectedAnnualSpend", projected);
+        model.addAttribute("rows", rows);
+        model.addAttribute("username", ctx.user().getUsername());
+        return "ledger";
+    }
+
+    private static BigDecimal nullToZero(BigDecimal v) {
+        return v == null ? BigDecimal.ZERO : v;
+    }
+}

--- a/src/main/resources/templates/ledger.html
+++ b/src/main/resources/templates/ledger.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Ledger - Majordomo</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-gray-100 min-h-screen">
+
+    <div th:replace="~{fragments/header :: header}"></div>
+
+    <div class="flex min-h-screen">
+        <div th:replace="~{fragments/sidebar :: sidebar('ledger')}"></div>
+
+        <main class="flex-1 p-6">
+
+            <div class="mb-6">
+                <h1 class="text-2xl font-bold text-gray-900">Ledger</h1>
+                <p class="text-sm text-gray-500">Spend across your properties.</p>
+            </div>
+
+            <!-- Summary cards -->
+            <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 mb-6">
+                <div class="bg-white rounded-lg shadow p-4">
+                    <p class="text-xs font-semibold text-gray-500 uppercase tracking-wider">Total spend</p>
+                    <p class="text-2xl font-bold text-gray-900 mt-1"
+                       th:text="${orgSpend.totalCost() != null ? '$' + #numbers.formatDecimal(orgSpend.totalCost(), 1, 'COMMA', 2, 'POINT') : '—'}">$0.00</p>
+                </div>
+                <div class="bg-white rounded-lg shadow p-4">
+                    <p class="text-xs font-semibold text-gray-500 uppercase tracking-wider">Purchase price</p>
+                    <p class="text-2xl font-bold text-gray-900 mt-1"
+                       th:text="${orgSpend.purchasePrice() != null ? '$' + #numbers.formatDecimal(orgSpend.purchasePrice(), 1, 'COMMA', 2, 'POINT') : '—'}">$0.00</p>
+                </div>
+                <div class="bg-white rounded-lg shadow p-4">
+                    <p class="text-xs font-semibold text-gray-500 uppercase tracking-wider">Maintenance to date</p>
+                    <p class="text-2xl font-bold text-gray-900 mt-1"
+                       th:text="${orgSpend.maintenanceCost() != null ? '$' + #numbers.formatDecimal(orgSpend.maintenanceCost(), 1, 'COMMA', 2, 'POINT') : '—'}">$0.00</p>
+                </div>
+                <div class="bg-white rounded-lg shadow p-4">
+                    <p class="text-xs font-semibold text-gray-500 uppercase tracking-wider">Projected annual</p>
+                    <p class="text-2xl font-bold text-gray-900 mt-1"
+                       th:text="${projectedAnnualSpend != null ? '$' + #numbers.formatDecimal(projectedAnnualSpend, 1, 'COMMA', 2, 'POINT') : '—'}">$0.00</p>
+                </div>
+            </div>
+
+            <!-- Per-property table -->
+            <div class="bg-white rounded-lg shadow overflow-hidden">
+                <div class="px-6 py-3 border-b border-gray-200">
+                    <h2 class="text-sm font-semibold text-gray-700 uppercase tracking-wider">Spend by property</h2>
+                </div>
+                <div th:if="${#lists.isEmpty(rows)}" class="px-6 py-12 text-center text-gray-500">
+                    No properties to summarize.
+                </div>
+                <table th:unless="${#lists.isEmpty(rows)}" class="min-w-full divide-y divide-gray-200">
+                    <thead class="bg-gray-50">
+                        <tr>
+                            <th class="px-6 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider">Property</th>
+                            <th class="px-6 py-3 text-right text-xs font-semibold text-gray-500 uppercase tracking-wider">Purchase price</th>
+                            <th class="px-6 py-3 text-right text-xs font-semibold text-gray-500 uppercase tracking-wider">Maintenance</th>
+                            <th class="px-6 py-3 text-right text-xs font-semibold text-gray-500 uppercase tracking-wider">Total</th>
+                        </tr>
+                    </thead>
+                    <tbody class="bg-white divide-y divide-gray-100">
+                        <tr th:each="r : ${rows}">
+                            <td class="px-6 py-3 whitespace-nowrap text-sm">
+                                <a th:href="@{|/properties/${r.property().getId()}|}"
+                                   th:text="${r.property().getName()}"
+                                   class="text-indigo-600 hover:text-indigo-800 font-medium">Property</a>
+                            </td>
+                            <td class="px-6 py-3 whitespace-nowrap text-sm text-gray-700 text-right"
+                                th:text="${r.summary().purchasePrice() != null ? '$' + #numbers.formatDecimal(r.summary().purchasePrice(), 1, 'COMMA', 2, 'POINT') : '—'}">$0.00</td>
+                            <td class="px-6 py-3 whitespace-nowrap text-sm text-gray-700 text-right"
+                                th:text="${r.summary().maintenanceCost() != null ? '$' + #numbers.formatDecimal(r.summary().maintenanceCost(), 1, 'COMMA', 2, 'POINT') : '—'}">$0.00</td>
+                            <td class="px-6 py-3 whitespace-nowrap text-sm text-gray-900 font-semibold text-right"
+                                th:text="${r.summary().totalCost() != null ? '$' + #numbers.formatDecimal(r.summary().totalCost(), 1, 'COMMA', 2, 'POINT') : '—'}">$0.00</td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+
+        </main>
+    </div>
+</body>
+</html>

--- a/src/test/java/com/majordomo/adapter/in/web/ledger/LedgerPageDashboardTest.java
+++ b/src/test/java/com/majordomo/adapter/in/web/ledger/LedgerPageDashboardTest.java
@@ -1,0 +1,151 @@
+package com.majordomo.adapter.in.web.ledger;
+
+import com.majordomo.adapter.in.web.config.OAuth2UserService;
+import com.majordomo.adapter.in.web.config.SecurityConfig;
+import com.majordomo.application.identity.CurrentOrganizationResolver;
+import com.majordomo.domain.model.UuidFactory;
+import com.majordomo.domain.model.identity.User;
+import com.majordomo.domain.model.ledger.SpendSummary;
+import com.majordomo.domain.model.steward.Property;
+import com.majordomo.domain.port.in.ledger.QuerySpendUseCase;
+import com.majordomo.domain.port.out.identity.ApiKeyRepository;
+import com.majordomo.domain.port.out.steward.PropertyRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
+
+/** Slice tests for the {@code /ledger} dashboard (#237). */
+@WebMvcTest(LedgerPageController.class)
+@Import(SecurityConfig.class)
+class LedgerPageDashboardTest {
+
+    @Autowired MockMvc mvc;
+
+    @MockitoBean QuerySpendUseCase spendUseCase;
+    @MockitoBean PropertyRepository propertyRepository;
+    @MockitoBean CurrentOrganizationResolver currentOrg;
+    @MockitoBean ApiKeyRepository apiKeyRepository;
+    @MockitoBean OAuth2UserService oAuth2UserService;
+
+    private static final UUID ORG_ID = UuidFactory.newId();
+
+    @BeforeEach
+    void seedAuth() {
+        User user = new User(UuidFactory.newId(), "robsartin", "rob@example.com");
+        when(currentOrg.resolve(any(UserDetails.class)))
+                .thenReturn(new CurrentOrganizationResolver.Resolved(user, ORG_ID));
+    }
+
+    /** Cycle 1: dashboard renders org spend cards + per-property rows. */
+    @Test
+    @WithMockUser
+    void dashboardRendersSummaryAndPerPropertyRows() throws Exception {
+        UUID propA = UuidFactory.newId();
+        UUID propB = UuidFactory.newId();
+        Property a = property(propA, "Beach House");
+        Property b = property(propB, "Mountain Cabin");
+        when(propertyRepository.findByOrganizationId(ORG_ID)).thenReturn(List.of(a, b));
+
+        when(spendUseCase.spendForOrganization(ORG_ID))
+                .thenReturn(new SpendSummary(
+                        new BigDecimal("750000.00"),
+                        new BigDecimal("12500.00"),
+                        new BigDecimal("762500.00")));
+        when(spendUseCase.projectedAnnualSpend(ORG_ID))
+                .thenReturn(new BigDecimal("4800.00"));
+        when(spendUseCase.spendForProperty(propA))
+                .thenReturn(new SpendSummary(
+                        new BigDecimal("450000.00"),
+                        new BigDecimal("9000.00"),
+                        new BigDecimal("459000.00")));
+        when(spendUseCase.spendForProperty(propB))
+                .thenReturn(new SpendSummary(
+                        new BigDecimal("300000.00"),
+                        new BigDecimal("3500.00"),
+                        new BigDecimal("303500.00")));
+
+        MvcResult result = mvc.perform(get("/ledger"))
+                .andExpect(status().isOk())
+                .andExpect(view().name("ledger"))
+                .andReturn();
+
+        String body = result.getResponse().getContentAsString();
+        // Org-level summary cards.
+        assertThat(body)
+                .contains("$762,500.00")
+                .contains("$750,000.00")
+                .contains("$12,500.00")
+                .contains("$4,800.00");
+        // Per-property rows.
+        assertThat(body)
+                .contains("Beach House").contains("$459,000.00")
+                .contains("Mountain Cabin").contains("$303,500.00");
+        // Sorted by total cost descending: Beach House (459k) before Mountain Cabin (303k).
+        int beachIdx = body.indexOf("Beach House");
+        int mountainIdx = body.indexOf("Mountain Cabin");
+        assertThat(beachIdx).isPositive();
+        assertThat(mountainIdx).isGreaterThan(beachIdx);
+        // Row links to /properties/{id}.
+        assertThat(body).contains("/properties/" + propA);
+    }
+
+    /** Cycle 2: redirect home when user has no org. */
+    @Test
+    @WithMockUser
+    void redirectHomeWhenNoOrg() throws Exception {
+        User user = new User(UuidFactory.newId(), "lonely", "lonely@example.com");
+        when(currentOrg.resolve(any(UserDetails.class)))
+                .thenReturn(new CurrentOrganizationResolver.Resolved(user, null));
+
+        mvc.perform(get("/ledger"))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(view().name("redirect:/"));
+    }
+
+    /** Cycle 2b: empty state when no (non-archived) properties. */
+    @Test
+    @WithMockUser
+    void emptyStateWhenNoProperties() throws Exception {
+        Property archived = property(UuidFactory.newId(), "Old place");
+        archived.setArchivedAt(Instant.now());
+        when(propertyRepository.findByOrganizationId(ORG_ID)).thenReturn(List.of(archived));
+        when(spendUseCase.spendForOrganization(ORG_ID))
+                .thenReturn(new SpendSummary(BigDecimal.ZERO, BigDecimal.ZERO, BigDecimal.ZERO));
+        when(spendUseCase.projectedAnnualSpend(ORG_ID)).thenReturn(BigDecimal.ZERO);
+
+        MvcResult result = mvc.perform(get("/ledger"))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        assertThat(result.getResponse().getContentAsString())
+                .contains("No properties to summarize")
+                .doesNotContain("Old place");
+    }
+
+    private static Property property(UUID id, String name) {
+        Property p = new Property();
+        p.setId(id);
+        p.setOrganizationId(ORG_ID);
+        p.setName(name);
+        return p;
+    }
+}


### PR DESCRIPTION
## Summary
- New `LedgerPageController` serves `/ledger` as a Thymeleaf dashboard, sibling to the REST controller at `/api/ledger` (untouched).
- Top summary cards: total spend, purchase price, maintenance to date, projected annual.
- Per-property table sourced from non-archived properties + `spendForProperty(...)`. Sorted by total cost descending; rows link to `/properties/{id}`.
- Empty state when no non-archived properties; redirect home when user has no org.

## Test plan
- [x] `./mvnw verify -DskipITs` green (520 tests, 0 failures, checkstyle clean)
- [x] Slice tests added: dashboard render with summary + per-property rows + sort order, redirect home when no org, empty state when no properties.
- [ ] `gh pr checks` green (will verify post-push, including CodeQL).

🤖 Generated with [Claude Code](https://claude.com/claude-code)