### PR TITLE
feat(dashboard): surface ledger spend cards (closes #241)

### DIFF
--- a/src/main/java/com/majordomo/adapter/in/web/DashboardPageController.java
+++ b/src/main/java/com/majordomo/adapter/in/web/DashboardPageController.java
@@ -3,6 +3,7 @@ package com.majordomo.adapter.in.web;
 import com.majordomo.application.identity.CurrentOrganizationResolver;
 import com.majordomo.domain.port.in.DashboardUseCase;
 import com.majordomo.domain.port.in.envoy.GetRecentApplyNowPostingsUseCase;
+import com.majordomo.domain.port.in.ledger.QuerySpendUseCase;
 
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -21,6 +22,7 @@ public class DashboardPageController {
     private final DashboardUseCase dashboardUseCase;
     private final CurrentOrganizationResolver currentOrg;
     private final GetRecentApplyNowPostingsUseCase recentApplyNowUseCase;
+    private final QuerySpendUseCase spendUseCase;
 
     /**
      * Constructs the dashboard page controller.
@@ -28,13 +30,16 @@ public class DashboardPageController {
      * @param dashboardUseCase      the inbound port for dashboard data retrieval
      * @param currentOrg            resolves the authenticated user's first organization
      * @param recentApplyNowUseCase inbound port for recent APPLY_NOW postings
+     * @param spendUseCase          inbound port for ledger spend queries
      */
     public DashboardPageController(DashboardUseCase dashboardUseCase,
                                    CurrentOrganizationResolver currentOrg,
-                                   GetRecentApplyNowPostingsUseCase recentApplyNowUseCase) {
+                                   GetRecentApplyNowPostingsUseCase recentApplyNowUseCase,
+                                   QuerySpendUseCase spendUseCase) {
         this.dashboardUseCase = dashboardUseCase;
         this.currentOrg = currentOrg;
         this.recentApplyNowUseCase = recentApplyNowUseCase;
+        this.spendUseCase = spendUseCase;
     }
 
     /**
@@ -56,6 +61,7 @@ public class DashboardPageController {
         model.addAttribute("username", resolved.user().getUsername());
         model.addAttribute("applyNowPostings",
                 recentApplyNowUseCase.getRecentApplyNow(orgId, APPLY_NOW_PANEL_LIMIT));
+        model.addAttribute("projectedAnnualSpend", spendUseCase.projectedAnnualSpend(orgId));
         return "dashboard";
     }
 }

--- a/src/main/resources/templates/dashboard.html
+++ b/src/main/resources/templates/dashboard.html
@@ -20,7 +20,7 @@
         <h1 class="text-2xl font-bold text-gray-900 mb-6">Dashboard</h1>
 
         <!-- Stat Cards -->
-        <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 mb-8">
+        <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6 mb-8">
 
             <!-- Property Count -->
             <div class="bg-white rounded-lg shadow p-6">
@@ -35,12 +35,18 @@
             </div>
 
             <!-- Total Spend -->
-            <div class="bg-white rounded-lg shadow p-6">
-                <div class="text-sm font-medium text-gray-500 uppercase tracking-wide">Total Spend</div>
-                <div class="mt-2 text-3xl font-bold text-indigo-700">
-                    $<span th:text="${#numbers.formatDecimal(summary.totalSpend(), 1, 2)}">0.00</span>
-                </div>
-            </div>
+            <a href="/ledger" class="bg-white rounded-lg shadow p-6 hover:shadow-md transition-shadow">
+                <div class="text-sm font-medium text-gray-500 uppercase tracking-wide">Total spend</div>
+                <div class="mt-2 text-3xl font-bold text-indigo-700"
+                     th:text="${'$' + (summary.totalSpend() != null ? #numbers.formatDecimal(summary.totalSpend(), 1, 'COMMA', 2, 'POINT') : '0.00')}">$0.00</div>
+            </a>
+
+            <!-- Projected Annual -->
+            <a href="/ledger" class="bg-white rounded-lg shadow p-6 hover:shadow-md transition-shadow">
+                <div class="text-sm font-medium text-gray-500 uppercase tracking-wide">Projected annual</div>
+                <div class="mt-2 text-3xl font-bold text-indigo-700"
+                     th:text="${'$' + (projectedAnnualSpend != null ? #numbers.formatDecimal(projectedAnnualSpend, 1, 'COMMA', 2, 'POINT') : '0.00')}">$0.00</div>
+            </a>
 
         </div>
 

--- a/src/test/java/com/majordomo/adapter/in/web/DashboardPageControllerTest.java
+++ b/src/test/java/com/majordomo/adapter/in/web/DashboardPageControllerTest.java
@@ -8,6 +8,7 @@ import com.majordomo.domain.model.envoy.ApplyNowPosting;
 import com.majordomo.domain.model.identity.User;
 import com.majordomo.domain.port.in.DashboardUseCase;
 import com.majordomo.domain.port.in.envoy.GetRecentApplyNowPostingsUseCase;
+import com.majordomo.domain.port.in.ledger.QuerySpendUseCase;
 import com.majordomo.domain.port.out.identity.ApiKeyRepository;
 
 import org.junit.jupiter.api.Test;
@@ -55,6 +56,9 @@ class DashboardPageControllerTest {
     @MockitoBean
     private GetRecentApplyNowPostingsUseCase recentApplyNowUseCase;
 
+    @MockitoBean
+    private QuerySpendUseCase spendUseCase;
+
     /** Authenticated user with an organization membership sees the dashboard. */
     @Test
     @WithMockUser(username = "testuser")
@@ -88,6 +92,35 @@ class DashboardPageControllerTest {
     void dashboardRequiresAuthentication() throws Exception {
         mockMvc.perform(get("/dashboard"))
                 .andExpect(status().is3xxRedirection());
+    }
+
+    /** #241: dashboard exposes projectedAnnualSpend + renders both cards linking to /ledger. */
+    @Test
+    @WithMockUser(username = "testuser")
+    void dashboardExposesSpendCardsLinkingToLedger() throws Exception {
+        UUID userId = UUID.randomUUID();
+        UUID orgId = UUID.randomUUID();
+        User user = new User(userId, "testuser", "test@example.com");
+        DashboardSummary summary = new DashboardSummary(
+                3, 5, List.of(), List.of(), List.of(), new BigDecimal("1234.56"));
+
+        when(currentOrg.resolve(any(UserDetails.class)))
+                .thenReturn(new CurrentOrganizationResolver.Resolved(user, orgId));
+        when(dashboardUseCase.getSummary(orgId)).thenReturn(summary);
+        when(recentApplyNowUseCase.getRecentApplyNow(orgId, 5)).thenReturn(List.of());
+        when(spendUseCase.projectedAnnualSpend(orgId)).thenReturn(new BigDecimal("4800.00"));
+
+        var result = mockMvc.perform(get("/dashboard"))
+                .andExpect(status().isOk())
+                .andExpect(model().attribute("projectedAnnualSpend", new BigDecimal("4800.00")))
+                .andReturn();
+
+        String body = result.getResponse().getContentAsString();
+        // Both spend cards link to the full ledger.
+        org.assertj.core.api.Assertions.assertThat(body)
+                .contains("$1,234.56")
+                .contains("$4,800.00")
+                .contains("href=\"/ledger\"");
     }
 
     /** User with no memberships is redirected to the home page. */


### PR DESCRIPTION
## Summary
- `DashboardPageController` now injects `QuerySpendUseCase` and exposes `projectedAnnualSpend` on the model.
- Total-spend card now formats with thousands separator (`$1,234.56` instead of `$0.00`) and links to `/ledger`.
- New "Projected annual" card alongside, also linked to `/ledger`.
- Stat grid widened from 3 to 4 columns.

## Test plan
- [x] `./mvnw verify -DskipITs` green (521 tests, 0 failures, checkstyle clean)
- [x] Slice tests added: model exposes `projectedAnnualSpend`, both cards render formatted values, both cards have `href="/ledger"`.
- [ ] `gh pr checks` green (verify post-push, CodeQL included).

🤖 Generated with [Claude Code](https://claude.com/claude-code)