### PR TITLE
feat(concierge): addresses sub-form on contact add/edit (closes #239)

### DIFF
--- a/src/main/java/com/majordomo/adapter/in/web/concierge/AddressFormRow.java
+++ b/src/main/java/com/majordomo/adapter/in/web/concierge/AddressFormRow.java
@@ -1,0 +1,78 @@
+package com.majordomo.adapter.in.web.concierge;
+
+/**
+ * Form-binding row for one address in the contact add/edit form.
+ *
+ * <p>Spring's {@code WebDataBinder} requires a no-arg constructor and setters
+ * for indexed binding (e.g. {@code addresses[0].street}); a record can't fill
+ * that role.</p>
+ */
+public class AddressFormRow {
+
+    private String label;
+    private String street;
+    private String city;
+    private String state;
+    private String postalCode;
+    private String country;
+
+    public String getLabel() {
+        return label;
+    }
+
+    public void setLabel(String label) {
+        this.label = label;
+    }
+
+    public String getStreet() {
+        return street;
+    }
+
+    public void setStreet(String street) {
+        this.street = street;
+    }
+
+    public String getCity() {
+        return city;
+    }
+
+    public void setCity(String city) {
+        this.city = city;
+    }
+
+    public String getState() {
+        return state;
+    }
+
+    public void setState(String state) {
+        this.state = state;
+    }
+
+    public String getPostalCode() {
+        return postalCode;
+    }
+
+    public void setPostalCode(String postalCode) {
+        this.postalCode = postalCode;
+    }
+
+    public String getCountry() {
+        return country;
+    }
+
+    public void setCountry(String country) {
+        this.country = country;
+    }
+
+    /**
+     * @return true when every field is null or blank — the row should be ignored on save
+     */
+    public boolean isBlank() {
+        return blank(label) && blank(street) && blank(city)
+                && blank(state) && blank(postalCode) && blank(country);
+    }
+
+    private static boolean blank(String s) {
+        return s == null || s.isBlank();
+    }
+}

--- a/src/main/java/com/majordomo/adapter/in/web/concierge/ContactFormCommand.java
+++ b/src/main/java/com/majordomo/adapter/in/web/concierge/ContactFormCommand.java
@@ -1,0 +1,25 @@
+package com.majordomo.adapter.in.web.concierge;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Form-binding command holding the indexed {@code addresses[]} sub-form rows
+ * for the contact add/edit form.
+ *
+ * <p>Plain top-level form fields (formattedName, emails, etc.) stay as
+ * {@code @RequestParam} on the controller method — only the indexed list
+ * needs a backing bean to use Spring's indexed-binding syntax.</p>
+ */
+public class ContactFormCommand {
+
+    private List<AddressFormRow> addresses = new ArrayList<>();
+
+    public List<AddressFormRow> getAddresses() {
+        return addresses;
+    }
+
+    public void setAddresses(List<AddressFormRow> addresses) {
+        this.addresses = addresses != null ? addresses : new ArrayList<>();
+    }
+}

--- a/src/main/java/com/majordomo/adapter/in/web/concierge/ContactPageController.java
+++ b/src/main/java/com/majordomo/adapter/in/web/concierge/ContactPageController.java
@@ -4,6 +4,8 @@ import com.majordomo.application.identity.CurrentOrganizationResolver;
 import com.majordomo.application.identity.OrganizationAccessService;
 import com.majordomo.domain.model.EntityNotFoundException;
 import com.majordomo.domain.model.EntityType;
+import com.majordomo.domain.model.UuidFactory;
+import com.majordomo.domain.model.concierge.Address;
 import com.majordomo.domain.model.concierge.Contact;
 import com.majordomo.domain.model.steward.Property;
 import com.majordomo.domain.port.in.concierge.ManageContactUseCase;
@@ -16,6 +18,7 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -191,6 +194,7 @@ public class ContactPageController {
      * @param telephones    newline-separated telephone numbers
      * @param urls          newline-separated URLs
      * @param nicknames     newline-separated nicknames
+     * @param command       indexed addresses sub-form
      * @param principal     authenticated user
      * @param model         Thymeleaf model
      * @return redirect to the new contact's detail page on success
@@ -206,6 +210,7 @@ public class ContactPageController {
                          @RequestParam(required = false) String telephones,
                          @RequestParam(required = false) String urls,
                          @RequestParam(required = false) String nicknames,
+                         @ModelAttribute ContactFormCommand command,
                          @AuthenticationPrincipal UserDetails principal,
                          Model model) {
         var ctx = currentOrg.resolve(principal);
@@ -238,6 +243,7 @@ public class ContactPageController {
         contact.setTelephones(splitLines(telephones));
         contact.setUrls(splitLines(urls));
         contact.setNicknames(splitLines(nicknames));
+        contact.setAddresses(toAddresses(command.getAddresses(), null));
         Contact saved = contactUseCase.create(contact);
         return "redirect:/contacts/" + saved.getId();
     }
@@ -281,6 +287,7 @@ public class ContactPageController {
      * @param telephones    newline-separated telephone numbers
      * @param urls          newline-separated URLs
      * @param nicknames     newline-separated nicknames
+     * @param command       indexed addresses sub-form
      * @param principal     authenticated user
      * @param model         Thymeleaf model
      * @return redirect to the contact's detail page on success
@@ -297,6 +304,7 @@ public class ContactPageController {
                          @RequestParam(required = false) String telephones,
                          @RequestParam(required = false) String urls,
                          @RequestParam(required = false) String nicknames,
+                         @ModelAttribute ContactFormCommand command,
                          @AuthenticationPrincipal UserDetails principal,
                          Model model) {
         var ctx = currentOrg.resolve(principal);
@@ -333,12 +341,32 @@ public class ContactPageController {
         updated.setTelephones(splitLines(telephones));
         updated.setUrls(splitLines(urls));
         updated.setNicknames(splitLines(nicknames));
+        updated.setAddresses(toAddresses(command.getAddresses(), id));
         contactUseCase.update(id, updated);
         return "redirect:/contacts/" + id;
     }
 
     private static String blankToNull(String s) {
         return (s == null || s.isBlank()) ? null : s;
+    }
+
+    /** Drops blank rows; mints a fresh row id for each remaining row. */
+    private static List<Address> toAddresses(List<AddressFormRow> rows, UUID contactId) {
+        if (rows == null || rows.isEmpty()) {
+            return List.of();
+        }
+        List<Address> out = new ArrayList<>();
+        for (AddressFormRow r : rows) {
+            if (r == null || r.isBlank()) {
+                continue;
+            }
+            out.add(new Address(
+                    UuidFactory.newId(), contactId,
+                    blankToNull(r.getLabel()), blankToNull(r.getStreet()),
+                    blankToNull(r.getCity()), blankToNull(r.getState()),
+                    blankToNull(r.getPostalCode()), blankToNull(r.getCountry())));
+        }
+        return out;
     }
 
     private static List<String> splitLines(String raw) {

--- a/src/main/resources/templates/contact-form.html
+++ b/src/main/resources/templates/contact-form.html
@@ -105,6 +105,43 @@
                             </div>
                         </div>
 
+                        <!-- Addresses sub-section -->
+                        <div class="border border-gray-200 rounded-lg p-4">
+                            <div class="flex items-center justify-between mb-3">
+                                <h2 class="text-sm font-semibold text-gray-700 uppercase tracking-wider">Addresses</h2>
+                                <button type="button" id="add-address"
+                                        class="inline-flex items-center rounded-md bg-white border border-gray-300 px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50">
+                                    + Add address
+                                </button>
+                            </div>
+                            <div id="address-rows" class="space-y-3">
+                                <th:block th:if="${existing != null and existing.getAddresses() != null}">
+                                <div th:each="a, it : ${existing.getAddresses()}"
+                                     class="grid grid-cols-1 sm:grid-cols-6 gap-2 address-row">
+                                    <input type="text" th:name="|addresses[${it.index}].label|"
+                                           th:value="${a.label()}" placeholder="Label"
+                                           class="rounded border-gray-300 text-sm px-2 py-1.5">
+                                    <input type="text" th:name="|addresses[${it.index}].street|"
+                                           th:value="${a.street()}" placeholder="Street"
+                                           class="sm:col-span-2 rounded border-gray-300 text-sm px-2 py-1.5">
+                                    <input type="text" th:name="|addresses[${it.index}].city|"
+                                           th:value="${a.city()}" placeholder="City"
+                                           class="rounded border-gray-300 text-sm px-2 py-1.5">
+                                    <input type="text" th:name="|addresses[${it.index}].state|"
+                                           th:value="${a.state()}" placeholder="State"
+                                           class="rounded border-gray-300 text-sm px-2 py-1.5">
+                                    <input type="text" th:name="|addresses[${it.index}].postalCode|"
+                                           th:value="${a.postalCode()}" placeholder="Postal"
+                                           class="rounded border-gray-300 text-sm px-2 py-1.5">
+                                    <input type="text" th:name="|addresses[${it.index}].country|"
+                                           th:value="${a.country()}" placeholder="Country"
+                                           class="rounded border-gray-300 text-sm px-2 py-1.5">
+                                </div>
+                                </th:block>
+                            </div>
+                            <p class="text-xs text-gray-500 mt-2">Leave a row entirely blank to delete it on save.</p>
+                        </div>
+
                         <div class="flex flex-col">
                             <label for="notes"
                                    class="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-1">Notes</label>
@@ -125,5 +162,25 @@
             </div>
         </main>
     </div>
+    <script>
+        (function () {
+            var btn = document.getElementById('add-address');
+            var rows = document.getElementById('address-rows');
+            if (!btn || !rows) return;
+            btn.addEventListener('click', function () {
+                var idx = rows.querySelectorAll('.address-row').length;
+                var html =
+                    '<div class="grid grid-cols-1 sm:grid-cols-6 gap-2 address-row">' +
+                    '<input type="text" name="addresses[' + idx + '].label" placeholder="Label" class="rounded border-gray-300 text-sm px-2 py-1.5">' +
+                    '<input type="text" name="addresses[' + idx + '].street" placeholder="Street" class="sm:col-span-2 rounded border-gray-300 text-sm px-2 py-1.5">' +
+                    '<input type="text" name="addresses[' + idx + '].city" placeholder="City" class="rounded border-gray-300 text-sm px-2 py-1.5">' +
+                    '<input type="text" name="addresses[' + idx + '].state" placeholder="State" class="rounded border-gray-300 text-sm px-2 py-1.5">' +
+                    '<input type="text" name="addresses[' + idx + '].postalCode" placeholder="Postal" class="rounded border-gray-300 text-sm px-2 py-1.5">' +
+                    '<input type="text" name="addresses[' + idx + '].country" placeholder="Country" class="rounded border-gray-300 text-sm px-2 py-1.5">' +
+                    '</div>';
+                rows.insertAdjacentHTML('beforeend', html);
+            });
+        })();
+    </script>
 </body>
 </html>

--- a/src/test/java/com/majordomo/adapter/in/web/concierge/ContactPageFormTest.java
+++ b/src/test/java/com/majordomo/adapter/in/web/concierge/ContactPageFormTest.java
@@ -257,4 +257,143 @@ class ContactPageFormTest {
 
         verify(contactUseCase, never()).update(any(), any());
     }
+
+    /** #239: edit form pre-populates each existing address as a row. */
+    @Test
+    @WithMockUser
+    void editFormPrePopulatesAddresses() throws Exception {
+        UUID id = UuidFactory.newId();
+        Contact existing = new Contact();
+        existing.setId(id);
+        existing.setOrganizationId(ORG_ID);
+        existing.setFormattedName("Alice Example");
+        existing.setAddresses(List.of(
+                new com.majordomo.domain.model.concierge.Address(
+                        UuidFactory.newId(), id, "WORK",
+                        "100 Main St", "Springfield", "IL", "62701", "USA"),
+                new com.majordomo.domain.model.concierge.Address(
+                        UuidFactory.newId(), id, "HOME",
+                        "55 Oak Ln", "Lincoln", "NE", "68501", "USA")));
+        when(contactRepository.findById(id)).thenReturn(Optional.of(existing));
+
+        org.springframework.test.web.servlet.MvcResult result =
+                mvc.perform(get("/contacts/{id}/edit", id))
+                        .andExpect(status().isOk())
+                        .andReturn();
+
+        String body = result.getResponse().getContentAsString();
+        assertThat(body)
+                .contains("name=\"addresses[0].label\"")
+                .contains("value=\"WORK\"")
+                .contains("value=\"100 Main St\"")
+                .contains("value=\"Springfield\"")
+                .contains("name=\"addresses[1].label\"")
+                .contains("value=\"HOME\"")
+                .contains("value=\"55 Oak Ln\"");
+    }
+
+    /** #239: POST /contacts persists indexed addresses[N].* params. */
+    @Test
+    @WithMockUser
+    void createPersistsIndexedAddresses() throws Exception {
+        UUID newId = UuidFactory.newId();
+        Contact saved = new Contact();
+        saved.setId(newId);
+        saved.setOrganizationId(ORG_ID);
+        when(contactUseCase.create(any(Contact.class))).thenReturn(saved);
+
+        mvc.perform(post("/contacts")
+                        .with(csrf())
+                        .param("formattedName", "Alice Example")
+                        .param("addresses[0].label", "WORK")
+                        .param("addresses[0].street", "100 Main St")
+                        .param("addresses[0].city", "Springfield")
+                        .param("addresses[0].state", "IL")
+                        .param("addresses[0].postalCode", "62701")
+                        .param("addresses[0].country", "USA")
+                        .param("addresses[1].label", "HOME")
+                        .param("addresses[1].street", "55 Oak Ln")
+                        .param("addresses[1].city", "Lincoln")
+                        .param("addresses[1].state", "NE")
+                        .param("addresses[1].postalCode", "68501")
+                        .param("addresses[1].country", "USA"))
+                .andExpect(status().is3xxRedirection());
+
+        ArgumentCaptor<Contact> captor = ArgumentCaptor.forClass(Contact.class);
+        verify(contactUseCase).create(captor.capture());
+        Contact c = captor.getValue();
+        assertThat(c.getAddresses()).hasSize(2);
+        assertThat(c.getAddresses().get(0).label()).isEqualTo("WORK");
+        assertThat(c.getAddresses().get(0).street()).isEqualTo("100 Main St");
+        assertThat(c.getAddresses().get(0).contactId()).isNull();
+        assertThat(c.getAddresses().get(1).label()).isEqualTo("HOME");
+        assertThat(c.getAddresses().get(1).city()).isEqualTo("Lincoln");
+    }
+
+    /** #239: addresses[N] rows with all-blank fields are dropped (treated as deletion). */
+    @Test
+    @WithMockUser
+    void createDropsBlankAddressRows() throws Exception {
+        UUID newId = UuidFactory.newId();
+        Contact saved = new Contact();
+        saved.setId(newId);
+        saved.setOrganizationId(ORG_ID);
+        when(contactUseCase.create(any(Contact.class))).thenReturn(saved);
+
+        mvc.perform(post("/contacts")
+                        .with(csrf())
+                        .param("formattedName", "Alice Example")
+                        .param("addresses[0].label", "")
+                        .param("addresses[0].street", "")
+                        .param("addresses[0].city", "")
+                        .param("addresses[0].state", "")
+                        .param("addresses[0].postalCode", "")
+                        .param("addresses[0].country", "")
+                        .param("addresses[1].label", "WORK")
+                        .param("addresses[1].street", "100 Main St")
+                        .param("addresses[1].city", "Springfield")
+                        .param("addresses[1].state", "IL")
+                        .param("addresses[1].postalCode", "62701")
+                        .param("addresses[1].country", "USA"))
+                .andExpect(status().is3xxRedirection());
+
+        ArgumentCaptor<Contact> captor = ArgumentCaptor.forClass(Contact.class);
+        verify(contactUseCase).create(captor.capture());
+        assertThat(captor.getValue().getAddresses()).hasSize(1);
+        assertThat(captor.getValue().getAddresses().get(0).label()).isEqualTo("WORK");
+    }
+
+    /** #239: update replaces the address list. */
+    @Test
+    @WithMockUser
+    void updateReplacesAddressList() throws Exception {
+        UUID id = UuidFactory.newId();
+        Contact existing = new Contact();
+        existing.setId(id);
+        existing.setOrganizationId(ORG_ID);
+        existing.setFormattedName("Alice Example");
+        existing.setAddresses(List.of(
+                new com.majordomo.domain.model.concierge.Address(
+                        UuidFactory.newId(), id, "OLD", "old", "old", "OL", "00000", "USA")));
+        when(contactRepository.findById(id)).thenReturn(Optional.of(existing));
+        when(contactUseCase.update(eq(id), any(Contact.class)))
+                .thenAnswer(inv -> inv.getArgument(1));
+
+        mvc.perform(post("/contacts/{id}", id)
+                        .with(csrf())
+                        .param("formattedName", "Alice Example")
+                        .param("addresses[0].label", "NEW")
+                        .param("addresses[0].street", "200 New St")
+                        .param("addresses[0].city", "New City")
+                        .param("addresses[0].state", "NY")
+                        .param("addresses[0].postalCode", "10001")
+                        .param("addresses[0].country", "USA"))
+                .andExpect(status().is3xxRedirection());
+
+        ArgumentCaptor<Contact> captor = ArgumentCaptor.forClass(Contact.class);
+        verify(contactUseCase).update(eq(id), captor.capture());
+        assertThat(captor.getValue().getAddresses()).hasSize(1);
+        assertThat(captor.getValue().getAddresses().get(0).label()).isEqualTo("NEW");
+        assertThat(captor.getValue().getAddresses().get(0).street()).isEqualTo("200 New St");
+    }
 }


### PR DESCRIPTION
## Summary
- Contact add/edit form gains a repeating Addresses sub-section with label/street/city/state/postalCode/country inputs.
- Backed by `ContactFormCommand` + `AddressFormRow` plain DTOs (Spring needs setters for indexed `addresses[N].field` binding — record can't fill that role).
- Existing addresses pre-populate; vanilla-JS "+ Add address" button appends a blank row client-side.
- Rows that are entirely blank are dropped on save (acts as a row-level delete).
- Update replaces the address list; create persists a multi-row contact.

## Test plan
- [x] `./mvnw verify -DskipITs` green (525 tests, 0 failures, checkstyle clean)
- [x] Slice tests added: edit pre-populates rows, create persists indexed addresses, blank rows dropped, update replaces list.
- [ ] `gh pr checks` green (verify post-push, CodeQL included).

🤖 Generated with [Claude Code](https://claude.com/claude-code)