### PR TITLE
feat(steward+concierge): link/unlink contacts ↔ properties (closes #240)

### DIFF
--- a/src/main/java/com/majordomo/adapter/in/web/concierge/ContactPageController.java
+++ b/src/main/java/com/majordomo/adapter/in/web/concierge/ContactPageController.java
@@ -8,10 +8,12 @@ import com.majordomo.domain.model.UuidFactory;
 import com.majordomo.domain.model.concierge.Address;
 import com.majordomo.domain.model.concierge.Contact;
 import com.majordomo.domain.model.steward.Property;
+import com.majordomo.domain.model.steward.PropertyContact;
 import com.majordomo.domain.port.in.concierge.ManageContactUseCase;
 import com.majordomo.domain.port.in.steward.ManagePropertyUseCase;
 import com.majordomo.domain.port.out.concierge.ContactRepository;
 import com.majordomo.domain.port.out.steward.PropertyContactRepository;
+import com.majordomo.domain.port.out.steward.PropertyRepository;
 
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -40,6 +42,7 @@ public class ContactPageController {
     private final ManageContactUseCase contactUseCase;
     private final ContactRepository contactRepository;
     private final ManagePropertyUseCase propertyUseCase;
+    private final PropertyRepository propertyRepository;
     private final PropertyContactRepository propertyContactRepository;
     private final CurrentOrganizationResolver currentOrg;
     private final OrganizationAccessService organizationAccessService;
@@ -50,6 +53,7 @@ public class ContactPageController {
      * @param contactUseCase            inbound port for contact management
      * @param contactRepository         outbound port for contact reads (used by list view)
      * @param propertyUseCase           inbound port for property lookups
+     * @param propertyRepository        outbound port for property reads (link picker)
      * @param propertyContactRepository outbound port for property–contact associations
      * @param currentOrg                resolves the authenticated user's organization
      * @param organizationAccessService verifies caller has access to a given organization
@@ -57,12 +61,14 @@ public class ContactPageController {
     public ContactPageController(ManageContactUseCase contactUseCase,
                                  ContactRepository contactRepository,
                                  ManagePropertyUseCase propertyUseCase,
+                                 PropertyRepository propertyRepository,
                                  PropertyContactRepository propertyContactRepository,
                                  CurrentOrganizationResolver currentOrg,
                                  OrganizationAccessService organizationAccessService) {
         this.contactUseCase = contactUseCase;
         this.contactRepository = contactRepository;
         this.propertyUseCase = propertyUseCase;
+        this.propertyRepository = propertyRepository;
         this.propertyContactRepository = propertyContactRepository;
         this.currentOrg = currentOrg;
         this.organizationAccessService = organizationAccessService;
@@ -149,18 +155,47 @@ public class ContactPageController {
                 .orElseThrow(() -> new EntityNotFoundException(EntityType.CONTACT.name(), id));
         organizationAccessService.verifyAccess(contact.getOrganizationId());
 
-        List<Property> linkedProperties = propertyContactRepository.findByContactId(id).stream()
-                .map(pc -> propertyUseCase.findById(pc.getPropertyId()).orElse(null))
-                .filter(p -> p != null)
-                .sorted(Comparator.comparing(Property::getName,
+        List<PropertyContact> activeLinks = propertyContactRepository.findByContactId(id).stream()
+                .filter(pc -> pc.getArchivedAt() == null)
+                .toList();
+        List<LinkedPropertyRow> linkedRows = activeLinks.stream()
+                .map(pc -> {
+                    Property p = propertyUseCase.findById(pc.getPropertyId()).orElse(null);
+                    return p == null ? null : new LinkedPropertyRow(pc, p);
+                })
+                .filter(r -> r != null)
+                .sorted(Comparator.comparing((LinkedPropertyRow r) -> r.property().getName(),
                         Comparator.nullsLast(String.CASE_INSENSITIVE_ORDER)))
                 .toList();
 
+        java.util.Set<UUID> linkedIds = activeLinks.stream()
+                .map(PropertyContact::getPropertyId)
+                .collect(java.util.stream.Collectors.toSet());
+        List<Property> propertyCandidates =
+                propertyRepository.findByOrganizationId(contact.getOrganizationId()).stream()
+                        .filter(p -> p.getArchivedAt() == null)
+                        .filter(p -> !linkedIds.contains(p.getId()))
+                        .sorted(Comparator.comparing(Property::getName,
+                                Comparator.nullsLast(String.CASE_INSENSITIVE_ORDER)))
+                        .toList();
+
         model.addAttribute("contact", contact);
-        model.addAttribute("linkedProperties", linkedProperties);
+        model.addAttribute("linkedRows", linkedRows);
+        model.addAttribute("propertyCandidates", propertyCandidates);
+        model.addAttribute("contactRoles",
+                com.majordomo.domain.model.concierge.ContactRole.values());
         model.addAttribute("username", ctx.user().getUsername());
         return "contact-detail";
     }
+
+    /**
+     * View-model row tying a property to its PropertyContact link id (needed by
+     * the unlink form on the contact-detail page).
+     *
+     * @param link     the underlying PropertyContact row
+     * @param property the linked property
+     */
+    public record LinkedPropertyRow(PropertyContact link, Property property) { }
 
     /**
      * Renders the new-contact form.

--- a/src/main/java/com/majordomo/adapter/in/web/concierge/ContactPropertyLinkController.java
+++ b/src/main/java/com/majordomo/adapter/in/web/concierge/ContactPropertyLinkController.java
@@ -1,0 +1,143 @@
+package com.majordomo.adapter.in.web.concierge;
+
+import com.majordomo.application.identity.CurrentOrganizationResolver;
+import com.majordomo.application.identity.OrganizationAccessService;
+import com.majordomo.domain.model.EntityNotFoundException;
+import com.majordomo.domain.model.EntityType;
+import com.majordomo.domain.model.UuidFactory;
+import com.majordomo.domain.model.concierge.Contact;
+import com.majordomo.domain.model.concierge.ContactRole;
+import com.majordomo.domain.model.steward.Property;
+import com.majordomo.domain.model.steward.PropertyContact;
+import com.majordomo.domain.port.in.steward.ManagePropertyUseCase;
+import com.majordomo.domain.port.out.concierge.ContactRepository;
+import com.majordomo.domain.port.out.steward.PropertyContactRepository;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.time.Instant;
+import java.util.Locale;
+import java.util.UUID;
+
+/**
+ * Web routes for linking and unlinking properties on a contact's detail page.
+ * Mirrors {@link com.majordomo.adapter.in.web.steward.PropertyContactLinkController}
+ * for the contact-side detail page.
+ */
+@Controller
+@RequestMapping("/contacts")
+public class ContactPropertyLinkController {
+
+    private final ContactRepository contactRepository;
+    private final ManagePropertyUseCase propertyUseCase;
+    private final PropertyContactRepository propertyContactRepository;
+    private final CurrentOrganizationResolver currentOrg;
+    private final OrganizationAccessService organizationAccessService;
+
+    /**
+     * Constructs the contact↔property link controller.
+     *
+     * @param contactRepository         outbound port for contact reads
+     * @param propertyUseCase           inbound port for property lookups
+     * @param propertyContactRepository outbound port for property–contact rows
+     * @param currentOrg                resolves the authenticated user's organization
+     * @param organizationAccessService verifies caller has access to a given organization
+     */
+    public ContactPropertyLinkController(ContactRepository contactRepository,
+                                         ManagePropertyUseCase propertyUseCase,
+                                         PropertyContactRepository propertyContactRepository,
+                                         CurrentOrganizationResolver currentOrg,
+                                         OrganizationAccessService organizationAccessService) {
+        this.contactRepository = contactRepository;
+        this.propertyUseCase = propertyUseCase;
+        this.propertyContactRepository = propertyContactRepository;
+        this.currentOrg = currentOrg;
+        this.organizationAccessService = organizationAccessService;
+    }
+
+    /**
+     * Links a property to a contact.
+     *
+     * @param id         contact UUID
+     * @param propertyId property to link
+     * @param role       role classification (defaults to OTHER if blank/unknown)
+     * @param notes      optional free-form notes
+     * @param principal  authenticated user
+     * @return redirect to the contact detail page
+     */
+    @PostMapping("/{id}/properties")
+    public String link(@PathVariable UUID id,
+                       @RequestParam UUID propertyId,
+                       @RequestParam(required = false) String role,
+                       @RequestParam(required = false) String notes,
+                       @AuthenticationPrincipal UserDetails principal) {
+        var ctx = currentOrg.resolve(principal);
+        if (ctx.organizationId() == null) {
+            return "redirect:/";
+        }
+        Contact contact = contactRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(EntityType.CONTACT.name(), id));
+        organizationAccessService.verifyAccess(contact.getOrganizationId());
+        Property property = propertyUseCase.findById(propertyId)
+                .orElseThrow(() -> new EntityNotFoundException(EntityType.PROPERTY.name(), propertyId));
+        organizationAccessService.verifyAccess(property.getOrganizationId());
+
+        PropertyContact link = new PropertyContact();
+        link.setId(UuidFactory.newId());
+        link.setPropertyId(propertyId);
+        link.setContactId(id);
+        link.setRole(parseRole(role));
+        link.setNotes(blankToNull(notes));
+        propertyContactRepository.save(link);
+        return "redirect:/contacts/" + id;
+    }
+
+    /**
+     * Unlinks (soft-deletes) a property association from this contact.
+     *
+     * @param id        contact UUID
+     * @param linkId    PropertyContact row UUID
+     * @param principal authenticated user
+     * @return redirect to the contact detail page
+     */
+    @PostMapping("/{id}/properties/{linkId}/unlink")
+    public String unlink(@PathVariable UUID id,
+                         @PathVariable UUID linkId,
+                         @AuthenticationPrincipal UserDetails principal) {
+        var ctx = currentOrg.resolve(principal);
+        if (ctx.organizationId() == null) {
+            return "redirect:/";
+        }
+        Contact contact = contactRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(EntityType.CONTACT.name(), id));
+        organizationAccessService.verifyAccess(contact.getOrganizationId());
+        propertyContactRepository.findById(linkId).ifPresent(link -> {
+            if (link.getContactId().equals(id)) {
+                link.setArchivedAt(Instant.now());
+                propertyContactRepository.save(link);
+            }
+        });
+        return "redirect:/contacts/" + id;
+    }
+
+    private static ContactRole parseRole(String role) {
+        if (role == null || role.isBlank()) {
+            return ContactRole.OTHER;
+        }
+        try {
+            return ContactRole.valueOf(role.trim().toUpperCase(Locale.ROOT));
+        } catch (IllegalArgumentException ex) {
+            return ContactRole.OTHER;
+        }
+    }
+
+    private static String blankToNull(String s) {
+        return (s == null || s.isBlank()) ? null : s;
+    }
+}

--- a/src/main/java/com/majordomo/adapter/in/web/steward/PropertyContactLinkController.java
+++ b/src/main/java/com/majordomo/adapter/in/web/steward/PropertyContactLinkController.java
@@ -1,0 +1,143 @@
+package com.majordomo.adapter.in.web.steward;
+
+import com.majordomo.application.identity.CurrentOrganizationResolver;
+import com.majordomo.application.identity.OrganizationAccessService;
+import com.majordomo.domain.model.EntityNotFoundException;
+import com.majordomo.domain.model.EntityType;
+import com.majordomo.domain.model.UuidFactory;
+import com.majordomo.domain.model.concierge.Contact;
+import com.majordomo.domain.model.concierge.ContactRole;
+import com.majordomo.domain.model.steward.Property;
+import com.majordomo.domain.model.steward.PropertyContact;
+import com.majordomo.domain.port.in.steward.ManagePropertyUseCase;
+import com.majordomo.domain.port.out.concierge.ContactRepository;
+import com.majordomo.domain.port.out.steward.PropertyContactRepository;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.time.Instant;
+import java.util.Locale;
+import java.util.UUID;
+
+/**
+ * Web routes for linking and unlinking contacts on a property's detail page.
+ * Sibling to {@link PropertyPageController}, kept separate to keep that class
+ * under the file-length budget.
+ */
+@Controller
+@RequestMapping("/properties")
+public class PropertyContactLinkController {
+
+    private final ManagePropertyUseCase propertyUseCase;
+    private final ContactRepository contactRepository;
+    private final PropertyContactRepository propertyContactRepository;
+    private final CurrentOrganizationResolver currentOrg;
+    private final OrganizationAccessService organizationAccessService;
+
+    /**
+     * Constructs the property↔contact link controller.
+     *
+     * @param propertyUseCase           inbound port for property lookups
+     * @param contactRepository         outbound port for contact reads
+     * @param propertyContactRepository outbound port for property–contact rows
+     * @param currentOrg                resolves the authenticated user's organization
+     * @param organizationAccessService verifies caller has access to a given organization
+     */
+    public PropertyContactLinkController(ManagePropertyUseCase propertyUseCase,
+                                         ContactRepository contactRepository,
+                                         PropertyContactRepository propertyContactRepository,
+                                         CurrentOrganizationResolver currentOrg,
+                                         OrganizationAccessService organizationAccessService) {
+        this.propertyUseCase = propertyUseCase;
+        this.contactRepository = contactRepository;
+        this.propertyContactRepository = propertyContactRepository;
+        this.currentOrg = currentOrg;
+        this.organizationAccessService = organizationAccessService;
+    }
+
+    /**
+     * Links a contact to a property.
+     *
+     * @param id        property UUID
+     * @param contactId the contact to link
+     * @param role      role classification (defaults to OTHER if blank/unknown)
+     * @param notes     optional free-form notes
+     * @param principal authenticated user
+     * @return redirect to the property detail page
+     */
+    @PostMapping("/{id}/contacts")
+    public String link(@PathVariable UUID id,
+                       @RequestParam UUID contactId,
+                       @RequestParam(required = false) String role,
+                       @RequestParam(required = false) String notes,
+                       @AuthenticationPrincipal UserDetails principal) {
+        var ctx = currentOrg.resolve(principal);
+        if (ctx.organizationId() == null) {
+            return "redirect:/";
+        }
+        Property property = propertyUseCase.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(EntityType.PROPERTY.name(), id));
+        organizationAccessService.verifyAccess(property.getOrganizationId());
+        Contact contact = contactRepository.findById(contactId)
+                .orElseThrow(() -> new EntityNotFoundException(EntityType.CONTACT.name(), contactId));
+        organizationAccessService.verifyAccess(contact.getOrganizationId());
+
+        PropertyContact link = new PropertyContact();
+        link.setId(UuidFactory.newId());
+        link.setPropertyId(id);
+        link.setContactId(contactId);
+        link.setRole(parseRole(role));
+        link.setNotes(blankToNull(notes));
+        propertyContactRepository.save(link);
+        return "redirect:/properties/" + id;
+    }
+
+    /**
+     * Unlinks (soft-deletes) a contact association.
+     *
+     * @param id        property UUID
+     * @param linkId    PropertyContact row UUID
+     * @param principal authenticated user
+     * @return redirect to the property detail page
+     */
+    @PostMapping("/{id}/contacts/{linkId}/unlink")
+    public String unlink(@PathVariable UUID id,
+                         @PathVariable UUID linkId,
+                         @AuthenticationPrincipal UserDetails principal) {
+        var ctx = currentOrg.resolve(principal);
+        if (ctx.organizationId() == null) {
+            return "redirect:/";
+        }
+        Property property = propertyUseCase.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(EntityType.PROPERTY.name(), id));
+        organizationAccessService.verifyAccess(property.getOrganizationId());
+        propertyContactRepository.findById(linkId).ifPresent(link -> {
+            if (link.getPropertyId().equals(id)) {
+                link.setArchivedAt(Instant.now());
+                propertyContactRepository.save(link);
+            }
+        });
+        return "redirect:/properties/" + id;
+    }
+
+    private static ContactRole parseRole(String role) {
+        if (role == null || role.isBlank()) {
+            return ContactRole.OTHER;
+        }
+        try {
+            return ContactRole.valueOf(role.trim().toUpperCase(Locale.ROOT));
+        } catch (IllegalArgumentException ex) {
+            return ContactRole.OTHER;
+        }
+    }
+
+    private static String blankToNull(String s) {
+        return (s == null || s.isBlank()) ? null : s;
+    }
+}

--- a/src/main/java/com/majordomo/adapter/in/web/steward/PropertyPageController.java
+++ b/src/main/java/com/majordomo/adapter/in/web/steward/PropertyPageController.java
@@ -3,6 +3,7 @@ package com.majordomo.adapter.in.web.steward;
 import com.majordomo.application.identity.CurrentOrganizationResolver;
 import com.majordomo.application.identity.OrganizationAccessService;
 import com.majordomo.domain.model.concierge.Contact;
+import com.majordomo.domain.model.concierge.ContactRole;
 import com.majordomo.domain.model.herald.MaintenanceSchedule;
 import com.majordomo.domain.model.herald.ServiceRecord;
 import com.majordomo.domain.model.steward.Property;
@@ -11,6 +12,7 @@ import com.majordomo.domain.port.in.ManageAttachmentUseCase;
 import com.majordomo.domain.port.in.concierge.ManageContactUseCase;
 import com.majordomo.domain.port.in.herald.ManageScheduleUseCase;
 import com.majordomo.domain.port.in.steward.ManagePropertyUseCase;
+import com.majordomo.domain.port.out.concierge.ContactRepository;
 import com.majordomo.domain.port.out.herald.ServiceRecordRepository;
 import com.majordomo.domain.port.out.identity.MembershipRepository;
 import com.majordomo.domain.port.out.identity.UserRepository;
@@ -51,6 +53,7 @@ public class PropertyPageController {
     private final ManageAttachmentUseCase attachmentUseCase;
     private final PropertyContactRepository propertyContactRepository;
     private final PropertyRepository propertyRepository;
+    private final ContactRepository contactRepository;
     private final ServiceRecordRepository serviceRecordRepository;
     private final CurrentOrganizationResolver currentOrg;
     private final OrganizationAccessService organizationAccessService;
@@ -79,6 +82,7 @@ public class PropertyPageController {
      * @param attachmentUseCase         the inbound port for attachment management
      * @param propertyContactRepository the outbound port for property-contact associations
      * @param propertyRepository        the outbound port for property reads (used by the list view)
+     * @param contactRepository         the outbound port for contact reads (used by the link picker)
      * @param serviceRecordRepository   the outbound port for service-record reads (recent activity panel)
      * @param currentOrg                resolves the authenticated user's organization
      * @param organizationAccessService verifies the caller has access to a given organization
@@ -91,6 +95,7 @@ public class PropertyPageController {
                                   ManageAttachmentUseCase attachmentUseCase,
                                   PropertyContactRepository propertyContactRepository,
                                   PropertyRepository propertyRepository,
+                                  ContactRepository contactRepository,
                                   ServiceRecordRepository serviceRecordRepository,
                                   CurrentOrganizationResolver currentOrg,
                                   OrganizationAccessService organizationAccessService,
@@ -102,6 +107,7 @@ public class PropertyPageController {
         this.attachmentUseCase = attachmentUseCase;
         this.propertyContactRepository = propertyContactRepository;
         this.propertyRepository = propertyRepository;
+        this.contactRepository = contactRepository;
         this.serviceRecordRepository = serviceRecordRepository;
         this.currentOrg = currentOrg;
         this.organizationAccessService = organizationAccessService;
@@ -427,10 +433,21 @@ public class PropertyPageController {
 
         List<Property> children = propertyUseCase.findByParentId(id);
 
-        List<PropertyContact> propertyContacts = propertyContactRepository.findByPropertyId(id);
+        List<PropertyContact> propertyContacts = propertyContactRepository.findByPropertyId(id).stream()
+                .filter(pc -> pc.getArchivedAt() == null)
+                .toList();
         List<Contact> contacts = propertyContacts.stream()
                 .map(pc -> contactUseCase.findById(pc.getContactId()).orElse(null))
                 .filter(c -> c != null)
+                .toList();
+        java.util.Set<UUID> linkedContactIds = propertyContacts.stream()
+                .map(PropertyContact::getContactId)
+                .collect(java.util.stream.Collectors.toSet());
+        List<Contact> contactCandidates = contactRepository.findByOrganizationId(property.getOrganizationId()).stream()
+                .filter(c -> c.getArchivedAt() == null)
+                .filter(c -> !linkedContactIds.contains(c.getId()))
+                .sorted(Comparator.comparing(Contact::getFormattedName,
+                        Comparator.nullsLast(String.CASE_INSENSITIVE_ORDER)))
                 .toList();
 
         LocalDate today = LocalDate.now();
@@ -464,6 +481,8 @@ public class PropertyPageController {
         model.addAttribute("children", children);
         model.addAttribute("propertyContacts", propertyContacts);
         model.addAttribute("contacts", contacts);
+        model.addAttribute("contactCandidates", contactCandidates);
+        model.addAttribute("contactRoles", ContactRole.values());
         model.addAttribute("scheduleRows", scheduleRows);
         model.addAttribute("recentRecords", recentRecords);
         model.addAttribute("attachments", attachments);

--- a/src/main/resources/templates/contact-detail.html
+++ b/src/main/resources/templates/contact-detail.html
@@ -133,13 +133,47 @@
                     <div class="px-6 py-3 border-b border-gray-200">
                         <h2 class="text-sm font-semibold text-gray-700 uppercase tracking-wider">Linked properties</h2>
                     </div>
-                    <ul class="p-6 space-y-1 text-sm">
-                        <li th:each="p : ${linkedProperties}">
-                            <a th:href="@{|/properties/${p.id}|}" th:text="${p.name}"
+                    <ul class="p-6 space-y-2 text-sm">
+                        <li th:each="r : ${linkedRows}" class="flex items-center justify-between">
+                            <a th:href="@{|/properties/${r.property().id}|}" th:text="${r.property().name}"
                                class="text-indigo-600 hover:text-indigo-800">property</a>
+                            <form method="post"
+                                  th:action="@{|/contacts/${contact.id}/properties/${r.link().id}/unlink|}">
+                                <button type="submit"
+                                        class="text-red-600 hover:text-red-800 text-xs">Unlink</button>
+                            </form>
                         </li>
-                        <li th:if="${#lists.isEmpty(linkedProperties)}" class="text-gray-400">None</li>
+                        <li th:if="${#lists.isEmpty(linkedRows)}" class="text-gray-400">None</li>
                     </ul>
+                    <div th:if="${propertyCandidates != null and !#lists.isEmpty(propertyCandidates)}"
+                         class="px-6 pb-6 border-t border-gray-100 pt-4">
+                        <form method="post" th:action="@{|/contacts/${contact.id}/properties|}"
+                              class="flex flex-wrap items-end gap-3">
+                            <div class="flex flex-col">
+                                <label for="link-propertyId" class="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-1">Property</label>
+                                <select id="link-propertyId" name="propertyId" required
+                                        class="rounded border-gray-300 text-sm px-2 py-1.5">
+                                    <option th:each="p : ${propertyCandidates}"
+                                            th:value="${p.id}" th:text="${p.name}"></option>
+                                </select>
+                            </div>
+                            <div class="flex flex-col">
+                                <label for="link-role" class="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-1">Role</label>
+                                <select id="link-role" name="role" class="rounded border-gray-300 text-sm px-2 py-1.5">
+                                    <option th:each="r : ${contactRoles}" th:value="${r}" th:text="${r}"></option>
+                                </select>
+                            </div>
+                            <div class="flex flex-col flex-grow">
+                                <label for="link-notes" class="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-1">Notes</label>
+                                <input id="link-notes" name="notes" type="text"
+                                       class="rounded border-gray-300 text-sm px-2 py-1.5">
+                            </div>
+                            <button type="submit"
+                                    class="inline-flex items-center rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-indigo-700">
+                                + Link property
+                            </button>
+                        </form>
+                    </div>
                 </div>
 
             </div>

--- a/src/main/resources/templates/property-detail.html
+++ b/src/main/resources/templates/property-detail.html
@@ -157,8 +157,11 @@
                         </thead>
                         <tbody class="bg-white divide-y divide-gray-200">
                             <tr th:each="contact, iterStat : ${contacts}">
-                                <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900"
-                                    th:text="${contact.formattedName}">Contact Name</td>
+                                <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">
+                                    <a th:href="@{|/contacts/${contact.id}|}"
+                                       th:text="${contact.formattedName}"
+                                       class="text-indigo-600 hover:text-indigo-800">Contact Name</a>
+                                </td>
                                 <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-600">
                                     <span th:if="${propertyContacts[iterStat.index].role != null}"
                                           th:text="${propertyContacts[iterStat.index].role}"></span>
@@ -172,9 +175,47 @@
                                     <span th:if="${!#lists.isEmpty(contact.telephones)}" th:text="${contact.telephones[0]}"></span>
                                     <span th:if="${#lists.isEmpty(contact.telephones)}" class="text-gray-400">—</span>
                                 </td>
+                                <td class="px-6 py-4 whitespace-nowrap text-sm text-right">
+                                    <form method="post"
+                                          th:action="@{|/properties/${property.id}/contacts/${propertyContacts[iterStat.index].id}/unlink|}">
+                                        <button type="submit"
+                                                class="text-red-600 hover:text-red-800 text-xs">Unlink</button>
+                                    </form>
+                                </td>
                             </tr>
                         </tbody>
                     </table>
+                </div>
+
+                <!-- Link contact form -->
+                <div th:if="${contactCandidates != null and !#lists.isEmpty(contactCandidates)}"
+                     class="mt-4 border-t border-gray-100 pt-4">
+                    <form method="post" th:action="@{|/properties/${property.id}/contacts|}"
+                          class="flex flex-wrap items-end gap-3">
+                        <div class="flex flex-col">
+                            <label for="link-contactId" class="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-1">Contact</label>
+                            <select id="link-contactId" name="contactId" required
+                                    class="rounded border-gray-300 text-sm px-2 py-1.5">
+                                <option th:each="c : ${contactCandidates}"
+                                        th:value="${c.id}" th:text="${c.formattedName}"></option>
+                            </select>
+                        </div>
+                        <div class="flex flex-col">
+                            <label for="link-role" class="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-1">Role</label>
+                            <select id="link-role" name="role" class="rounded border-gray-300 text-sm px-2 py-1.5">
+                                <option th:each="r : ${contactRoles}" th:value="${r}" th:text="${r}"></option>
+                            </select>
+                        </div>
+                        <div class="flex flex-col flex-grow">
+                            <label for="link-notes" class="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-1">Notes</label>
+                            <input id="link-notes" name="notes" type="text"
+                                   class="rounded border-gray-300 text-sm px-2 py-1.5">
+                        </div>
+                        <button type="submit"
+                                class="inline-flex items-center rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-indigo-700">
+                            + Link contact
+                        </button>
+                    </form>
                 </div>
             </div>
         </div>

--- a/src/test/java/com/majordomo/adapter/in/web/concierge/ContactPageDetailTest.java
+++ b/src/test/java/com/majordomo/adapter/in/web/concierge/ContactPageDetailTest.java
@@ -50,6 +50,7 @@ class ContactPageDetailTest {
     @MockitoBean ManageContactUseCase contactUseCase;
     @MockitoBean ContactRepository contactRepository;
     @MockitoBean ManagePropertyUseCase propertyUseCase;
+    @MockitoBean com.majordomo.domain.port.out.steward.PropertyRepository propertyRepository;
     @MockitoBean PropertyContactRepository propertyContactRepository;
     @MockitoBean CurrentOrganizationResolver currentOrg;
     @MockitoBean OrganizationAccessService organizationAccessService;

--- a/src/test/java/com/majordomo/adapter/in/web/concierge/ContactPageFormTest.java
+++ b/src/test/java/com/majordomo/adapter/in/web/concierge/ContactPageFormTest.java
@@ -53,6 +53,7 @@ class ContactPageFormTest {
     @MockitoBean ManageContactUseCase contactUseCase;
     @MockitoBean ContactRepository contactRepository;
     @MockitoBean ManagePropertyUseCase propertyUseCase;
+    @MockitoBean com.majordomo.domain.port.out.steward.PropertyRepository propertyRepository;
     @MockitoBean PropertyContactRepository propertyContactRepository;
     @MockitoBean CurrentOrganizationResolver currentOrg;
     @MockitoBean OrganizationAccessService organizationAccessService;

--- a/src/test/java/com/majordomo/adapter/in/web/concierge/ContactPageLinkPropertyTest.java
+++ b/src/test/java/com/majordomo/adapter/in/web/concierge/ContactPageLinkPropertyTest.java
@@ -1,0 +1,171 @@
+package com.majordomo.adapter.in.web.concierge;
+
+import com.majordomo.adapter.in.web.config.OAuth2UserService;
+import com.majordomo.adapter.in.web.config.SecurityConfig;
+import com.majordomo.application.identity.CurrentOrganizationResolver;
+import com.majordomo.application.identity.OrganizationAccessService;
+import com.majordomo.domain.model.UuidFactory;
+import com.majordomo.domain.model.concierge.Contact;
+import com.majordomo.domain.model.identity.User;
+import com.majordomo.domain.model.steward.Property;
+import com.majordomo.domain.model.steward.PropertyContact;
+import com.majordomo.domain.port.in.steward.ManagePropertyUseCase;
+import com.majordomo.domain.port.out.concierge.ContactRepository;
+import com.majordomo.domain.port.out.identity.ApiKeyRepository;
+import com.majordomo.domain.port.out.steward.PropertyContactRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/** Slice tests for contact→property link/unlink (#240). */
+@WebMvcTest(ContactPropertyLinkController.class)
+@Import(SecurityConfig.class)
+class ContactPageLinkPropertyTest {
+
+    @Autowired MockMvc mvc;
+
+    @MockitoBean ContactRepository contactRepository;
+    @MockitoBean ManagePropertyUseCase propertyUseCase;
+    @MockitoBean PropertyContactRepository propertyContactRepository;
+    @MockitoBean CurrentOrganizationResolver currentOrg;
+    @MockitoBean OrganizationAccessService organizationAccessService;
+    @MockitoBean ApiKeyRepository apiKeyRepository;
+    @MockitoBean OAuth2UserService oAuth2UserService;
+
+    private static final UUID ORG_ID = UuidFactory.newId();
+
+    @BeforeEach
+    void seedAuth() {
+        User user = new User(UuidFactory.newId(), "robsartin", "rob@example.com");
+        when(currentOrg.resolve(any(UserDetails.class)))
+                .thenReturn(new CurrentOrganizationResolver.Resolved(user, ORG_ID));
+    }
+
+    /** POST /contacts/{id}/properties persists a new PropertyContact. */
+    @Test
+    @WithMockUser
+    void linkPropertyPersistsAndRedirects() throws Exception {
+        UUID contactId = UuidFactory.newId();
+        UUID propId = UuidFactory.newId();
+        when(contactRepository.findById(contactId)).thenReturn(Optional.of(contact(contactId)));
+        when(propertyUseCase.findById(propId)).thenReturn(Optional.of(property(propId)));
+        when(propertyContactRepository.save(any(PropertyContact.class)))
+                .thenAnswer(inv -> inv.getArgument(0));
+
+        mvc.perform(post("/contacts/{id}/properties", contactId)
+                        .with(csrf())
+                        .param("propertyId", propId.toString())
+                        .param("role", "MANUFACTURER"))
+                .andExpect(status().is3xxRedirection());
+
+        ArgumentCaptor<PropertyContact> captor = ArgumentCaptor.forClass(PropertyContact.class);
+        verify(propertyContactRepository).save(captor.capture());
+        assertThat(captor.getValue().getContactId()).isEqualTo(contactId);
+        assertThat(captor.getValue().getPropertyId()).isEqualTo(propId);
+        assertThat(captor.getValue().getRole().name()).isEqualTo("MANUFACTURER");
+    }
+
+    /** POST /contacts/{id}/properties/{linkId}/unlink soft-deletes. */
+    @Test
+    @WithMockUser
+    void unlinkPropertySoftDeletesLink() throws Exception {
+        UUID contactId = UuidFactory.newId();
+        UUID propId = UuidFactory.newId();
+        UUID linkId = UuidFactory.newId();
+        Contact contact = contact(contactId);
+        PropertyContact link = new PropertyContact();
+        link.setId(linkId);
+        link.setContactId(contactId);
+        link.setPropertyId(propId);
+        when(contactRepository.findById(contactId)).thenReturn(Optional.of(contact));
+        when(propertyContactRepository.findById(linkId)).thenReturn(Optional.of(link));
+        when(propertyContactRepository.save(any(PropertyContact.class)))
+                .thenAnswer(inv -> inv.getArgument(0));
+
+        mvc.perform(post("/contacts/{id}/properties/{linkId}/unlink", contactId, linkId)
+                        .with(csrf()))
+                .andExpect(status().is3xxRedirection());
+
+        ArgumentCaptor<PropertyContact> captor = ArgumentCaptor.forClass(PropertyContact.class);
+        verify(propertyContactRepository).save(captor.capture());
+        assertThat(captor.getValue().getArchivedAt()).isNotNull();
+    }
+
+    /** Cross-org link returns 403. */
+    @Test
+    @WithMockUser
+    void linkPropertyReturns403WhenCrossOrgContact() throws Exception {
+        UUID contactId = UuidFactory.newId();
+        UUID otherOrg = UuidFactory.newId();
+        Contact foreign = contact(contactId);
+        foreign.setOrganizationId(otherOrg);
+        when(contactRepository.findById(contactId)).thenReturn(Optional.of(foreign));
+        doThrow(new AccessDeniedException("denied"))
+                .when(organizationAccessService).verifyAccess(otherOrg);
+
+        mvc.perform(post("/contacts/{id}/properties", contactId)
+                        .with(csrf())
+                        .param("propertyId", UuidFactory.newId().toString())
+                        .param("role", "VENDOR"))
+                .andExpect(status().isForbidden());
+
+        verify(propertyContactRepository, never()).save(any());
+    }
+
+    /** Cross-org unlink returns 403. */
+    @Test
+    @WithMockUser
+    void unlinkPropertyReturns403WhenCrossOrgContact() throws Exception {
+        UUID contactId = UuidFactory.newId();
+        UUID otherOrg = UuidFactory.newId();
+        UUID linkId = UuidFactory.newId();
+        Contact foreign = contact(contactId);
+        foreign.setOrganizationId(otherOrg);
+        when(contactRepository.findById(contactId)).thenReturn(Optional.of(foreign));
+        doThrow(new AccessDeniedException("denied"))
+                .when(organizationAccessService).verifyAccess(otherOrg);
+
+        mvc.perform(post("/contacts/{id}/properties/{linkId}/unlink", contactId, linkId)
+                        .with(csrf()))
+                .andExpect(status().isForbidden());
+
+        verify(propertyContactRepository, never()).save(any());
+    }
+
+    private static Contact contact(UUID id) {
+        Contact c = new Contact();
+        c.setId(id);
+        c.setOrganizationId(ORG_ID);
+        c.setFormattedName("Carol");
+        return c;
+    }
+
+    private static Property property(UUID id) {
+        Property p = new Property();
+        p.setId(id);
+        p.setOrganizationId(ORG_ID);
+        p.setName("Beach House");
+        return p;
+    }
+}

--- a/src/test/java/com/majordomo/adapter/in/web/concierge/ContactPageListTest.java
+++ b/src/test/java/com/majordomo/adapter/in/web/concierge/ContactPageListTest.java
@@ -41,6 +41,7 @@ class ContactPageListTest {
     @MockitoBean ManageContactUseCase contactUseCase;
     @MockitoBean ContactRepository contactRepository;
     @MockitoBean com.majordomo.domain.port.in.steward.ManagePropertyUseCase propertyUseCase;
+    @MockitoBean com.majordomo.domain.port.out.steward.PropertyRepository propertyRepository;
     @MockitoBean com.majordomo.domain.port.out.steward.PropertyContactRepository propertyContactRepository;
     @MockitoBean CurrentOrganizationResolver currentOrg;
     @MockitoBean com.majordomo.application.identity.OrganizationAccessService organizationAccessService;

--- a/src/test/java/com/majordomo/adapter/in/web/steward/PropertyPageControllerTest.java
+++ b/src/test/java/com/majordomo/adapter/in/web/steward/PropertyPageControllerTest.java
@@ -63,6 +63,9 @@ class PropertyPageControllerTest {
     private com.majordomo.domain.port.out.steward.PropertyRepository propertyRepository;
 
     @MockitoBean
+    private com.majordomo.domain.port.out.concierge.ContactRepository contactRepository;
+
+    @MockitoBean
     private com.majordomo.domain.port.out.herald.ServiceRecordRepository serviceRecordRepository;
 
     @MockitoBean

--- a/src/test/java/com/majordomo/adapter/in/web/steward/PropertyPageDetailPanelsTest.java
+++ b/src/test/java/com/majordomo/adapter/in/web/steward/PropertyPageDetailPanelsTest.java
@@ -57,6 +57,7 @@ class PropertyPageDetailPanelsTest {
     @MockitoBean ManageAttachmentUseCase attachmentUseCase;
     @MockitoBean PropertyContactRepository propertyContactRepository;
     @MockitoBean PropertyRepository propertyRepository;
+    @MockitoBean com.majordomo.domain.port.out.concierge.ContactRepository contactRepository;
     @MockitoBean ServiceRecordRepository serviceRecordRepository;
     @MockitoBean CurrentOrganizationResolver currentOrg;
     @MockitoBean com.majordomo.application.identity.OrganizationAccessService organizationAccessService;

--- a/src/test/java/com/majordomo/adapter/in/web/steward/PropertyPageFormTest.java
+++ b/src/test/java/com/majordomo/adapter/in/web/steward/PropertyPageFormTest.java
@@ -50,6 +50,7 @@ class PropertyPageFormTest {
     @MockitoBean ManageAttachmentUseCase attachmentUseCase;
     @MockitoBean PropertyContactRepository propertyContactRepository;
     @MockitoBean PropertyRepository propertyRepository;
+    @MockitoBean com.majordomo.domain.port.out.concierge.ContactRepository contactRepository;
     @MockitoBean ServiceRecordRepository serviceRecordRepository;
     @MockitoBean CurrentOrganizationResolver currentOrg;
     @MockitoBean OrganizationAccessService organizationAccessService;

--- a/src/test/java/com/majordomo/adapter/in/web/steward/PropertyPageLinkContactTest.java
+++ b/src/test/java/com/majordomo/adapter/in/web/steward/PropertyPageLinkContactTest.java
@@ -1,0 +1,184 @@
+package com.majordomo.adapter.in.web.steward;
+
+import com.majordomo.adapter.in.web.config.OAuth2UserService;
+import com.majordomo.adapter.in.web.config.SecurityConfig;
+import com.majordomo.application.identity.CurrentOrganizationResolver;
+import com.majordomo.application.identity.OrganizationAccessService;
+import com.majordomo.domain.model.UuidFactory;
+import com.majordomo.domain.model.concierge.Contact;
+import com.majordomo.domain.model.identity.User;
+import com.majordomo.domain.model.steward.Property;
+import com.majordomo.domain.model.steward.PropertyContact;
+import com.majordomo.domain.port.in.steward.ManagePropertyUseCase;
+import com.majordomo.domain.port.out.concierge.ContactRepository;
+import com.majordomo.domain.port.out.identity.ApiKeyRepository;
+import com.majordomo.domain.port.out.steward.PropertyContactRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/** Slice tests for property→contact link/unlink (#240). */
+@WebMvcTest(PropertyContactLinkController.class)
+@Import(SecurityConfig.class)
+class PropertyPageLinkContactTest {
+
+    @Autowired MockMvc mvc;
+
+    @MockitoBean ManagePropertyUseCase propertyUseCase;
+    @MockitoBean ContactRepository contactRepository;
+    @MockitoBean PropertyContactRepository propertyContactRepository;
+    @MockitoBean CurrentOrganizationResolver currentOrg;
+    @MockitoBean OrganizationAccessService organizationAccessService;
+    @MockitoBean ApiKeyRepository apiKeyRepository;
+    @MockitoBean OAuth2UserService oAuth2UserService;
+
+    private static final UUID ORG_ID = UuidFactory.newId();
+
+    @BeforeEach
+    void seedAuth() {
+        User user = new User(UuidFactory.newId(), "robsartin", "rob@example.com");
+        when(currentOrg.resolve(any(UserDetails.class)))
+                .thenReturn(new CurrentOrganizationResolver.Resolved(user, ORG_ID));
+    }
+
+    /** POST /properties/{id}/contacts persists a new PropertyContact and redirects. */
+    @Test
+    @WithMockUser
+    void linkContactPersistsAndRedirects() throws Exception {
+        UUID propId = UuidFactory.newId();
+        UUID contactId = UuidFactory.newId();
+        Property property = property(propId);
+        when(propertyUseCase.findById(propId)).thenReturn(Optional.of(property));
+        when(contactRepository.findById(contactId))
+                .thenReturn(Optional.of(contact(contactId, "Carol")));
+        when(propertyContactRepository.save(any(PropertyContact.class)))
+                .thenAnswer(inv -> inv.getArgument(0));
+
+        mvc.perform(post("/properties/{id}/contacts", propId)
+                        .with(csrf())
+                        .param("contactId", contactId.toString())
+                        .param("role", "VENDOR")
+                        .param("notes", "HVAC tech"))
+                .andExpect(status().is3xxRedirection());
+
+        ArgumentCaptor<PropertyContact> captor = ArgumentCaptor.forClass(PropertyContact.class);
+        verify(propertyContactRepository).save(captor.capture());
+        PropertyContact saved = captor.getValue();
+        assertThat(saved.getPropertyId()).isEqualTo(propId);
+        assertThat(saved.getContactId()).isEqualTo(contactId);
+        assertThat(saved.getRole().name()).isEqualTo("VENDOR");
+        assertThat(saved.getNotes()).isEqualTo("HVAC tech");
+    }
+
+    /** POST /properties/{id}/contacts/{linkId}/unlink soft-deletes (sets archivedAt). */
+    @Test
+    @WithMockUser
+    void unlinkContactSoftDeletesLink() throws Exception {
+        UUID propId = UuidFactory.newId();
+        UUID contactId = UuidFactory.newId();
+        UUID linkId = UuidFactory.newId();
+        Property property = property(propId);
+        PropertyContact link = propertyContactLink(propId, contactId);
+        link.setId(linkId);
+        when(propertyUseCase.findById(propId)).thenReturn(Optional.of(property));
+        when(propertyContactRepository.findById(linkId)).thenReturn(Optional.of(link));
+        when(propertyContactRepository.save(any(PropertyContact.class)))
+                .thenAnswer(inv -> inv.getArgument(0));
+
+        mvc.perform(post("/properties/{id}/contacts/{linkId}/unlink", propId, linkId)
+                        .with(csrf()))
+                .andExpect(status().is3xxRedirection());
+
+        ArgumentCaptor<PropertyContact> captor = ArgumentCaptor.forClass(PropertyContact.class);
+        verify(propertyContactRepository).save(captor.capture());
+        assertThat(captor.getValue().getId()).isEqualTo(linkId);
+        assertThat(captor.getValue().getArchivedAt()).isNotNull();
+    }
+
+    /** Cross-org link returns 403 (verified against the property's org). */
+    @Test
+    @WithMockUser
+    void linkContactReturns403WhenCrossOrgProperty() throws Exception {
+        UUID propId = UuidFactory.newId();
+        UUID otherOrg = UuidFactory.newId();
+        Property foreign = property(propId);
+        foreign.setOrganizationId(otherOrg);
+        when(propertyUseCase.findById(propId)).thenReturn(Optional.of(foreign));
+        doThrow(new AccessDeniedException("denied"))
+                .when(organizationAccessService).verifyAccess(otherOrg);
+
+        mvc.perform(post("/properties/{id}/contacts", propId)
+                        .with(csrf())
+                        .param("contactId", UuidFactory.newId().toString())
+                        .param("role", "VENDOR"))
+                .andExpect(status().isForbidden());
+
+        verify(propertyContactRepository, never()).save(any());
+    }
+
+    /** Cross-org unlink returns 403. */
+    @Test
+    @WithMockUser
+    void unlinkContactReturns403WhenCrossOrgProperty() throws Exception {
+        UUID propId = UuidFactory.newId();
+        UUID otherOrg = UuidFactory.newId();
+        UUID linkId = UuidFactory.newId();
+        Property foreign = property(propId);
+        foreign.setOrganizationId(otherOrg);
+        when(propertyUseCase.findById(propId)).thenReturn(Optional.of(foreign));
+        doThrow(new AccessDeniedException("denied"))
+                .when(organizationAccessService).verifyAccess(otherOrg);
+
+        mvc.perform(post("/properties/{id}/contacts/{linkId}/unlink", propId, linkId)
+                        .with(csrf()))
+                .andExpect(status().isForbidden());
+
+        verify(propertyContactRepository, never()).save(any());
+    }
+
+    private static Property property(UUID id) {
+        Property p = new Property();
+        p.setId(id);
+        p.setOrganizationId(ORG_ID);
+        p.setName("Property " + id);
+        return p;
+    }
+
+    private static Contact contact(UUID id, String name) {
+        Contact c = new Contact();
+        c.setId(id);
+        c.setOrganizationId(ORG_ID);
+        c.setFormattedName(name);
+        return c;
+    }
+
+    private static PropertyContact propertyContactLink(UUID propId, UUID contactId) {
+        PropertyContact pc = new PropertyContact();
+        pc.setId(UuidFactory.newId());
+        pc.setPropertyId(propId);
+        pc.setContactId(contactId);
+        pc.setRole(com.majordomo.domain.model.concierge.ContactRole.VENDOR);
+        return pc;
+    }
+}

--- a/src/test/java/com/majordomo/adapter/in/web/steward/PropertyPageListTest.java
+++ b/src/test/java/com/majordomo/adapter/in/web/steward/PropertyPageListTest.java
@@ -54,6 +54,7 @@ class PropertyPageListTest {
     @MockitoBean ManageAttachmentUseCase attachmentUseCase;
     @MockitoBean PropertyContactRepository propertyContactRepository;
     @MockitoBean PropertyRepository propertyRepository;
+    @MockitoBean com.majordomo.domain.port.out.concierge.ContactRepository contactRepository;
     @MockitoBean com.majordomo.domain.port.out.herald.ServiceRecordRepository serviceRecordRepository;
     @MockitoBean CurrentOrganizationResolver currentOrg;
     @MockitoBean com.majordomo.application.identity.OrganizationAccessService organizationAccessService;


### PR DESCRIPTION
## Summary
- Two new sibling controllers: `PropertyContactLinkController` (`POST /properties/{id}/contacts`, `POST /properties/{id}/contacts/{linkId}/unlink`) and `ContactPropertyLinkController` (mirror under `/contacts/`). Kept separate from the existing detail controllers to stay under the 500-line file budget.
- Property detail page exposes `contactCandidates` (org's contacts excluding already-linked + archived) plus a `+ Link contact` form (role + notes) and a per-row `Unlink` button.
- Contact detail page mirror: `linkedRows` (carrying the `PropertyContact.id` for unlink), `propertyCandidates`, and matching `+ Link property` / `Unlink` UX.
- Both detail handlers filter out archived `PropertyContact` rows so the panels and pickers stay consistent.
- Cross-org access verified (`OrganizationAccessService.verifyAccess`) on both link + unlink, both controllers.

## Test plan
- [x] `./mvnw verify -DskipITs` green (533 tests, 0 failures, checkstyle clean)
- [x] New slice tests: `PropertyPageLinkContactTest` (4 cases) and `ContactPageLinkPropertyTest` (4 cases) cover link happy path, unlink soft-delete, cross-org 403 on link + unlink.
- [x] Existing slice tests updated to declare the new mock beans (`ContactRepository` on Steward side, `PropertyRepository` on Concierge side).
- [ ] `gh pr checks` green (verify post-push, CodeQL included).

🤖 Generated with [Claude Code](https://claude.com/claude-code)