### PR TITLE
feat(audit): log viewer UI at /audit (closes #242)

### DIFF
--- a/src/main/java/com/majordomo/adapter/in/event/AuditEventListener.java
+++ b/src/main/java/com/majordomo/adapter/in/event/AuditEventListener.java
@@ -47,7 +47,7 @@ public class AuditEventListener {
      */
     @EventListener
     public void onServiceRecordCreated(ServiceRecordCreated event) {
-        log(EntityType.SERVICE_RECORD.name(), event.serviceRecordId(),
+        log(null, EntityType.SERVICE_RECORD.name(), event.serviceRecordId(),
                 AuditAction.CREATE.name(), event.occurredAt());
     }
 
@@ -58,7 +58,7 @@ public class AuditEventListener {
      */
     @EventListener
     public void onPropertyArchived(PropertyArchived event) {
-        log(EntityType.PROPERTY.name(), event.propertyId(),
+        log(event.organizationId(), EntityType.PROPERTY.name(), event.propertyId(),
                 AuditAction.ARCHIVE.name(), event.occurredAt());
     }
 
@@ -69,7 +69,7 @@ public class AuditEventListener {
      */
     @EventListener
     public void onUserCreated(UserCreated event) {
-        log(EntityType.USER.name(), event.userId(),
+        log(event.organizationId(), EntityType.USER.name(), event.userId(),
                 AuditAction.CREATE.name(), event.occurredAt());
     }
 
@@ -80,7 +80,7 @@ public class AuditEventListener {
      */
     @EventListener
     public void onJobPostingIngested(JobPostingIngested event) {
-        log(EntityType.JOB_POSTING.name(), event.postingId(),
+        log(event.organizationId(), EntityType.JOB_POSTING.name(), event.postingId(),
                 AuditAction.CREATE.name(), event.occurredAt());
     }
 
@@ -91,7 +91,7 @@ public class AuditEventListener {
      */
     @EventListener
     public void onJobPostingScored(JobPostingScored event) {
-        log(EntityType.SCORE_REPORT.name(), event.reportId(),
+        log(event.organizationId(), EntityType.SCORE_REPORT.name(), event.reportId(),
                 AuditAction.CREATE.name(), event.occurredAt());
     }
 
@@ -102,7 +102,7 @@ public class AuditEventListener {
      */
     @EventListener
     public void onPostingMarkedApplied(PostingMarkedApplied event) {
-        log(EntityType.JOB_POSTING.name(), event.postingId(),
+        log(event.organizationId(), EntityType.JOB_POSTING.name(), event.postingId(),
                 AuditAction.APPLY.name(), event.occurredAt());
     }
 
@@ -113,13 +113,15 @@ public class AuditEventListener {
      */
     @EventListener
     public void onPostingDismissed(PostingDismissed event) {
-        log(EntityType.JOB_POSTING.name(), event.postingId(),
+        log(event.organizationId(), EntityType.JOB_POSTING.name(), event.postingId(),
                 AuditAction.DISMISS.name(), event.occurredAt());
     }
 
-    private void log(String entityType, UUID entityId, String action, Instant occurredAt) {
+    private void log(UUID organizationId, String entityType, UUID entityId,
+                     String action, Instant occurredAt) {
         var entry = new AuditLogEntry();
         entry.setId(UuidFactory.newId());
+        entry.setOrganizationId(organizationId);
         entry.setEntityType(entityType);
         entry.setEntityId(entityId);
         entry.setAction(action);

--- a/src/main/java/com/majordomo/adapter/in/web/audit/AuditPageController.java
+++ b/src/main/java/com/majordomo/adapter/in/web/audit/AuditPageController.java
@@ -1,0 +1,144 @@
+package com.majordomo.adapter.in.web.audit;
+
+import com.majordomo.application.identity.CurrentOrganizationResolver;
+import com.majordomo.domain.model.AuditLogEntry;
+import com.majordomo.domain.model.identity.User;
+import com.majordomo.domain.port.out.AuditLogRepository;
+import com.majordomo.domain.port.out.identity.UserRepository;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Serves the audit log viewer at {@code /audit}. Reads-only — writes are
+ * driven by the {@code AuditEventListener}.
+ */
+@Controller
+public class AuditPageController {
+
+    private static final int DEFAULT_PAGE_LIMIT = 50;
+
+    private final AuditLogRepository auditLogRepository;
+    private final UserRepository userRepository;
+    private final CurrentOrganizationResolver currentOrg;
+
+    /**
+     * View-model row pairing an audit entry with the resolved actor username.
+     *
+     * @param entry          the underlying audit-log entry
+     * @param actorUsername  the actor's username, or {@code null} if not resolvable
+     */
+    public record AuditRow(AuditLogEntry entry, String actorUsername) { }
+
+    /**
+     * Constructs the audit page controller.
+     *
+     * @param auditLogRepository outbound port for audit-log queries
+     * @param userRepository     outbound port for user lookups (actor resolution)
+     * @param currentOrg         resolves the authenticated user's organization
+     */
+    public AuditPageController(AuditLogRepository auditLogRepository,
+                               UserRepository userRepository,
+                               CurrentOrganizationResolver currentOrg) {
+        this.auditLogRepository = auditLogRepository;
+        this.userRepository = userRepository;
+        this.currentOrg = currentOrg;
+    }
+
+    /**
+     * Renders the audit log table for the user's organization.
+     *
+     * @param entityType optional entity-type filter
+     * @param actor      optional actor-username filter
+     * @param since      optional inclusive lower-bound date (yyyy-MM-dd)
+     * @param until      optional exclusive upper-bound date (yyyy-MM-dd)
+     * @param principal  authenticated user
+     * @param model      Thymeleaf model
+     * @return the {@code audit} template, or a redirect home if no org
+     */
+    @GetMapping("/audit")
+    public String list(@RequestParam(required = false) String entityType,
+                       @RequestParam(required = false) String actor,
+                       @RequestParam(required = false) String since,
+                       @RequestParam(required = false) String until,
+                       @AuthenticationPrincipal UserDetails principal,
+                       Model model) {
+        var ctx = currentOrg.resolve(principal);
+        if (ctx.organizationId() == null) {
+            return "redirect:/";
+        }
+        UUID orgId = ctx.organizationId();
+
+        String entityTypeFilter = blankToNull(entityType);
+        UUID actorId = resolveActor(actor);
+        Instant sinceInstant = parseDate(since);
+        Instant untilInstant = parseDate(until);
+
+        List<AuditLogEntry> entries = auditLogRepository.find(
+                orgId, entityTypeFilter, actorId, sinceInstant, untilInstant, DEFAULT_PAGE_LIMIT);
+
+        Map<UUID, String> usernamesById = new HashMap<>();
+        List<AuditRow> rows = new java.util.ArrayList<>(entries.size());
+        for (AuditLogEntry entry : entries) {
+            String username = null;
+            if (entry.getUserId() != null) {
+                username = usernamesById.computeIfAbsent(entry.getUserId(),
+                        uid -> userRepository.findById(uid).map(User::getUsername).orElse(null));
+            }
+            rows.add(new AuditRow(entry, username));
+        }
+
+        model.addAttribute("rows", rows);
+        model.addAttribute("entityType", entityType);
+        model.addAttribute("actor", actor);
+        model.addAttribute("since", since);
+        model.addAttribute("until", until);
+        model.addAttribute("entityTypeOptions", entityTypeOptions(entries));
+        model.addAttribute("username", ctx.user().getUsername());
+        return "audit";
+    }
+
+    private UUID resolveActor(String actor) {
+        if (actor == null || actor.isBlank()) {
+            return null;
+        }
+        return userRepository.findByUsername(actor.trim())
+                .map(User::getId)
+                .orElse(null);
+    }
+
+    private static Instant parseDate(String iso) {
+        if (iso == null || iso.isBlank()) {
+            return null;
+        }
+        return LocalDate.parse(iso.trim()).atStartOfDay(ZoneOffset.UTC).toInstant();
+    }
+
+    private static String blankToNull(String s) {
+        return (s == null || s.isBlank()) ? null : s;
+    }
+
+    /** Ordered set of entity types appearing in the current result page (for the filter dropdown). */
+    private static List<String> entityTypeOptions(List<AuditLogEntry> entries) {
+        Map<String, Boolean> ordered = new LinkedHashMap<>();
+        for (AuditLogEntry e : entries) {
+            if (e.getEntityType() != null) {
+                ordered.putIfAbsent(e.getEntityType(), Boolean.TRUE);
+            }
+        }
+        return List.copyOf(ordered.keySet());
+    }
+}

--- a/src/main/java/com/majordomo/adapter/out/persistence/audit/AuditLogEntity.java
+++ b/src/main/java/com/majordomo/adapter/out/persistence/audit/AuditLogEntity.java
@@ -20,6 +20,9 @@ public class AuditLogEntity {
     @Id
     private UUID id;
 
+    @Column(name = "organization_id")
+    private UUID organizationId;
+
     @Column(name = "entity_type", nullable = false)
     private String entityType;
 
@@ -40,6 +43,9 @@ public class AuditLogEntity {
 
     public UUID getId() { return id; }
     public void setId(UUID id) { this.id = id; }
+
+    public UUID getOrganizationId() { return organizationId; }
+    public void setOrganizationId(UUID organizationId) { this.organizationId = organizationId; }
 
     public String getEntityType() { return entityType; }
     public void setEntityType(String entityType) { this.entityType = entityType; }

--- a/src/main/java/com/majordomo/adapter/out/persistence/audit/AuditLogMapper.java
+++ b/src/main/java/com/majordomo/adapter/out/persistence/audit/AuditLogMapper.java
@@ -9,6 +9,7 @@ final class AuditLogMapper {
     static AuditLogEntity toEntity(AuditLogEntry entry) {
         var entity = new AuditLogEntity();
         entity.setId(entry.getId());
+        entity.setOrganizationId(entry.getOrganizationId());
         entity.setEntityType(entry.getEntityType());
         entity.setEntityId(entry.getEntityId());
         entity.setAction(entry.getAction());
@@ -21,6 +22,7 @@ final class AuditLogMapper {
     static AuditLogEntry toDomain(AuditLogEntity entity) {
         var entry = new AuditLogEntry();
         entry.setId(entity.getId());
+        entry.setOrganizationId(entity.getOrganizationId());
         entry.setEntityType(entity.getEntityType());
         entry.setEntityId(entity.getEntityId());
         entry.setAction(entity.getAction());

--- a/src/main/java/com/majordomo/adapter/out/persistence/audit/AuditLogRepositoryAdapter.java
+++ b/src/main/java/com/majordomo/adapter/out/persistence/audit/AuditLogRepositoryAdapter.java
@@ -3,8 +3,10 @@ package com.majordomo.adapter.out.persistence.audit;
 import com.majordomo.domain.model.AuditLogEntry;
 import com.majordomo.domain.port.out.AuditLogRepository;
 
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Repository;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
 
@@ -43,6 +45,16 @@ public class AuditLogRepositoryAdapter implements AuditLogRepository {
     @Override
     public List<AuditLogEntry> findByUserId(UUID userId) {
         return jpa.findByUserIdOrderByOccurredAtDesc(userId)
+                .stream()
+                .map(AuditLogMapper::toDomain)
+                .toList();
+    }
+
+    @Override
+    public List<AuditLogEntry> find(UUID organizationId, String entityType, UUID userId,
+                                    Instant since, Instant until, int limit) {
+        return jpa.findScoped(organizationId, entityType, userId, since, until,
+                        PageRequest.of(0, Math.max(1, limit)))
                 .stream()
                 .map(AuditLogMapper::toDomain)
                 .toList();

--- a/src/main/java/com/majordomo/adapter/out/persistence/audit/JpaAuditLogRepository.java
+++ b/src/main/java/com/majordomo/adapter/out/persistence/audit/JpaAuditLogRepository.java
@@ -1,7 +1,11 @@
 package com.majordomo.adapter.out.persistence.audit;
 
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
 
@@ -27,4 +31,29 @@ public interface JpaAuditLogRepository extends JpaRepository<AuditLogEntity, UUI
      * @return list of audit log entities
      */
     List<AuditLogEntity> findByUserIdOrderByOccurredAtDesc(UUID userId);
+
+    /**
+     * Queries entries scoped to an organization with optional filters; null
+     * parameters skip that filter. Results are ordered by occurred_at desc.
+     *
+     * @param organizationId required organization scope
+     * @param entityType     optional entity-type filter
+     * @param userId         optional actor filter
+     * @param since          optional inclusive lower bound on occurred_at
+     * @param until          optional exclusive upper bound on occurred_at
+     * @param pageable       pagination/limit
+     * @return matching entries
+     */
+    @Query("SELECT a FROM AuditLogEntity a WHERE a.organizationId = :orgId"
+            + " AND (:entityType IS NULL OR a.entityType = :entityType)"
+            + " AND (:userId IS NULL OR a.userId = :userId)"
+            + " AND (:since IS NULL OR a.occurredAt >= :since)"
+            + " AND (:until IS NULL OR a.occurredAt < :until)"
+            + " ORDER BY a.occurredAt DESC")
+    List<AuditLogEntity> findScoped(@Param("orgId") UUID organizationId,
+                                    @Param("entityType") String entityType,
+                                    @Param("userId") UUID userId,
+                                    @Param("since") Instant since,
+                                    @Param("until") Instant until,
+                                    Pageable pageable);
 }

--- a/src/main/java/com/majordomo/domain/model/AuditLogEntry.java
+++ b/src/main/java/com/majordomo/domain/model/AuditLogEntry.java
@@ -9,6 +9,7 @@ import java.util.UUID;
 public class AuditLogEntry {
 
     private UUID id;
+    private UUID organizationId;
     private String entityType;
     private UUID entityId;
     private String action;
@@ -18,6 +19,9 @@ public class AuditLogEntry {
 
     public UUID getId() { return id; }
     public void setId(UUID id) { this.id = id; }
+
+    public UUID getOrganizationId() { return organizationId; }
+    public void setOrganizationId(UUID organizationId) { this.organizationId = organizationId; }
 
     public String getEntityType() { return entityType; }
     public void setEntityType(String entityType) { this.entityType = entityType; }

--- a/src/main/java/com/majordomo/domain/port/out/AuditLogRepository.java
+++ b/src/main/java/com/majordomo/domain/port/out/AuditLogRepository.java
@@ -2,6 +2,7 @@ package com.majordomo.domain.port.out;
 
 import com.majordomo.domain.model.AuditLogEntry;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
 
@@ -36,4 +37,20 @@ public interface AuditLogRepository {
      * @return list of audit log entries, or an empty list if none exist
      */
     List<AuditLogEntry> findByUserId(UUID userId);
+
+    /**
+     * Queries entries scoped to an organization, with optional filters. Each
+     * filter is independent — pass {@code null} to skip. Results are ordered
+     * by {@code occurred_at} descending and capped at {@code limit}.
+     *
+     * @param organizationId required organization scope
+     * @param entityType     optional entity-type filter (e.g. "PROPERTY")
+     * @param userId         optional actor filter
+     * @param since          optional inclusive lower bound on occurred_at
+     * @param until          optional exclusive upper bound on occurred_at
+     * @param limit          maximum rows to return
+     * @return matching entries
+     */
+    List<AuditLogEntry> find(UUID organizationId, String entityType, UUID userId,
+                             Instant since, Instant until, int limit);
 }

--- a/src/main/resources/db/migration/V18__audit_log_organization_id.sql
+++ b/src/main/resources/db/migration/V18__audit_log_organization_id.sql
@@ -1,0 +1,5 @@
+ALTER TABLE audit_log
+    ADD COLUMN organization_id UUID NULL;
+
+CREATE INDEX idx_audit_log_organization_id ON audit_log(organization_id);
+CREATE INDEX idx_audit_log_org_occurred_at ON audit_log(organization_id, occurred_at DESC);

--- a/src/main/resources/templates/audit.html
+++ b/src/main/resources/templates/audit.html
@@ -1,0 +1,100 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Audit log - Majordomo</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-gray-100 min-h-screen">
+
+    <div th:replace="~{fragments/header :: header}"></div>
+
+    <div class="flex min-h-screen">
+        <div th:replace="~{fragments/sidebar :: sidebar('audit')}"></div>
+
+        <main class="flex-1 p-6">
+
+            <div class="mb-6">
+                <h1 class="text-2xl font-bold text-gray-900">Audit log</h1>
+                <p class="text-sm text-gray-500">State-changing events recorded for your organization.</p>
+            </div>
+
+            <!-- Filter strip -->
+            <div class="bg-white rounded-lg shadow p-4 mb-6">
+                <form method="get" th:action="@{/audit}" class="flex flex-wrap items-end gap-4">
+                    <div class="flex flex-col">
+                        <label for="entityType" class="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-1">Entity type</label>
+                        <input id="entityType" name="entityType" type="text" th:value="${entityType}"
+                               list="entityTypeOptions"
+                               class="rounded border-gray-300 text-sm px-2 py-1.5"
+                               placeholder="e.g. PROPERTY">
+                        <datalist id="entityTypeOptions">
+                            <option th:each="o : ${entityTypeOptions}" th:value="${o}"></option>
+                        </datalist>
+                    </div>
+                    <div class="flex flex-col">
+                        <label for="actor" class="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-1">Actor (username)</label>
+                        <input id="actor" name="actor" type="text" th:value="${actor}"
+                               class="rounded border-gray-300 text-sm px-2 py-1.5">
+                    </div>
+                    <div class="flex flex-col">
+                        <label for="since" class="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-1">Since</label>
+                        <input id="since" name="since" type="date" th:value="${since}"
+                               class="rounded border-gray-300 text-sm px-2 py-1.5">
+                    </div>
+                    <div class="flex flex-col">
+                        <label for="until" class="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-1">Until</label>
+                        <input id="until" name="until" type="date" th:value="${until}"
+                               class="rounded border-gray-300 text-sm px-2 py-1.5">
+                    </div>
+                    <div class="flex gap-2">
+                        <button type="submit"
+                                class="inline-flex items-center rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-indigo-700">
+                            Filter
+                        </button>
+                        <a th:href="@{/audit}"
+                           class="inline-flex items-center rounded-md bg-white border border-gray-300 px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50">
+                            Reset
+                        </a>
+                    </div>
+                </form>
+            </div>
+
+            <div class="bg-white rounded-lg shadow overflow-hidden">
+                <div th:if="${#lists.isEmpty(rows)}" class="px-6 py-12 text-center text-gray-500">
+                    No audit entries.
+                </div>
+                <table th:unless="${#lists.isEmpty(rows)}" class="min-w-full divide-y divide-gray-200">
+                    <thead class="bg-gray-50">
+                        <tr>
+                            <th class="px-6 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider">When</th>
+                            <th class="px-6 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider">Actor</th>
+                            <th class="px-6 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider">Action</th>
+                            <th class="px-6 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider">Entity</th>
+                            <th class="px-6 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider">ID</th>
+                        </tr>
+                    </thead>
+                    <tbody class="bg-white divide-y divide-gray-100">
+                        <tr th:each="r : ${rows}">
+                            <td class="px-6 py-3 whitespace-nowrap text-sm text-gray-700"
+                                th:text="${r.entry().getOccurredAt() != null ? r.entry().getOccurredAt().toString() : ''}">when</td>
+                            <td class="px-6 py-3 whitespace-nowrap text-sm text-gray-700">
+                                <span th:if="${r.actorUsername() != null}" th:text="${r.actorUsername()}"></span>
+                                <span th:unless="${r.actorUsername() != null}" class="text-gray-400">—</span>
+                            </td>
+                            <td class="px-6 py-3 whitespace-nowrap text-sm text-gray-900 font-medium"
+                                th:text="${r.entry().getAction()}">action</td>
+                            <td class="px-6 py-3 whitespace-nowrap text-sm text-gray-700"
+                                th:text="${r.entry().getEntityType()}">type</td>
+                            <td class="px-6 py-3 whitespace-nowrap text-xs text-gray-500 font-mono"
+                                th:text="${r.entry().getEntityId()}">id</td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+
+        </main>
+    </div>
+</body>
+</html>

--- a/src/main/resources/templates/fragments/sidebar.html
+++ b/src/main/resources/templates/fragments/sidebar.html
@@ -20,5 +20,8 @@
         <li><a th:href="@{/envoy}"
                th:classappend="${currentPage == 'envoy'} ? 'bg-indigo-50 text-indigo-600 border-l-4 border-indigo-600' : 'text-gray-700 hover:bg-gray-50'"
                class="block px-6 py-3 font-medium">Envoy</a></li>
+        <li><a th:href="@{/audit}"
+               th:classappend="${currentPage == 'audit'} ? 'bg-indigo-50 text-indigo-600 border-l-4 border-indigo-600' : 'text-gray-700 hover:bg-gray-50'"
+               class="block px-6 py-3 font-medium">Audit</a></li>
     </ul>
 </nav>

--- a/src/test/java/com/majordomo/adapter/in/web/audit/AuditPageControllerTest.java
+++ b/src/test/java/com/majordomo/adapter/in/web/audit/AuditPageControllerTest.java
@@ -1,0 +1,148 @@
+package com.majordomo.adapter.in.web.audit;
+
+import com.majordomo.adapter.in.web.config.OAuth2UserService;
+import com.majordomo.adapter.in.web.config.SecurityConfig;
+import com.majordomo.application.identity.CurrentOrganizationResolver;
+import com.majordomo.domain.model.AuditLogEntry;
+import com.majordomo.domain.model.UuidFactory;
+import com.majordomo.domain.model.identity.User;
+import com.majordomo.domain.port.out.AuditLogRepository;
+import com.majordomo.domain.port.out.identity.ApiKeyRepository;
+import com.majordomo.domain.port.out.identity.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
+
+/** Slice tests for the {@code /audit} log viewer (#242). */
+@WebMvcTest(AuditPageController.class)
+@Import(SecurityConfig.class)
+class AuditPageControllerTest {
+
+    @Autowired MockMvc mvc;
+
+    @MockitoBean AuditLogRepository auditLogRepository;
+    @MockitoBean UserRepository userRepository;
+    @MockitoBean CurrentOrganizationResolver currentOrg;
+    @MockitoBean ApiKeyRepository apiKeyRepository;
+    @MockitoBean OAuth2UserService oAuth2UserService;
+
+    private static final UUID ORG_ID = UuidFactory.newId();
+
+    @BeforeEach
+    void seedAuth() {
+        User user = new User(UuidFactory.newId(), "robsartin", "rob@example.com");
+        when(currentOrg.resolve(any(UserDetails.class)))
+                .thenReturn(new CurrentOrganizationResolver.Resolved(user, ORG_ID));
+    }
+
+    /** GET /audit returns 200 + audit view with rows for the user's org. */
+    @Test
+    @WithMockUser
+    void listRendersAuditEntriesForOrg() throws Exception {
+        UUID actorId = UuidFactory.newId();
+        AuditLogEntry e1 = entry(ORG_ID, "PROPERTY", "ARCHIVE", actorId,
+                Instant.parse("2026-04-01T10:00:00Z"));
+        AuditLogEntry e2 = entry(ORG_ID, "JOB_POSTING", "CREATE", actorId,
+                Instant.parse("2026-04-15T15:30:00Z"));
+        when(auditLogRepository.find(eq(ORG_ID), isNull(), isNull(), isNull(), isNull(),
+                org.mockito.ArgumentMatchers.anyInt()))
+                .thenReturn(List.of(e2, e1));
+        when(userRepository.findById(actorId))
+                .thenReturn(Optional.of(new User(actorId, "robsartin", "rob@e.com")));
+
+        MvcResult result = mvc.perform(get("/audit"))
+                .andExpect(status().isOk())
+                .andExpect(view().name("audit"))
+                .andReturn();
+
+        String body = result.getResponse().getContentAsString();
+        assertThat(body)
+                .contains("PROPERTY").contains("ARCHIVE")
+                .contains("JOB_POSTING").contains("CREATE")
+                .contains("robsartin");
+    }
+
+    /** Filter parameters propagate to the repository call. */
+    @Test
+    @WithMockUser
+    void listForwardsFiltersToRepo() throws Exception {
+        when(auditLogRepository.find(eq(ORG_ID), eq("PROPERTY"), any(),
+                any(), any(), org.mockito.ArgumentMatchers.anyInt()))
+                .thenReturn(List.of());
+
+        mvc.perform(get("/audit")
+                        .param("entityType", "PROPERTY")
+                        .param("since", "2026-01-01")
+                        .param("until", "2026-12-31"))
+                .andExpect(status().isOk());
+
+        org.mockito.Mockito.verify(auditLogRepository).find(
+                eq(ORG_ID),
+                eq("PROPERTY"),
+                isNull(),
+                eq(Instant.parse("2026-01-01T00:00:00Z")),
+                eq(Instant.parse("2026-12-31T00:00:00Z")),
+                org.mockito.ArgumentMatchers.anyInt());
+    }
+
+    /** Empty state when no entries match. */
+    @Test
+    @WithMockUser
+    void emptyStateRendersWhenNoEntries() throws Exception {
+        when(auditLogRepository.find(eq(ORG_ID), any(), any(), any(), any(),
+                org.mockito.ArgumentMatchers.anyInt())).thenReturn(List.of());
+
+        MvcResult result = mvc.perform(get("/audit"))
+                .andExpect(status().isOk())
+                .andReturn();
+        assertThat(result.getResponse().getContentAsString())
+                .contains("No audit entries");
+    }
+
+    /** No-org user redirects home. */
+    @Test
+    @WithMockUser
+    void redirectHomeWhenNoOrg() throws Exception {
+        User user = new User(UuidFactory.newId(), "lonely", "lonely@e.com");
+        when(currentOrg.resolve(any(UserDetails.class)))
+                .thenReturn(new CurrentOrganizationResolver.Resolved(user, null));
+
+        mvc.perform(get("/audit"))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(view().name("redirect:/"));
+    }
+
+    private static AuditLogEntry entry(UUID orgId, String entityType, String action,
+                                       UUID userId, Instant occurredAt) {
+        AuditLogEntry e = new AuditLogEntry();
+        e.setId(UuidFactory.newId());
+        e.setOrganizationId(orgId);
+        e.setEntityType(entityType);
+        e.setEntityId(UuidFactory.newId());
+        e.setAction(action);
+        e.setUserId(userId);
+        e.setOccurredAt(occurredAt);
+        return e;
+    }
+}


### PR DESCRIPTION
## Summary
- New `/audit` Tailwind viewer with timestamp, actor, action, entity-type, entity-id columns and a filter strip (entity type, actor username, since/until dates).
- Schema + plumbing: V18 migration adds `organization_id` (nullable) to `audit_log` plus indices; the model/entity/mapper/listener thread it through; `AuditLogRepository.find(orgId, entityType, userId, since, until, limit)` query method skips null filters.
- Listener populates `organizationId` from events that already carry it (PropertyArchived, UserCreated, JobPostingIngested/Scored, PostingMarkedApplied/Dismissed). `ServiceRecordCreated` records `null` org until the event is enriched — flagging as a follow-up.
- Sidebar gains an "Audit" entry.

## Test plan
- [x] `./mvnw verify -DskipITs` green (529 tests, 0 failures, checkstyle clean)
- [x] Slice tests added: list render, filters propagate to repo, empty state, redirect home when no org.
- [ ] `gh pr checks` green (verify post-push, CodeQL included).

## Follow-up to file after merge
- Enrich `ServiceRecordCreated` with `organizationId` (already accessible via `Property`) so service-record audit entries appear in the org-scoped viewer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)