### PR TITLE
feat(identity): API key management UI at /account/api-keys (closes #243)

### DIFF
--- a/src/main/java/com/majordomo/adapter/in/web/identity/AccountApiKeyPageController.java
+++ b/src/main/java/com/majordomo/adapter/in/web/identity/AccountApiKeyPageController.java
@@ -1,0 +1,143 @@
+package com.majordomo.adapter.in.web.identity;
+
+import com.majordomo.adapter.in.web.config.ApiKeyAuthenticationFilter;
+import com.majordomo.application.identity.CurrentOrganizationResolver;
+import com.majordomo.domain.model.UuidFactory;
+import com.majordomo.domain.model.identity.ApiKey;
+import com.majordomo.domain.port.out.identity.ApiKeyRepository;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+
+import java.security.SecureRandom;
+import java.time.Instant;
+import java.util.HexFormat;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Account API key management UI. Mints, lists, and revokes API keys scoped to
+ * the authenticated user's organization. Sibling to the REST
+ * {@link ApiKeyController} at {@code /api/organizations/{orgId}/api-keys},
+ * which is untouched.
+ */
+@Controller
+@RequestMapping("/account/api-keys")
+public class AccountApiKeyPageController {
+
+    private static final int KEY_RANDOM_BYTES = 32;
+    private static final SecureRandom SECURE_RANDOM = new SecureRandom();
+
+    private final ApiKeyRepository apiKeyRepository;
+    private final CurrentOrganizationResolver currentOrg;
+
+    /**
+     * Constructs the API key page controller.
+     *
+     * @param apiKeyRepository outbound port for API key persistence
+     * @param currentOrg       resolves the authenticated user's organization
+     */
+    public AccountApiKeyPageController(ApiKeyRepository apiKeyRepository,
+                                       CurrentOrganizationResolver currentOrg) {
+        this.apiKeyRepository = apiKeyRepository;
+        this.currentOrg = currentOrg;
+    }
+
+    /**
+     * Renders the API key list for the user's organization.
+     *
+     * @param principal authenticated user
+     * @param model     Thymeleaf model
+     * @return the {@code account-api-keys} template, or a redirect home if no org
+     */
+    @GetMapping
+    public String list(@AuthenticationPrincipal UserDetails principal, Model model) {
+        var ctx = currentOrg.resolve(principal);
+        if (ctx.organizationId() == null) {
+            return "redirect:/";
+        }
+        List<ApiKey> keys = apiKeyRepository.findByOrganizationId(ctx.organizationId()).stream()
+                .filter(k -> k.getArchivedAt() == null)
+                .toList();
+        model.addAttribute("keys", keys);
+        model.addAttribute("username", ctx.user().getUsername());
+        return "account-api-keys";
+    }
+
+    /**
+     * Mints a new API key for the user's organization. The plaintext value is
+     * passed back through a flash attribute so the redirected list page can
+     * display it once. SHA-256 of the plaintext is persisted; the plaintext is
+     * never stored.
+     *
+     * @param name       the key label (required)
+     * @param principal  authenticated user
+     * @param redirect   redirect attributes (used as flash for one-shot plaintext)
+     * @return redirect back to the list
+     */
+    @PostMapping
+    public String create(@RequestParam(required = false) String name,
+                         @AuthenticationPrincipal UserDetails principal,
+                         RedirectAttributes redirect) {
+        var ctx = currentOrg.resolve(principal);
+        if (ctx.organizationId() == null) {
+            return "redirect:/";
+        }
+        if (name == null || name.isBlank()) {
+            redirect.addFlashAttribute("formError", "Name is required.");
+            return "redirect:/account/api-keys";
+        }
+        String plaintext = generateRawKey();
+        String hashed = ApiKeyAuthenticationFilter.sha256(plaintext);
+        Instant now = Instant.now();
+        ApiKey key = new ApiKey(UuidFactory.newId(), ctx.organizationId(), name.trim(), hashed);
+        key.setCreatedAt(now);
+        key.setUpdatedAt(now);
+        apiKeyRepository.save(key);
+        redirect.addFlashAttribute("plaintextKey", plaintext);
+        redirect.addFlashAttribute("plaintextKeyName", name.trim());
+        return "redirect:/account/api-keys";
+    }
+
+    /**
+     * Revokes (soft-deletes) an API key by setting {@code archivedAt}.
+     * Cross-organization revokes are silently ignored — the redirect lands on
+     * the same list, which won't contain the foreign key.
+     *
+     * @param id        the key UUID
+     * @param principal authenticated user
+     * @return redirect back to the list
+     */
+    @PostMapping("/{id}/revoke")
+    public String revoke(@PathVariable UUID id,
+                         @AuthenticationPrincipal UserDetails principal) {
+        var ctx = currentOrg.resolve(principal);
+        if (ctx.organizationId() == null) {
+            return "redirect:/";
+        }
+        UUID orgId = ctx.organizationId();
+        apiKeyRepository.findById(id).ifPresent(k -> {
+            if (orgId.equals(k.getOrganizationId())) {
+                Instant now = Instant.now();
+                k.setArchivedAt(now);
+                k.setUpdatedAt(now);
+                apiKeyRepository.save(k);
+            }
+        });
+        return "redirect:/account/api-keys";
+    }
+
+    private static String generateRawKey() {
+        byte[] bytes = new byte[KEY_RANDOM_BYTES];
+        SECURE_RANDOM.nextBytes(bytes);
+        return HexFormat.of().formatHex(bytes);
+    }
+}

--- a/src/main/resources/templates/account-api-keys.html
+++ b/src/main/resources/templates/account-api-keys.html
@@ -1,0 +1,93 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>API keys - Majordomo</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-gray-100 min-h-screen">
+
+    <div th:replace="~{fragments/header :: header}"></div>
+
+    <div class="flex min-h-screen">
+        <div th:replace="~{fragments/sidebar :: sidebar('account')}"></div>
+
+        <main class="flex-1 p-6">
+
+            <div class="mb-6">
+                <h1 class="text-2xl font-bold text-gray-900">API keys</h1>
+                <p class="text-sm text-gray-500">Used by external integrations to authenticate against <code>/api/...</code> endpoints.</p>
+            </div>
+
+            <!-- One-shot plaintext banner -->
+            <div th:if="${plaintextKey}"
+                 class="mb-6 bg-amber-50 border border-amber-300 rounded-md p-4">
+                <p class="text-sm font-semibold text-amber-900">
+                    New key created<span th:if="${plaintextKeyName}" th:text="' for ' + ${plaintextKeyName}"></span>.
+                    Copy it now — you won't see it again.
+                </p>
+                <pre class="mt-2 bg-white border border-amber-200 rounded p-3 text-xs font-mono text-gray-800 break-all"
+                     th:text="${plaintextKey}">key</pre>
+            </div>
+
+            <!-- Form-error banner -->
+            <div th:if="${formError}"
+                 class="mb-6 rounded-md bg-red-50 border border-red-200 px-4 py-3 text-sm text-red-700"
+                 th:text="${formError}">Error</div>
+
+            <!-- Create key form -->
+            <div class="bg-white rounded-lg shadow p-4 mb-6">
+                <form method="post" th:action="@{/account/api-keys}" class="flex items-end gap-3">
+                    <div class="flex flex-col flex-grow">
+                        <label for="name" class="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-1">Name</label>
+                        <input id="name" name="name" type="text" required
+                               class="rounded border-gray-300 text-sm px-2 py-1.5"
+                               placeholder="e.g. CI runner">
+                    </div>
+                    <button type="submit"
+                            class="inline-flex items-center rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-indigo-700">
+                        + Create key
+                    </button>
+                </form>
+            </div>
+
+            <!-- Existing keys -->
+            <div class="bg-white rounded-lg shadow overflow-hidden">
+                <div th:if="${#lists.isEmpty(keys)}" class="px-6 py-12 text-center text-gray-500">
+                    No active keys.
+                </div>
+                <table th:unless="${#lists.isEmpty(keys)}" class="min-w-full divide-y divide-gray-200">
+                    <thead class="bg-gray-50">
+                        <tr>
+                            <th class="px-6 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider">Name</th>
+                            <th class="px-6 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider">Created</th>
+                            <th class="px-6 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider">Expires</th>
+                            <th class="px-6 py-3 text-right text-xs font-semibold text-gray-500 uppercase tracking-wider">Actions</th>
+                        </tr>
+                    </thead>
+                    <tbody class="bg-white divide-y divide-gray-100">
+                        <tr th:each="k : ${keys}">
+                            <td class="px-6 py-3 whitespace-nowrap text-sm text-gray-900 font-medium" th:text="${k.name}">Name</td>
+                            <td class="px-6 py-3 whitespace-nowrap text-sm text-gray-700"
+                                th:text="${k.createdAt != null ? k.createdAt.toString() : ''}">created</td>
+                            <td class="px-6 py-3 whitespace-nowrap text-sm text-gray-700">
+                                <span th:if="${k.expiresAt != null}" th:text="${k.expiresAt}"></span>
+                                <span th:unless="${k.expiresAt != null}" class="text-gray-400">—</span>
+                            </td>
+                            <td class="px-6 py-3 whitespace-nowrap text-sm text-right">
+                                <form method="post" th:action="@{|/account/api-keys/${k.id}/revoke|}"
+                                      onsubmit="return confirm('Revoke this key? Anything using it will lose access.');">
+                                    <button type="submit"
+                                            class="text-red-600 hover:text-red-800 text-xs">Revoke</button>
+                                </form>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+
+        </main>
+    </div>
+</body>
+</html>

--- a/src/main/resources/templates/fragments/header.html
+++ b/src/main/resources/templates/fragments/header.html
@@ -5,6 +5,7 @@
     <a th:href="@{/dashboard}" class="text-xl font-bold hover:text-indigo-200">Majordomo</a>
     <div class="flex items-center gap-4" sec:authorize="isAuthenticated()">
         <span sec:authentication="name" class="text-sm">User</span>
+        <a th:href="@{/account/api-keys}" class="text-indigo-200 hover:text-white text-sm">API keys</a>
         <form th:action="@{/logout}" method="post" class="inline">
             <button type="submit" class="text-indigo-200 hover:text-white text-sm">Sign out</button>
         </form>

--- a/src/test/java/com/majordomo/adapter/in/web/identity/AccountApiKeyPageControllerTest.java
+++ b/src/test/java/com/majordomo/adapter/in/web/identity/AccountApiKeyPageControllerTest.java
@@ -1,0 +1,166 @@
+package com.majordomo.adapter.in.web.identity;
+
+import com.majordomo.adapter.in.web.config.OAuth2UserService;
+import com.majordomo.adapter.in.web.config.SecurityConfig;
+import com.majordomo.application.identity.CurrentOrganizationResolver;
+import com.majordomo.domain.model.UuidFactory;
+import com.majordomo.domain.model.identity.ApiKey;
+import com.majordomo.domain.model.identity.User;
+import com.majordomo.domain.port.out.identity.ApiKeyRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
+
+/** Slice tests for the {@code /account/api-keys} management UI (#243). */
+@WebMvcTest(AccountApiKeyPageController.class)
+@Import(SecurityConfig.class)
+class AccountApiKeyPageControllerTest {
+
+    @Autowired MockMvc mvc;
+
+    @MockitoBean ApiKeyRepository apiKeyRepository;
+    @MockitoBean CurrentOrganizationResolver currentOrg;
+    @MockitoBean OAuth2UserService oAuth2UserService;
+
+    private static final UUID ORG_ID = UuidFactory.newId();
+
+    @BeforeEach
+    void seedAuth() {
+        User user = new User(UuidFactory.newId(), "robsartin", "rob@example.com");
+        when(currentOrg.resolve(any(UserDetails.class)))
+                .thenReturn(new CurrentOrganizationResolver.Resolved(user, ORG_ID));
+    }
+
+    /** GET /account/api-keys lists keys for the user's org, hiding archived. */
+    @Test
+    @WithMockUser
+    void listRendersOrgKeysExcludingArchived() throws Exception {
+        ApiKey active = key("CI runner", false);
+        ApiKey revoked = key("Old key", true);
+        when(apiKeyRepository.findByOrganizationId(ORG_ID)).thenReturn(List.of(active, revoked));
+
+        MvcResult result = mvc.perform(get("/account/api-keys"))
+                .andExpect(status().isOk())
+                .andExpect(view().name("account-api-keys"))
+                .andReturn();
+
+        String body = result.getResponse().getContentAsString();
+        assertThat(body).contains("CI runner").doesNotContain("Old key");
+    }
+
+    /** POST mints a key, persists hashed value, redirects with plaintext flash for one-time display. */
+    @Test
+    @WithMockUser
+    void createMintsKeyAndShowsPlaintextOnce() throws Exception {
+        when(apiKeyRepository.save(any(ApiKey.class)))
+                .thenAnswer(inv -> inv.getArgument(0));
+
+        MvcResult result = mvc.perform(post("/account/api-keys")
+                        .with(csrf())
+                        .param("name", "CI runner"))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(view().name("redirect:/account/api-keys"))
+                .andReturn();
+
+        // Plaintext key passed via flash attribute.
+        Object plaintext = result.getFlashMap().get("plaintextKey");
+        assertThat(plaintext).isInstanceOf(String.class);
+        assertThat((String) plaintext).hasSize(64); // 32 bytes hex-encoded
+
+        ArgumentCaptor<ApiKey> captor = ArgumentCaptor.forClass(ApiKey.class);
+        verify(apiKeyRepository).save(captor.capture());
+        ApiKey saved = captor.getValue();
+        assertThat(saved.getName()).isEqualTo("CI runner");
+        assertThat(saved.getOrganizationId()).isEqualTo(ORG_ID);
+        assertThat(saved.getHashedKey()).hasSize(64); // SHA-256 hex digest
+        assertThat(saved.getHashedKey()).isNotEqualTo(plaintext);
+    }
+
+    /** POST with blank name re-renders with error (flash) and does not save. */
+    @Test
+    @WithMockUser
+    void createWithBlankNameRendersErrorAndDoesNotSave() throws Exception {
+        MvcResult result = mvc.perform(post("/account/api-keys")
+                        .with(csrf())
+                        .param("name", ""))
+                .andExpect(status().is3xxRedirection())
+                .andReturn();
+
+        assertThat(result.getFlashMap().get("formError")).isEqualTo("Name is required.");
+        verify(apiKeyRepository, never()).save(any());
+    }
+
+    /** POST /account/api-keys/{id}/revoke soft-deletes (sets archivedAt), only when org matches. */
+    @Test
+    @WithMockUser
+    void revokeSoftDeletesOwnKey() throws Exception {
+        UUID keyId = UuidFactory.newId();
+        ApiKey existing = key("CI runner", false);
+        existing.setId(keyId);
+        when(apiKeyRepository.findById(keyId)).thenReturn(Optional.of(existing));
+        when(apiKeyRepository.save(any(ApiKey.class)))
+                .thenAnswer(inv -> inv.getArgument(0));
+
+        mvc.perform(post("/account/api-keys/{id}/revoke", keyId)
+                        .with(csrf()))
+                .andExpect(status().is3xxRedirection());
+
+        ArgumentCaptor<ApiKey> captor = ArgumentCaptor.forClass(ApiKey.class);
+        verify(apiKeyRepository).save(captor.capture());
+        assertThat(captor.getValue().getArchivedAt()).isNotNull();
+    }
+
+    /** Cross-org revoke is silently ignored (404 not surfaced — page redirects + flashes "key not found"). */
+    @Test
+    @WithMockUser
+    void revokeCrossOrgKeyIsIgnored() throws Exception {
+        UUID keyId = UuidFactory.newId();
+        ApiKey foreign = key("Other org", false);
+        foreign.setId(keyId);
+        foreign.setOrganizationId(UuidFactory.newId());
+        when(apiKeyRepository.findById(keyId)).thenReturn(Optional.of(foreign));
+
+        mvc.perform(post("/account/api-keys/{id}/revoke", keyId)
+                        .with(csrf()))
+                .andExpect(status().is3xxRedirection());
+
+        verify(apiKeyRepository, never()).save(any());
+    }
+
+    private static ApiKey key(String name, boolean archived) {
+        ApiKey k = new ApiKey();
+        k.setId(UuidFactory.newId());
+        k.setOrganizationId(ORG_ID);
+        k.setName(name);
+        k.setHashedKey("0".repeat(64));
+        k.setCreatedAt(Instant.now());
+        if (archived) {
+            k.setArchivedAt(Instant.now());
+        }
+        return k;
+    }
+}


### PR DESCRIPTION
## Summary
- New `/account/api-keys` Tailwind page lets the user mint, list, and revoke API keys scoped to their organization. Sibling to the REST controller at `/api/organizations/{orgId}/api-keys` (untouched).
- Create: mints a 32-byte `SecureRandom` key (hex-encoded → 64 chars), persists only the SHA-256 hash, returns plaintext via a flash attribute so the redirected list page shows it once with a "you won't see this again" warning.
- Revoke: soft-deletes the row (archivedAt). Cross-org revokes silently ignored.
- Blank-name on create flashes "Name is required." back to the list.
- Header gains an "API keys" link next to Sign out.

## Test plan
- [x] `./mvnw verify -DskipITs` green (542 tests, 0 failures, checkstyle clean)
- [x] Slice tests: list excludes archived, create mints + persists SHA-256 hash + flashes plaintext, blank-name validation, revoke own key sets `archivedAt`, cross-org revoke ignored.
- [ ] `gh pr checks` green (verify post-push, CodeQL included).

## Notes
- Sticks with SHA-256 for hashing per CLAUDE.md trade-off (Argon2id is overkill for high-entropy random keys).
- Plaintext only crosses the wire on the create response — never persisted, never re-shown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)