### PR TITLE
refactor(web): extract shared form helpers (closes #246)

### DIFF
--- a/src/main/java/com/majordomo/adapter/in/web/FormBindingHelper.java
+++ b/src/main/java/com/majordomo/adapter/in/web/FormBindingHelper.java
@@ -1,0 +1,80 @@
+package com.majordomo.adapter.in.web;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Form-binding utilities shared by the page controllers.
+ *
+ * <p>Each helper here was previously duplicated across PropertyPageController,
+ * ContactPageController, AuditPageController, and the link/unlink controllers.
+ * Centralized per #246. Pure functions only — no Spring dependencies, no
+ * mutable state.</p>
+ *
+ * <p>Note: the per-controller {@code populateFormState}/{@code echoFormState}
+ * methods are intentionally NOT extracted; their field lists differ enough
+ * across forms that a generic builder costs more abstraction than the few
+ * extra lines of duplication.</p>
+ */
+public final class FormBindingHelper {
+
+    private FormBindingHelper() { }
+
+    /**
+     * @param s any string
+     * @return {@code null} when the input is null or blank, otherwise the input unchanged
+     */
+    public static String blankToNull(String s) {
+        return (s == null || s.isBlank()) ? null : s;
+    }
+
+    /**
+     * Splits a textarea-style multi-line value into trimmed, non-blank lines.
+     *
+     * @param raw newline-separated input ({@code \r?\n})
+     * @return ordered list of trimmed lines, possibly empty (never null)
+     */
+    public static List<String> splitLines(String raw) {
+        if (raw == null || raw.isBlank()) {
+            return List.of();
+        }
+        List<String> out = new ArrayList<>();
+        for (String line : raw.split("\\r?\\n")) {
+            String trimmed = line.trim();
+            if (!trimmed.isEmpty()) {
+                out.add(trimmed);
+            }
+        }
+        return out;
+    }
+
+    /**
+     * Parses an optional UUID-string form parameter.
+     *
+     * @param s the form value (may be null/blank)
+     * @return parsed UUID, or {@code null} when blank
+     * @throws IllegalArgumentException if the input is non-blank but not a valid UUID
+     */
+    public static UUID parseUuid(String s) {
+        if (s == null || s.isBlank()) {
+            return null;
+        }
+        return UUID.fromString(s.trim());
+    }
+
+    /**
+     * Parses an optional decimal price-string form parameter.
+     *
+     * @param s the form value (may be null/blank)
+     * @return parsed BigDecimal, or {@code null} when blank
+     * @throws NumberFormatException if the input is non-blank but not a valid decimal
+     */
+    public static BigDecimal parsePrice(String s) {
+        if (s == null || s.isBlank()) {
+            return null;
+        }
+        return new BigDecimal(s.trim());
+    }
+}

--- a/src/main/java/com/majordomo/adapter/in/web/audit/AuditPageController.java
+++ b/src/main/java/com/majordomo/adapter/in/web/audit/AuditPageController.java
@@ -1,5 +1,6 @@
 package com.majordomo.adapter.in.web.audit;
 
+import com.majordomo.adapter.in.web.FormBindingHelper;
 import com.majordomo.application.identity.CurrentOrganizationResolver;
 import com.majordomo.domain.model.AuditLogEntry;
 import com.majordomo.domain.model.identity.User;
@@ -82,7 +83,7 @@ public class AuditPageController {
         }
         UUID orgId = ctx.organizationId();
 
-        String entityTypeFilter = blankToNull(entityType);
+        String entityTypeFilter = FormBindingHelper.blankToNull(entityType);
         UUID actorId = resolveActor(actor);
         Instant sinceInstant = parseDate(since);
         Instant untilInstant = parseDate(until);
@@ -125,10 +126,6 @@ public class AuditPageController {
             return null;
         }
         return LocalDate.parse(iso.trim()).atStartOfDay(ZoneOffset.UTC).toInstant();
-    }
-
-    private static String blankToNull(String s) {
-        return (s == null || s.isBlank()) ? null : s;
     }
 
     /** Ordered set of entity types appearing in the current result page (for the filter dropdown). */

--- a/src/main/java/com/majordomo/adapter/in/web/concierge/ContactPageController.java
+++ b/src/main/java/com/majordomo/adapter/in/web/concierge/ContactPageController.java
@@ -1,5 +1,6 @@
 package com.majordomo.adapter.in.web.concierge;
 
+import com.majordomo.adapter.in.web.FormBindingHelper;
 import com.majordomo.application.identity.CurrentOrganizationResolver;
 import com.majordomo.application.identity.OrganizationAccessService;
 import com.majordomo.domain.model.EntityNotFoundException;
@@ -258,7 +259,7 @@ public class ContactPageController {
                     organization, title, notes, emails, telephones, urls, nicknames);
             return "contact-form";
         }
-        List<String> emailList = splitLines(emails);
+        List<String> emailList = FormBindingHelper.splitLines(emails);
         String emailError = validateEmails(emailList);
         if (emailError != null) {
             populateFormState(model, null, null, ctx.user().getUsername(), emailError,
@@ -269,15 +270,15 @@ public class ContactPageController {
         Contact contact = new Contact();
         contact.setOrganizationId(ctx.organizationId());
         contact.setFormattedName(formattedName);
-        contact.setGivenName(blankToNull(givenName));
-        contact.setFamilyName(blankToNull(familyName));
-        contact.setOrganization(blankToNull(organization));
-        contact.setTitle(blankToNull(title));
-        contact.setNotes(blankToNull(notes));
+        contact.setGivenName(FormBindingHelper.blankToNull(givenName));
+        contact.setFamilyName(FormBindingHelper.blankToNull(familyName));
+        contact.setOrganization(FormBindingHelper.blankToNull(organization));
+        contact.setTitle(FormBindingHelper.blankToNull(title));
+        contact.setNotes(FormBindingHelper.blankToNull(notes));
         contact.setEmails(emailList);
-        contact.setTelephones(splitLines(telephones));
-        contact.setUrls(splitLines(urls));
-        contact.setNicknames(splitLines(nicknames));
+        contact.setTelephones(FormBindingHelper.splitLines(telephones));
+        contact.setUrls(FormBindingHelper.splitLines(urls));
+        contact.setNicknames(FormBindingHelper.splitLines(nicknames));
         contact.setAddresses(toAddresses(command.getAddresses(), null));
         Contact saved = contactUseCase.create(contact);
         return "redirect:/contacts/" + saved.getId();
@@ -355,7 +356,7 @@ public class ContactPageController {
                     organization, title, notes, emails, telephones, urls, nicknames);
             return "contact-form";
         }
-        List<String> emailList = splitLines(emails);
+        List<String> emailList = FormBindingHelper.splitLines(emails);
         String emailError = validateEmails(emailList);
         if (emailError != null) {
             populateFormState(model, id, existing, ctx.user().getUsername(), emailError,
@@ -367,22 +368,18 @@ public class ContactPageController {
         updated.setId(id);
         updated.setOrganizationId(existing.getOrganizationId());
         updated.setFormattedName(formattedName);
-        updated.setGivenName(blankToNull(givenName));
-        updated.setFamilyName(blankToNull(familyName));
-        updated.setOrganization(blankToNull(organization));
-        updated.setTitle(blankToNull(title));
-        updated.setNotes(blankToNull(notes));
+        updated.setGivenName(FormBindingHelper.blankToNull(givenName));
+        updated.setFamilyName(FormBindingHelper.blankToNull(familyName));
+        updated.setOrganization(FormBindingHelper.blankToNull(organization));
+        updated.setTitle(FormBindingHelper.blankToNull(title));
+        updated.setNotes(FormBindingHelper.blankToNull(notes));
         updated.setEmails(emailList);
-        updated.setTelephones(splitLines(telephones));
-        updated.setUrls(splitLines(urls));
-        updated.setNicknames(splitLines(nicknames));
+        updated.setTelephones(FormBindingHelper.splitLines(telephones));
+        updated.setUrls(FormBindingHelper.splitLines(urls));
+        updated.setNicknames(FormBindingHelper.splitLines(nicknames));
         updated.setAddresses(toAddresses(command.getAddresses(), id));
         contactUseCase.update(id, updated);
         return "redirect:/contacts/" + id;
-    }
-
-    private static String blankToNull(String s) {
-        return (s == null || s.isBlank()) ? null : s;
     }
 
     /** Drops blank rows; mints a fresh row id for each remaining row. */
@@ -397,25 +394,11 @@ public class ContactPageController {
             }
             out.add(new Address(
                     UuidFactory.newId(), contactId,
-                    blankToNull(r.getLabel()), blankToNull(r.getStreet()),
-                    blankToNull(r.getCity()), blankToNull(r.getState()),
-                    blankToNull(r.getPostalCode()), blankToNull(r.getCountry())));
+                    FormBindingHelper.blankToNull(r.getLabel()), FormBindingHelper.blankToNull(r.getStreet()),
+                    FormBindingHelper.blankToNull(r.getCity()), FormBindingHelper.blankToNull(r.getState()),
+                    FormBindingHelper.blankToNull(r.getPostalCode()), FormBindingHelper.blankToNull(r.getCountry())));
         }
         return out;
-    }
-
-    private static List<String> splitLines(String raw) {
-        if (raw == null || raw.isBlank()) {
-            return List.of();
-        }
-        List<String> lines = new ArrayList<>();
-        for (String line : raw.split("\\r?\\n")) {
-            String trimmed = line.trim();
-            if (!trimmed.isEmpty()) {
-                lines.add(trimmed);
-            }
-        }
-        return lines;
     }
 
     /** Returns null if all emails parse, or an error message naming the first bad line. */

--- a/src/main/java/com/majordomo/adapter/in/web/concierge/ContactPropertyLinkController.java
+++ b/src/main/java/com/majordomo/adapter/in/web/concierge/ContactPropertyLinkController.java
@@ -1,5 +1,6 @@
 package com.majordomo.adapter.in.web.concierge;
 
+import com.majordomo.adapter.in.web.FormBindingHelper;
 import com.majordomo.application.identity.CurrentOrganizationResolver;
 import com.majordomo.application.identity.OrganizationAccessService;
 import com.majordomo.domain.model.EntityNotFoundException;
@@ -93,7 +94,7 @@ public class ContactPropertyLinkController {
         link.setPropertyId(propertyId);
         link.setContactId(id);
         link.setRole(parseRole(role));
-        link.setNotes(blankToNull(notes));
+        link.setNotes(FormBindingHelper.blankToNull(notes));
         propertyContactRepository.save(link);
         return "redirect:/contacts/" + id;
     }
@@ -137,7 +138,4 @@ public class ContactPropertyLinkController {
         }
     }
 
-    private static String blankToNull(String s) {
-        return (s == null || s.isBlank()) ? null : s;
-    }
 }

--- a/src/main/java/com/majordomo/adapter/in/web/steward/PropertyContactLinkController.java
+++ b/src/main/java/com/majordomo/adapter/in/web/steward/PropertyContactLinkController.java
@@ -1,5 +1,6 @@
 package com.majordomo.adapter.in.web.steward;
 
+import com.majordomo.adapter.in.web.FormBindingHelper;
 import com.majordomo.application.identity.CurrentOrganizationResolver;
 import com.majordomo.application.identity.OrganizationAccessService;
 import com.majordomo.domain.model.EntityNotFoundException;
@@ -93,7 +94,7 @@ public class PropertyContactLinkController {
         link.setPropertyId(id);
         link.setContactId(contactId);
         link.setRole(parseRole(role));
-        link.setNotes(blankToNull(notes));
+        link.setNotes(FormBindingHelper.blankToNull(notes));
         propertyContactRepository.save(link);
         return "redirect:/properties/" + id;
     }
@@ -137,7 +138,4 @@ public class PropertyContactLinkController {
         }
     }
 
-    private static String blankToNull(String s) {
-        return (s == null || s.isBlank()) ? null : s;
-    }
 }

--- a/src/main/java/com/majordomo/adapter/in/web/steward/PropertyPageController.java
+++ b/src/main/java/com/majordomo/adapter/in/web/steward/PropertyPageController.java
@@ -1,5 +1,6 @@
 package com.majordomo.adapter.in.web.steward;
 
+import com.majordomo.adapter.in.web.FormBindingHelper;
 import com.majordomo.application.identity.CurrentOrganizationResolver;
 import com.majordomo.application.identity.OrganizationAccessService;
 import com.majordomo.domain.model.concierge.Contact;
@@ -237,23 +238,12 @@ public class PropertyPageController {
         property.setOrganizationId(ctx.organizationId());
         property.setName(name);
         property.setCategory(category);
-        property.setDescription(blankToNull(description));
-        property.setLocation(blankToNull(location));
+        property.setDescription(FormBindingHelper.blankToNull(description));
+        property.setLocation(FormBindingHelper.blankToNull(location));
         property.setPurchasePrice(price);
-        property.setParentId(parseUuid(parentId));
+        property.setParentId(FormBindingHelper.parseUuid(parentId));
         Property saved = propertyUseCase.create(property);
         return "redirect:/properties/" + saved.getId();
-    }
-
-    private static String blankToNull(String s) {
-        return (s == null || s.isBlank()) ? null : s;
-    }
-
-    private static UUID parseUuid(String s) {
-        if (s == null || s.isBlank()) {
-            return null;
-        }
-        return UUID.fromString(s.trim());
     }
 
     /**
@@ -372,10 +362,10 @@ public class PropertyPageController {
         updated.setOrganizationId(existing.getOrganizationId());
         updated.setName(name);
         updated.setCategory(category);
-        updated.setDescription(blankToNull(description));
-        updated.setLocation(blankToNull(location));
+        updated.setDescription(FormBindingHelper.blankToNull(description));
+        updated.setLocation(FormBindingHelper.blankToNull(location));
         updated.setPurchasePrice(price);
-        updated.setParentId(parseUuid(parentId));
+        updated.setParentId(FormBindingHelper.parseUuid(parentId));
         propertyUseCase.update(id, updated);
         return "redirect:/properties/" + id;
     }


### PR DESCRIPTION
## Summary
- New `com.majordomo.adapter.in.web.FormBindingHelper` carries `blankToNull`, `splitLines`, `parseUuid`, `parsePrice`. Pure functions, no Spring deps.
- Removes duplicates in `PropertyPageController`, `ContactPageController`, `AuditPageController`, `PropertyContactLinkController`, `ContactPropertyLinkController`.
- The validating `parsePrice` in `PropertyPageController` (signum check + `PriceFormatException`) stays local — its contract is property-specific.
- Per-controller `populateFormState` helpers are intentionally NOT extracted; field lists differ enough that a generic builder would cost more abstraction than the few lines of duplication. Documented in the helper class Javadoc.

## Test plan
- [x] `./mvnw verify -DskipITs` green (544 tests, 0 failures, checkstyle clean)
- [x] No behavior change — refactor only.
- [ ] `gh pr checks` green (verify post-push, CodeQL included).

🤖 Generated with [Claude Code](https://claude.com/claude-code)