### PR TITLE
test(envoy): move EnvoyVerticalSliceTest to *IntegrationTest profile (closes #257)

### DIFF
--- a/src/test/java/com/majordomo/application/envoy/EnvoyVerticalSliceIntegrationTest.java
+++ b/src/test/java/com/majordomo/application/envoy/EnvoyVerticalSliceIntegrationTest.java
@@ -36,9 +36,18 @@ import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+/**
+ * Vertical slice covering ingest → score → persist → notify with a mocked
+ * Anthropic client. Renamed to {@code *IntegrationTest} so it runs only under
+ * the {@code integration-tests} profile (Testcontainers Postgres) — the
+ * default H2 test profile rejects PostgreSQL-flavored array DDL like
+ * {@code text[]} that Hibernate generates for {@link com.majordomo.adapter.out.persistence.concierge.ContactEntity}
+ * and {@code user_preferences}, causing ordering-dependent failures when the
+ * full unit-test suite runs (issue #257).
+ */
 @SpringBootTest
-@ActiveProfiles("test")
-class EnvoyVerticalSliceTest {
+@ActiveProfiles("integration")
+class EnvoyVerticalSliceIntegrationTest {
 
     private static MockWebServer server;
     private static final UUID ORG_ID = UuidFactory.newId();


### PR DESCRIPTION
## Summary
`EnvoyVerticalSliceTest` bootstraps the full Spring context (`@SpringBootTest`) and Hibernate generates PostgreSQL-flavored DDL — `text[]` arrays — for the `contacts` and `user_preferences` tables. On the default H2 test profile this DDL fails to parse, but only when the full suite runs (test ordering corrupts the shared in-memory DB). Caused intermittent `mvn verify` failures.

Fix per the issue's Option C: rename to `EnvoyVerticalSliceIntegrationTest` and switch `@ActiveProfiles` to `integration`. Surefire's default config excludes `**/*IntegrationTest.java`; Failsafe (under the `integration-tests` Maven profile) includes the same pattern + uses Testcontainers Postgres + Flyway-managed schema, where array columns work correctly.

## Test plan
- [x] `./mvnw verify -DskipITs` deterministically green (543 tests). Previously flaky 537–544 depending on ordering.
- [x] Test still discoverable under `mvn -P integration-tests verify` (Postgres backed) — verified by inclusion pattern.
- [ ] `gh pr checks` green (verify post-push, CodeQL included).

🤖 Generated with [Claude Code](https://claude.com/claude-code)