### PR TITLE
docs: refresh developer documentation (closes #255)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,12 +14,13 @@ Majordomo is built as a collection of independent services, each named after a r
 
 | Service | Role | Responsibility |
 |---------|------|----------------|
-| **The Steward** | Property Service | Manages physical assets, their current state, and documentation (manuals, receipts) |
-| **The Concierge** | Contact Service | Manages relationships — vendors, maintenance professionals, and sellers |
-| **The Herald** | Calendar/Notification Service | Handles scheduling — service dates, reminders, warranty expirations |
-| **The Ledger** | Finance Service | Tracks costs from purchase price to lifetime maintenance spend |
+| **The Steward** | Property Service | Manages physical assets, their current state, parent/child hierarchy, and documentation (manuals, receipts, attachments) |
+| **The Concierge** | Contact Service | Manages relationships — vendors, maintenance professionals, sellers — and links them to properties |
+| **The Herald** | Calendar/Notification Service | Maintenance schedules, service-record history, due-date reminders, warranty expirations |
+| **The Ledger** | Finance Service | Tracks costs from purchase price to lifetime maintenance spend; per-property and org-level rollups |
+| **The Envoy** | Job-Posting Scoring (ADR-0022) | LLM-graded scoring of job postings against versioned rubrics; ingest from manual paste, URL, or Greenhouse |
 | **Identity** | User/Auth Service | Users, organizations, memberships, API keys, OAuth links |
-| **The Dashboard** | Summary Service | Aggregated overview of properties, contacts, maintenance, and spending |
+| **The Dashboard** | Summary Service | Aggregated overview — properties, contacts, upcoming maintenance, total/projected spend, recent apply-now postings |
 
 The **Majordomo** itself is the orchestration layer that ties these services together.
 
@@ -60,13 +61,13 @@ For detailed developer documentation, see [doc/authentication.md](doc/authentica
 # Start PostgreSQL and Redis
 docker-compose up -d
 
-# Run the application
+# Run the application (Java 25 required)
 ./mvnw spring-boot:run
 
 # Access
-# App:     http://localhost:8080
-# Login:   http://localhost:8080/login (robsartin / xyzzyPLAN9)
-# Swagger: http://localhost:8080/swagger-ui.html
+# App:      http://localhost:8080
+# Login:    http://localhost:8080/login  (robsartin / xyzzyPLAN9)
+# Swagger:  http://localhost:8080/swagger-ui.html
 ```
 
 To stop:
@@ -75,9 +76,24 @@ docker-compose down        # Stop containers (keep data)
 docker-compose down -v     # Stop and remove data volume
 ```
 
+If your shell defaults to JDK 17 or earlier (e.g. via SDKMAN), point Maven at a JDK 25 install:
+
+```bash
+export JAVA_HOME=/Library/Java/JavaVirtualMachines/temurin-25.jdk/Contents/Home
+./mvnw verify -DskipITs
+```
+
+## For developers
+
+- **[CLAUDE.md](CLAUDE.md)** — full developer guide: tech stack, ADR index, conventions, build commands.
+- **[doc/architecture.md](doc/architecture.md)** — top-down view of services, ports, adapters, and request flow.
+- **[doc/development.md](doc/development.md)** — build commands, test conventions, pre-PR checklist.
+- **[doc/domain-model.md](doc/domain-model.md)** — aggregate diagrams.
+- **[doc/adr/](doc/adr/)** — every architectural decision, numbered.
+
 ## Status
 
-Feature-complete. All services implemented, authentication operational (form login, OAuth2, API keys), documentation finalized. Architecture decisions recorded in `doc/adr/`.
+Active development. Core services (Steward, Concierge, Herald, Ledger, Envoy, Identity) and their web UIs are operational. Architecture decisions recorded in `doc/adr/`.
 
 ## License
 

--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -1,0 +1,124 @@
+# Architecture
+
+Majordomo is a single Spring Boot application organized as a set of services
+named after household staff. Each service follows hexagonal architecture
+(ports + adapters, ADR-0004) so the domain core never depends on Spring,
+JPA, or any specific transport.
+
+## Top-down view
+
+```mermaid
+flowchart LR
+    subgraph In[adapter/in]
+        Web[web controllers<br/>Thymeleaf + REST]
+        Event[event listeners<br/>AuditEventListener]
+    end
+
+    subgraph Core[domain + application]
+        Domain[domain/model<br/>aggregates, events, value objects]
+        Ports[domain/port<br/>in: use cases — out: repos]
+        App[application<br/>use case impls — *Service]
+    end
+
+    subgraph Out[adapter/out]
+        Persistence[persistence<br/>JPA entities + adapters]
+        Notification[notification<br/>email]
+        Storage[storage<br/>local file attachments]
+        LLM[llm<br/>Anthropic client]
+        EventOut[event<br/>Spring publisher]
+    end
+
+    Web -->|calls inbound port| App
+    Event -->|listens| EventOut
+    App -->|implements| Ports
+    App -->|reads/writes| Domain
+    App -->|calls outbound port| Persistence
+    App --> Notification
+    App --> Storage
+    App --> LLM
+```
+
+Hard rules (enforced by ArchUnit in `HexagonalArchitectureTest`):
+
+- `domain.model` has zero Spring or JPA imports (Jakarta Validation is the only
+  acknowledged exception, see CLAUDE.md "Known Trade-offs").
+- `domain.port` does not depend on adapters.
+- `application` does not depend on adapters.
+- `adapter.out` does not depend on `adapter.in`.
+- `adapter.in` does not depend on `adapter.out` (added by #248).
+- Production code calls `UuidFactory.newId()`, never `UUID.randomUUID()`
+  (added by #249).
+
+Cycles between top-level slices are detected and fail the build.
+
+## Services
+
+| Service | Domain package | Notable use cases |
+|---|---|---|
+| Steward | `domain/model/steward` | `ManagePropertyUseCase`, `PropertyContact` association |
+| Concierge | `domain/model/concierge` | `ManageContactUseCase`, vCard generation |
+| Herald | `domain/model/herald` | `ManageScheduleUseCase`, service-record history, due-date computation |
+| Ledger | `domain/model/ledger` | `QuerySpendUseCase` — read-only derivations |
+| Envoy | `domain/model/envoy` | `IngestJobPostingUseCase`, `ScoreJobPostingUseCase`, rubric versioning |
+| Identity | `domain/model/identity` | User, Membership, Credential, ApiKey, OAuthLink |
+| Dashboard | `domain/model/DashboardSummary` | aggregation over the others |
+
+Each service exposes a sibling REST controller under `/api/...` and a
+Thymeleaf web page controller under the unprefixed path:
+
+| URL prefix | Web controller | REST controller |
+|---|---|---|
+| `/properties` | `steward.PropertyPageController` | `steward.PropertyController` (`/api/properties`) |
+| `/contacts` | `concierge.ContactPageController` | `concierge.ContactController` (`/api/contacts`) |
+| `/schedules` | `herald.SchedulePageController` | `herald.ScheduleController` (`/api/schedules`) |
+| `/ledger` | `ledger.LedgerPageController` | `ledger.LedgerController` (`/api/ledger`) |
+| `/envoy` | `envoy.EnvoyPageController` | `envoy.EnvoyController` (`/api/envoy`) |
+| `/audit` | `audit.AuditPageController` | (no REST surface) |
+| `/account/api-keys` | `identity.AccountApiKeyPageController` | `identity.ApiKeyController` (`/api/organizations/{orgId}/api-keys`) |
+| `/dashboard` | `DashboardPageController` | `DashboardController` (`/api/dashboard`) |
+
+This split keeps each REST surface pure and the page controllers free to
+evolve UX-driven shapes (filters, picker dropdowns, indexed form binding).
+
+## Request flow: `GET /properties/{id}`
+
+1. **Spring Security filter chain** — `ApiKeyAuthenticationFilter`,
+   `CorrelationIdFilter`, then form-login / OAuth2 authentication.
+2. **`PropertyPageController.detail(id, principal, model)`** —
+   - Resolves the user's organization via `CurrentOrganizationResolver`
+   - Verifies cross-org access via `OrganizationAccessService.verifyAccess(...)`
+   - Loads the property, parent, children, linked contacts, schedules,
+     recent service records, attachments — all through inbound ports
+   - Builds candidate-contact list for the link picker
+   - Returns the `property-detail` Thymeleaf template name
+3. **Thymeleaf** renders the template with the populated model.
+4. **`GlobalExceptionHandler`** maps any `EntityNotFoundException` to 404 and
+   `AccessDeniedException` to 403; everything else to 500 with a JSON
+   `{ message, correlationId }` body.
+
+## Adding a new feature
+
+The shape of a typical feature is:
+
+1. **Domain first**: add records / entity fields / events under
+   `domain/model`. Use Jakarta Validation annotations for invariants the
+   adapters need to honor.
+2. **Port**: add a method to an existing inbound use-case interface (`domain/port/in/...`)
+   or outbound repo (`domain/port/out/...`), or — rarely — define a new port
+   interface.
+3. **Application**: implement the inbound port in `application/...`. Stay
+   free of Spring annotations except `@Service`. Avoid pulling in adapter
+   classes.
+4. **Adapters**: update JPA entities + mappers + adapter classes for the
+   outbound side; update web controllers for the inbound side. Keep
+   controllers under the 500-line checkstyle cap — split a sibling
+   controller for orthogonal POST routes (see `PropertyContactLinkController`).
+5. **Tests**: prefer `@WebMvcTest` slice tests over `@SpringBootTest`
+   (ADR-0021). Mock the inbound ports — do **not** mock the application
+   service unless you're slicing the controller alone.
+6. **Migration**: any new column or table goes through a Flyway migration
+   `V<next>__description.sql`; never edit a previously-shipped migration.
+7. **Verify**: run `./mvnw verify -DskipITs` and `gh pr checks <PR#>` after
+   pushing — CI gates merges via CodeQL too.
+
+See [development.md](development.md) for the full pre-PR checklist.

--- a/doc/development.md
+++ b/doc/development.md
@@ -1,0 +1,108 @@
+# Development
+
+This is the day-to-day reference. For the wide context (tech stack, ADR
+index, architecture rules), see [CLAUDE.md](../CLAUDE.md) and
+[architecture.md](architecture.md).
+
+## Prerequisites
+
+- **Java 25** — required by `pom.xml`. If your shell defaults to a lower
+  JDK (SDKMAN often points to 17 or 21), point Maven at a JDK 25 install:
+  ```bash
+  export JAVA_HOME=/Library/Java/JavaVirtualMachines/temurin-25.jdk/Contents/Home
+  ```
+- **Docker** — for local PostgreSQL 18 + Redis 7 (`docker-compose up -d`)
+  and for Testcontainers (integration tests).
+- **Maven 3.9+** — provided via `./mvnw` wrapper.
+
+## Build commands
+
+| Command | What it does |
+|---|---|
+| `./mvnw validate` | Checkstyle only — fast static check |
+| `./mvnw compile` | Compile main sources |
+| `./mvnw test` | Surefire unit tests (excludes `*IntegrationTest.java`) |
+| `./mvnw verify -DskipITs` | Compile + checkstyle + Surefire + JaCoCo (unit only) |
+| `./mvnw -Pintegration-tests verify` | Adds Failsafe integration tests (Testcontainers Postgres) |
+| `./mvnw spring-boot:run` | Starts the app; needs PostgreSQL + Redis up |
+
+JaCoCo reports land at `target/site/jacoco/index.html` after `verify`.
+
+## Test conventions (ADR-0021)
+
+- **Slice tests are the default.** Use `@WebMvcTest(SomeController.class)`
+  for controller behavior and `@DataJpaTest` for repository adapters. Mock
+  the inbound ports directly with `@MockitoBean`.
+- **`@SpringBootTest` is reserved** for end-to-end pipeline coverage and
+  smoke tests. The vertical-slice tests that need it are named
+  `*IntegrationTest.java` so they only run under the integration-tests
+  Maven profile (Testcontainers Postgres).
+- **Test method names** follow `behaviorWhenCondition` style (e.g.
+  `editFormReturns403WhenCrossOrg`). Each test has a one-line Javadoc
+  describing intent.
+- **TDD is mandatory** (ADR-0003): write a failing test, watch it RED,
+  implement the minimum to make it GREEN, commit, refactor, commit.
+
+## Pre-PR checklist
+
+Run **all** of these before declaring a PR ready:
+
+1. `./mvnw verify -DskipITs` — green locally (use the JAVA_HOME export above).
+2. `git push -u origin <branch>` — push the branch.
+3. `gh pr create --title ... --body ...` — open the PR.
+4. `gh pr checks <PR#>` — wait until **all four checks pass**:
+   - `Analyze (java-kotlin)` — CodeQL build
+   - `CodeQL` — security findings (this is the silent killer; e.g. ReDoS,
+     SSRF, command injection — fixes typically a regex or boundary check)
+   - `build` — Spring Boot CI
+   - `checkstyle` — style enforcement
+5. Only then ping for review.
+
+If any check fails, fix and push again before the PR is reviewable.
+Local checkstyle and tests don't catch CodeQL findings.
+
+## Conventions you'll bump into
+
+- **File length budget**: 500 lines per file (Checkstyle). When a
+  controller crosses, split a sibling for orthogonal routes (see
+  `PropertyContactLinkController`).
+- **Line length budget**: 120 characters.
+- **Javadoc**: required on public classes and methods (ADR-0015).
+  Getters / setters / JPA entities / mappers are exempt via
+  `config/checkstyle/suppressions.xml`.
+- **UUIDs**: always `UuidFactory.newId()`. Never `UUID.randomUUID()` in
+  production code — ArchUnit will fail the build (#249).
+- **Soft delete**: set `archivedAt` to `Instant.now()`. No hard deletes
+  except in tests.
+- **Form helpers**: pull `blankToNull`, `splitLines`, `parseUuid`, and
+  `parsePrice` from `com.majordomo.adapter.in.web.FormBindingHelper`
+  rather than re-rolling them.
+- **Cross-org access**: every page handler that loads a foreign entity
+  must call `OrganizationAccessService.verifyAccess(entity.getOrganizationId())`.
+  Surface 403 via `AccessDeniedException` (`GlobalExceptionHandler`
+  maps it).
+- **Migrations**: forward-only, numbered `V<next>__description.sql`.
+  Never edit a previously-shipped file.
+
+## Working with the LLM-driven services
+
+Envoy uses a real Anthropic client in production. For local dev:
+
+- Set `ANTHROPIC_API_KEY` in your environment, or
+- Run with profile `local-mock` (if present) which stubs the LLM.
+
+Tests mock `AnthropicMessageClient` — see `EnvoyVerticalSliceIntegrationTest`
+for the pattern.
+
+## Common gotchas
+
+- **Hibernate's H2 schema generation rejects `text[]` arrays.** Anything
+  hitting `@SpringBootTest` against H2 will see this; rename to
+  `*IntegrationTest.java` to route through Failsafe + Postgres
+  Testcontainers (ADR-0011).
+- **`@WebMvcTest` slice tests** must declare `@MockitoBean` for every
+  bean the controller's constructor injects, including `ApiKeyRepository`
+  and `OAuth2UserService` because the security filter chain reaches them.
+- **`@AuthenticationPrincipal UserDetails principal`** in Spring tests
+  pairs with `@WithMockUser(username = "...")` — the principal's
+  `getUsername()` is what `CurrentOrganizationResolver` resolves on.

--- a/doc/domain-model.md
+++ b/doc/domain-model.md
@@ -234,6 +234,7 @@ classDiagram
 
     %% ── Audit Log ──
     class AuditLogEntry {
+        +uuid_v7 organization_id
         +string entity_type
         +uuid_v7 entity_id
         +string action
@@ -252,10 +253,77 @@ classDiagram
 
     UserPreferences --> NotificationCategory
 
+    %% ── The Envoy (Job-Posting Scoring, ADR-0022) ──
+    class JobPosting {
+        +uuid_v7 organization_id
+        +string source_type
+        +string source_url
+        +string title
+        +string company
+        +string location
+        +string raw_text
+    }
+
+    class Rubric {
+        +uuid_v7 organization_id
+        +string name
+        +int version
+        +List~Category~ categories
+        +Thresholds thresholds
+    }
+
+    class ScoreReport {
+        +uuid_v7 organization_id
+        +uuid_v7 posting_id
+        +uuid_v7 rubric_id
+        +int total_score
+        +Recommendation recommendation
+        +List~Category~ categories
+        +List~Flag~ flags
+        +LlmUsage llm_usage
+    }
+
+    class Recommendation {
+        <<enumeration>>
+        APPLY_NOW
+        CONSIDER
+        SKIP
+    }
+
+    JobPosting --|> BaseEntity
+    Rubric --|> BaseEntity
+    ScoreReport --|> BaseEntity
+    JobPosting "1" --> "*" ScoreReport
+    Rubric "1" --> "*" ScoreReport
+    ScoreReport --> Recommendation
+
     %% ── Ownership ──
     Organization "1" --> "*" Property
     Organization "1" --> "*" Contact
+    Organization "1" --> "*" JobPosting
+    Organization "1" --> "*" Rubric
 ```
+
+## Recent additions
+
+- **`AuditLogEntry.organization_id`** (#242, V18 migration): scopes audit
+  entries to an organization so the `/audit` page filters cross-org rows
+  out. Populated from domain events that already carry `organizationId`;
+  events that don't (notably `ServiceRecordCreated`) record `null` until
+  enriched.
+- **`Property.parent_id`**: enables the parent-property picker on the add /
+  edit form (#229). Cycle prevention happens in `PropertyPageController`
+  by walking `findByParentId(...)` on the editing subtree.
+- **`Contact.addresses`**: editable as an indexed sub-form (#239) via the
+  `addresses[N].field` Spring binding pattern. Backed by
+  `ContactFormCommand` + `AddressFormRow`.
+- **`PropertyContact` link/unlink** (#240): the `archivedAt` field is now
+  the soft-delete signal for unlinks; both the property-detail and
+  contact-detail pages filter on it.
+- **`Envoy` aggregates** (ADR-0022): rubric versioning is append-only;
+  rescoring a posting against a new rubric version creates a new
+  `ScoreReport` rather than mutating the old one.
+
 
 ## Authentication Sequence
 


### PR DESCRIPTION
## Summary
- **README.md**: Envoy added to the services table; Java 25 / `JAVA_HOME` hint; pointer block to CLAUDE.md, architecture.md, development.md, and the ADR index.
- **doc/architecture.md** (new): top-down service+adapter diagram, the ArchUnit-enforced rules, URL-prefix table mapping web pages to their REST siblings, request-flow walkthrough for `GET /properties/{id}`, and a 6-step "adding a feature" recipe.
- **doc/development.md** (new): build commands, ADR-0021 test conventions, pre-PR checklist (including `gh pr checks` for the CodeQL gate), file/line budgets, soft-delete + form-helper + cross-org-access conventions, common gotchas (H2 array DDL, `@WebMvcTest` mock-bean expectations).
- **doc/domain-model.md**: `AuditLogEntry.organization_id` (#242); added the four Envoy aggregates with cardinalities; "Recent additions" changelog covering the recent UI parity sprint.

No code changes — purely doc updates.

## Test plan
- [x] `./mvnw verify -DskipITs` green (no Javadoc regressions, checkstyle clean)
- [ ] `gh pr checks` green post-push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)