### PR TITLE
refactor(web): finish FormBindingHelper extraction + tighten splitLines

### DIFF
--- a/src/main/java/com/majordomo/adapter/in/web/FormBindingHelper.java
+++ b/src/main/java/com/majordomo/adapter/in/web/FormBindingHelper.java
@@ -1,8 +1,10 @@
 package com.majordomo.adapter.in.web;
 
+import com.majordomo.domain.model.concierge.ContactRole;
+
 import java.math.BigDecimal;
-import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.UUID;
 
 /**
@@ -33,21 +35,17 @@ public final class FormBindingHelper {
     /**
      * Splits a textarea-style multi-line value into trimmed, non-blank lines.
      *
-     * @param raw newline-separated input ({@code \r?\n})
+     * @param raw newline-separated input (handles {@code \r}, {@code \n}, {@code \r\n})
      * @return ordered list of trimmed lines, possibly empty (never null)
      */
     public static List<String> splitLines(String raw) {
         if (raw == null || raw.isBlank()) {
             return List.of();
         }
-        List<String> out = new ArrayList<>();
-        for (String line : raw.split("\\r?\\n")) {
-            String trimmed = line.trim();
-            if (!trimmed.isEmpty()) {
-                out.add(trimmed);
-            }
-        }
-        return out;
+        return raw.lines()
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .toList();
     }
 
     /**
@@ -76,5 +74,24 @@ public final class FormBindingHelper {
             return null;
         }
         return new BigDecimal(s.trim());
+    }
+
+    /**
+     * Parses a contact-role form value, falling back to {@link ContactRole#OTHER}
+     * for blank or unrecognized input. Used by the property↔contact link forms
+     * where a role dropdown is always offered but the underlying enum may evolve.
+     *
+     * @param role the form value (may be null/blank)
+     * @return the matching {@link ContactRole}, or {@code OTHER} when unrecognized
+     */
+    public static ContactRole parseRole(String role) {
+        if (role == null || role.isBlank()) {
+            return ContactRole.OTHER;
+        }
+        try {
+            return ContactRole.valueOf(role.trim().toUpperCase(Locale.ROOT));
+        } catch (IllegalArgumentException ex) {
+            return ContactRole.OTHER;
+        }
     }
 }

--- a/src/main/java/com/majordomo/adapter/in/web/concierge/ContactPropertyLinkController.java
+++ b/src/main/java/com/majordomo/adapter/in/web/concierge/ContactPropertyLinkController.java
@@ -7,7 +7,6 @@ import com.majordomo.domain.model.EntityNotFoundException;
 import com.majordomo.domain.model.EntityType;
 import com.majordomo.domain.model.UuidFactory;
 import com.majordomo.domain.model.concierge.Contact;
-import com.majordomo.domain.model.concierge.ContactRole;
 import com.majordomo.domain.model.steward.Property;
 import com.majordomo.domain.model.steward.PropertyContact;
 import com.majordomo.domain.port.in.steward.ManagePropertyUseCase;
@@ -23,7 +22,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
 import java.time.Instant;
-import java.util.Locale;
 import java.util.UUID;
 
 /**
@@ -93,7 +91,7 @@ public class ContactPropertyLinkController {
         link.setId(UuidFactory.newId());
         link.setPropertyId(propertyId);
         link.setContactId(id);
-        link.setRole(parseRole(role));
+        link.setRole(FormBindingHelper.parseRole(role));
         link.setNotes(FormBindingHelper.blankToNull(notes));
         propertyContactRepository.save(link);
         return "redirect:/contacts/" + id;
@@ -125,17 +123,6 @@ public class ContactPropertyLinkController {
             }
         });
         return "redirect:/contacts/" + id;
-    }
-
-    private static ContactRole parseRole(String role) {
-        if (role == null || role.isBlank()) {
-            return ContactRole.OTHER;
-        }
-        try {
-            return ContactRole.valueOf(role.trim().toUpperCase(Locale.ROOT));
-        } catch (IllegalArgumentException ex) {
-            return ContactRole.OTHER;
-        }
     }
 
 }

--- a/src/main/java/com/majordomo/adapter/in/web/steward/PropertyContactLinkController.java
+++ b/src/main/java/com/majordomo/adapter/in/web/steward/PropertyContactLinkController.java
@@ -7,7 +7,6 @@ import com.majordomo.domain.model.EntityNotFoundException;
 import com.majordomo.domain.model.EntityType;
 import com.majordomo.domain.model.UuidFactory;
 import com.majordomo.domain.model.concierge.Contact;
-import com.majordomo.domain.model.concierge.ContactRole;
 import com.majordomo.domain.model.steward.Property;
 import com.majordomo.domain.model.steward.PropertyContact;
 import com.majordomo.domain.port.in.steward.ManagePropertyUseCase;
@@ -23,7 +22,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
 import java.time.Instant;
-import java.util.Locale;
 import java.util.UUID;
 
 /**
@@ -93,7 +91,7 @@ public class PropertyContactLinkController {
         link.setId(UuidFactory.newId());
         link.setPropertyId(id);
         link.setContactId(contactId);
-        link.setRole(parseRole(role));
+        link.setRole(FormBindingHelper.parseRole(role));
         link.setNotes(FormBindingHelper.blankToNull(notes));
         propertyContactRepository.save(link);
         return "redirect:/properties/" + id;
@@ -125,17 +123,6 @@ public class PropertyContactLinkController {
             }
         });
         return "redirect:/properties/" + id;
-    }
-
-    private static ContactRole parseRole(String role) {
-        if (role == null || role.isBlank()) {
-            return ContactRole.OTHER;
-        }
-        try {
-            return ContactRole.valueOf(role.trim().toUpperCase(Locale.ROOT));
-        } catch (IllegalArgumentException ex) {
-            return ContactRole.OTHER;
-        }
     }
 
 }

--- a/src/test/java/com/majordomo/architecture/HexagonalArchitectureTest.java
+++ b/src/test/java/com/majordomo/architecture/HexagonalArchitectureTest.java
@@ -83,8 +83,8 @@ class HexagonalArchitectureTest {
 
     /**
      * Inbound adapters (controllers) must not depend on outbound adapters
-     * (persistence, notification, storage). They go through ports only.
-     * Per #248 / ADR-0004.
+     * (persistence, notification, storage). They go through ports only
+     * (ADR-0004).
      */
     @Test
     void inboundAdaptersHaveNoOutboundDependency() {


### PR DESCRIPTION
## Summary
Three small follow-ups from a `/simplify` pass over the UI parity work:

1. **Extract `parseRole` to `FormBindingHelper`** — both `PropertyContactLinkController` and `ContactPropertyLinkController` had identical 10-line `parseRole(String) -> ContactRole` methods. Centralized.
2. **Modernize `splitLines`** — replaced the manual `split("\\r?\\n")` + trim/filter loop with `raw.lines().map(String::trim).filter(s -> !s.isEmpty()).toList()`. `String.lines()` already handles `\r`, `\n`, and `\r\n` line endings.
3. **Drop `// Per #248 / ADR-0004` task ref** in the Javadoc of the new ArchUnit rule. The ADR pointer is the durable info; PR refs rot.

## Test plan
- [x] `./mvnw verify -DskipITs` green (543 tests, 0 failures, checkstyle clean)
- [ ] `gh pr checks` green post-push.

## Larger findings filed as follow-ups
The /simplify review surfaced three issues bigger than this PR:

- **#263** — perf: batch-fetch linked properties/contacts on detail pages (N+1)
- **#264** — perf: avoid full-org fetch + in-memory filter for link pickers
- **#265** — tech-debt: collapse populateFormState parameter sprawl

🤖 Generated with [Claude Code](https://claude.com/claude-code)