### PR TITLE
perf(web): batch-fetch linked entities on detail pages (closes #263)

### DIFF
--- a/src/main/java/com/majordomo/adapter/in/web/concierge/ContactPageController.java
+++ b/src/main/java/com/majordomo/adapter/in/web/concierge/ContactPageController.java
@@ -11,7 +11,6 @@ import com.majordomo.domain.model.concierge.Contact;
 import com.majordomo.domain.model.steward.Property;
 import com.majordomo.domain.model.steward.PropertyContact;
 import com.majordomo.domain.port.in.concierge.ManageContactUseCase;
-import com.majordomo.domain.port.in.steward.ManagePropertyUseCase;
 import com.majordomo.domain.port.out.concierge.ContactRepository;
 import com.majordomo.domain.port.out.steward.PropertyContactRepository;
 import com.majordomo.domain.port.out.steward.PropertyRepository;
@@ -42,7 +41,6 @@ public class ContactPageController {
 
     private final ManageContactUseCase contactUseCase;
     private final ContactRepository contactRepository;
-    private final ManagePropertyUseCase propertyUseCase;
     private final PropertyRepository propertyRepository;
     private final PropertyContactRepository propertyContactRepository;
     private final CurrentOrganizationResolver currentOrg;
@@ -53,22 +51,19 @@ public class ContactPageController {
      *
      * @param contactUseCase            inbound port for contact management
      * @param contactRepository         outbound port for contact reads (used by list view)
-     * @param propertyUseCase           inbound port for property lookups
-     * @param propertyRepository        outbound port for property reads (link picker)
+     * @param propertyRepository        outbound port for property reads (link picker, batch hydration)
      * @param propertyContactRepository outbound port for property–contact associations
      * @param currentOrg                resolves the authenticated user's organization
      * @param organizationAccessService verifies caller has access to a given organization
      */
     public ContactPageController(ManageContactUseCase contactUseCase,
                                  ContactRepository contactRepository,
-                                 ManagePropertyUseCase propertyUseCase,
                                  PropertyRepository propertyRepository,
                                  PropertyContactRepository propertyContactRepository,
                                  CurrentOrganizationResolver currentOrg,
                                  OrganizationAccessService organizationAccessService) {
         this.contactUseCase = contactUseCase;
         this.contactRepository = contactRepository;
-        this.propertyUseCase = propertyUseCase;
         this.propertyRepository = propertyRepository;
         this.propertyContactRepository = propertyContactRepository;
         this.currentOrg = currentOrg;
@@ -159,19 +154,20 @@ public class ContactPageController {
         List<PropertyContact> activeLinks = propertyContactRepository.findByContactId(id).stream()
                 .filter(pc -> pc.getArchivedAt() == null)
                 .toList();
+        java.util.Set<UUID> linkedIds = activeLinks.stream()
+                .map(PropertyContact::getPropertyId)
+                .collect(java.util.stream.Collectors.toSet());
+        java.util.Map<UUID, Property> propertiesById = propertyRepository.findByIdIn(linkedIds).stream()
+                .collect(java.util.stream.Collectors.toMap(Property::getId, p -> p));
         List<LinkedPropertyRow> linkedRows = activeLinks.stream()
                 .map(pc -> {
-                    Property p = propertyUseCase.findById(pc.getPropertyId()).orElse(null);
+                    Property p = propertiesById.get(pc.getPropertyId());
                     return p == null ? null : new LinkedPropertyRow(pc, p);
                 })
                 .filter(r -> r != null)
                 .sorted(Comparator.comparing((LinkedPropertyRow r) -> r.property().getName(),
                         Comparator.nullsLast(String.CASE_INSENSITIVE_ORDER)))
                 .toList();
-
-        java.util.Set<UUID> linkedIds = activeLinks.stream()
-                .map(PropertyContact::getPropertyId)
-                .collect(java.util.stream.Collectors.toSet());
         List<Property> propertyCandidates =
                 propertyRepository.findByOrganizationId(contact.getOrganizationId()).stream()
                         .filter(p -> p.getArchivedAt() == null)

--- a/src/main/java/com/majordomo/adapter/in/web/steward/PropertyPageController.java
+++ b/src/main/java/com/majordomo/adapter/in/web/steward/PropertyPageController.java
@@ -10,7 +10,6 @@ import com.majordomo.domain.model.herald.ServiceRecord;
 import com.majordomo.domain.model.steward.Property;
 import com.majordomo.domain.model.steward.PropertyContact;
 import com.majordomo.domain.port.in.ManageAttachmentUseCase;
-import com.majordomo.domain.port.in.concierge.ManageContactUseCase;
 import com.majordomo.domain.port.in.herald.ManageScheduleUseCase;
 import com.majordomo.domain.port.in.steward.ManagePropertyUseCase;
 import com.majordomo.domain.port.out.concierge.ContactRepository;
@@ -50,7 +49,6 @@ public class PropertyPageController {
 
     private final ManagePropertyUseCase propertyUseCase;
     private final ManageScheduleUseCase scheduleUseCase;
-    private final ManageContactUseCase contactUseCase;
     private final ManageAttachmentUseCase attachmentUseCase;
     private final PropertyContactRepository propertyContactRepository;
     private final PropertyRepository propertyRepository;
@@ -79,11 +77,10 @@ public class PropertyPageController {
      *
      * @param propertyUseCase           the inbound port for property management
      * @param scheduleUseCase           the inbound port for maintenance schedule management
-     * @param contactUseCase            the inbound port for contact management
      * @param attachmentUseCase         the inbound port for attachment management
      * @param propertyContactRepository the outbound port for property-contact associations
      * @param propertyRepository        the outbound port for property reads (used by the list view)
-     * @param contactRepository         the outbound port for contact reads (used by the link picker)
+     * @param contactRepository         the outbound port for contact reads (link picker, batch hydration)
      * @param serviceRecordRepository   the outbound port for service-record reads (recent activity panel)
      * @param currentOrg                resolves the authenticated user's organization
      * @param organizationAccessService verifies the caller has access to a given organization
@@ -92,7 +89,6 @@ public class PropertyPageController {
      */
     public PropertyPageController(ManagePropertyUseCase propertyUseCase,
                                   ManageScheduleUseCase scheduleUseCase,
-                                  ManageContactUseCase contactUseCase,
                                   ManageAttachmentUseCase attachmentUseCase,
                                   PropertyContactRepository propertyContactRepository,
                                   PropertyRepository propertyRepository,
@@ -104,7 +100,6 @@ public class PropertyPageController {
                                   MembershipRepository membershipRepository) {
         this.propertyUseCase = propertyUseCase;
         this.scheduleUseCase = scheduleUseCase;
-        this.contactUseCase = contactUseCase;
         this.attachmentUseCase = attachmentUseCase;
         this.propertyContactRepository = propertyContactRepository;
         this.propertyRepository = propertyRepository;
@@ -426,13 +421,15 @@ public class PropertyPageController {
         List<PropertyContact> propertyContacts = propertyContactRepository.findByPropertyId(id).stream()
                 .filter(pc -> pc.getArchivedAt() == null)
                 .toList();
-        List<Contact> contacts = propertyContacts.stream()
-                .map(pc -> contactUseCase.findById(pc.getContactId()).orElse(null))
-                .filter(c -> c != null)
-                .toList();
         java.util.Set<UUID> linkedContactIds = propertyContacts.stream()
                 .map(PropertyContact::getContactId)
                 .collect(java.util.stream.Collectors.toSet());
+        java.util.Map<UUID, Contact> contactsById = contactRepository.findByIdIn(linkedContactIds).stream()
+                .collect(java.util.stream.Collectors.toMap(Contact::getId, c -> c));
+        List<Contact> contacts = propertyContacts.stream()
+                .map(pc -> contactsById.get(pc.getContactId()))
+                .filter(c -> c != null)
+                .toList();
         List<Contact> contactCandidates = contactRepository.findByOrganizationId(property.getOrganizationId()).stream()
                 .filter(c -> c.getArchivedAt() == null)
                 .filter(c -> !linkedContactIds.contains(c.getId()))

--- a/src/main/java/com/majordomo/adapter/out/persistence/concierge/ContactRepositoryAdapter.java
+++ b/src/main/java/com/majordomo/adapter/out/persistence/concierge/ContactRepositoryAdapter.java
@@ -9,6 +9,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Repository;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -35,6 +36,14 @@ public class ContactRepositoryAdapter implements ContactRepository {
     @Override
     public Optional<Contact> findById(UUID id) {
         return jpa.findById(id).map(ContactMapper::toDomain);
+    }
+
+    @Override
+    public List<Contact> findByIdIn(Collection<UUID> ids) {
+        if (ids == null || ids.isEmpty()) {
+            return List.of();
+        }
+        return jpa.findAllById(ids).stream().map(ContactMapper::toDomain).toList();
     }
 
     @Override

--- a/src/main/java/com/majordomo/adapter/out/persistence/steward/PropertyRepositoryAdapter.java
+++ b/src/main/java/com/majordomo/adapter/out/persistence/steward/PropertyRepositoryAdapter.java
@@ -11,6 +11,7 @@ import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDate;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -37,6 +38,14 @@ public class PropertyRepositoryAdapter implements PropertyRepository {
     @Override
     public Optional<Property> findById(UUID id) {
         return jpa.findById(id).map(PropertyMapper::toDomain);
+    }
+
+    @Override
+    public List<Property> findByIdIn(Collection<UUID> ids) {
+        if (ids == null || ids.isEmpty()) {
+            return List.of();
+        }
+        return jpa.findAllById(ids).stream().map(PropertyMapper::toDomain).toList();
     }
 
     @Override

--- a/src/main/java/com/majordomo/domain/port/out/concierge/ContactRepository.java
+++ b/src/main/java/com/majordomo/domain/port/out/concierge/ContactRepository.java
@@ -2,6 +2,7 @@ package com.majordomo.domain.port.out.concierge;
 
 import com.majordomo.domain.model.concierge.Contact;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -28,6 +29,15 @@ public interface ContactRepository {
      * @return the contact, or empty if not found
      */
     Optional<Contact> findById(UUID id);
+
+    /**
+     * Batch-fetches contacts by id. Used by detail handlers that need to
+     * hydrate a small set of linked contacts in a single round trip.
+     *
+     * @param ids the contact ids to load
+     * @return the matching contacts in arbitrary order, missing ids omitted
+     */
+    List<Contact> findByIdIn(Collection<UUID> ids);
 
     /**
      * Returns all contacts belonging to a given organization.

--- a/src/main/java/com/majordomo/domain/port/out/steward/PropertyRepository.java
+++ b/src/main/java/com/majordomo/domain/port/out/steward/PropertyRepository.java
@@ -3,6 +3,7 @@ package com.majordomo.domain.port.out.steward;
 import com.majordomo.domain.model.steward.Property;
 
 import java.time.LocalDate;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -30,6 +31,15 @@ public interface PropertyRepository {
      * @return the property, or empty if not found
      */
     Optional<Property> findById(UUID id);
+
+    /**
+     * Batch-fetches properties by id. Used by detail handlers that need to
+     * hydrate a small set of linked properties in a single round trip.
+     *
+     * @param ids the property ids to load
+     * @return the matching properties in arbitrary order, missing ids omitted
+     */
+    List<Property> findByIdIn(Collection<UUID> ids);
 
     /**
      * Returns all top-level and nested properties belonging to a given organization.

--- a/src/test/java/com/majordomo/adapter/in/web/concierge/ContactPageDetailTest.java
+++ b/src/test/java/com/majordomo/adapter/in/web/concierge/ContactPageDetailTest.java
@@ -176,8 +176,7 @@ class ContactPageDetailTest {
         b.setId(propB);
         b.setOrganizationId(ORG_ID);
         b.setName("Mountain Cabin");
-        when(propertyUseCase.findById(propA)).thenReturn(Optional.of(a));
-        when(propertyUseCase.findById(propB)).thenReturn(Optional.of(b));
+        when(propertyRepository.findByIdIn(any())).thenReturn(List.of(a, b));
 
         MvcResult result = mvc.perform(get("/contacts/{id}", id))
                 .andExpect(status().isOk())


### PR DESCRIPTION
## Summary
Both detail handlers were doing per-row entity lookups inside a stream walk — a textbook N+1 against the linked-entities count.

- `ContactPageController.detail`: replaced `activeLinks.stream().map(pc -> propertyUseCase.findById(...).orElse(null))` with one `propertyRepository.findByIdIn(linkedIds)` plus a `Map<UUID, Property>` for O(1) row hydration.
- `PropertyPageController.detail`: same pattern, now `contactRepository.findByIdIn`.

## Port + adapter changes
- `ContactRepository.findByIdIn(Collection<UUID>)` — delegates to Spring Data's `findAllById`.
- `PropertyRepository.findByIdIn(Collection<UUID>)` — same.
- Both return an empty `List` for `null`/empty input.

## Cleanup
- `ContactPageController` no longer needs `ManagePropertyUseCase` (only used for the now-batched lookup) — dropped from constructor + field.
- `PropertyPageController` no longer needs `ManageContactUseCase` for the same reason — dropped.
- `ContactPageDetailTest` updated to stub `propertyRepository.findByIdIn` instead of two `propertyUseCase.findById` calls.

## Test plan
- [x] `./mvnw verify -DskipITs` green (543 tests, 0 failures, checkstyle clean)
- [ ] `gh pr checks` green post-push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)