### PR TITLE
perf(web): scoped link-picker queries (closes #264)

### DIFF
--- a/src/main/java/com/majordomo/adapter/in/web/concierge/ContactPageController.java
+++ b/src/main/java/com/majordomo/adapter/in/web/concierge/ContactPageController.java
@@ -168,13 +168,11 @@ public class ContactPageController {
                 .sorted(Comparator.comparing((LinkedPropertyRow r) -> r.property().getName(),
                         Comparator.nullsLast(String.CASE_INSENSITIVE_ORDER)))
                 .toList();
-        List<Property> propertyCandidates =
-                propertyRepository.findByOrganizationId(contact.getOrganizationId()).stream()
-                        .filter(p -> p.getArchivedAt() == null)
-                        .filter(p -> !linkedIds.contains(p.getId()))
-                        .sorted(Comparator.comparing(Property::getName,
-                                Comparator.nullsLast(String.CASE_INSENSITIVE_ORDER)))
-                        .toList();
+        List<Property> propertyCandidates = propertyRepository
+                .findActiveByOrganizationIdExcluding(contact.getOrganizationId(), linkedIds).stream()
+                .sorted(Comparator.comparing(Property::getName,
+                        Comparator.nullsLast(String.CASE_INSENSITIVE_ORDER)))
+                .toList();
 
         model.addAttribute("contact", contact);
         model.addAttribute("linkedRows", linkedRows);

--- a/src/main/java/com/majordomo/adapter/in/web/steward/PropertyPageController.java
+++ b/src/main/java/com/majordomo/adapter/in/web/steward/PropertyPageController.java
@@ -430,9 +430,8 @@ public class PropertyPageController {
                 .map(pc -> contactsById.get(pc.getContactId()))
                 .filter(c -> c != null)
                 .toList();
-        List<Contact> contactCandidates = contactRepository.findByOrganizationId(property.getOrganizationId()).stream()
-                .filter(c -> c.getArchivedAt() == null)
-                .filter(c -> !linkedContactIds.contains(c.getId()))
+        List<Contact> contactCandidates = contactRepository
+                .findActiveByOrganizationIdExcluding(property.getOrganizationId(), linkedContactIds).stream()
                 .sorted(Comparator.comparing(Contact::getFormattedName,
                         Comparator.nullsLast(String.CASE_INSENSITIVE_ORDER)))
                 .toList();

--- a/src/main/java/com/majordomo/adapter/out/persistence/concierge/ContactRepositoryAdapter.java
+++ b/src/main/java/com/majordomo/adapter/out/persistence/concierge/ContactRepositoryAdapter.java
@@ -47,6 +47,15 @@ public class ContactRepositoryAdapter implements ContactRepository {
     }
 
     @Override
+    public List<Contact> findActiveByOrganizationIdExcluding(UUID organizationId,
+                                                             Collection<UUID> excludedIds) {
+        List<ContactEntity> rows = (excludedIds == null || excludedIds.isEmpty())
+                ? jpa.findByOrganizationIdAndArchivedAtIsNull(organizationId)
+                : jpa.findByOrganizationIdAndArchivedAtIsNullAndIdNotIn(organizationId, excludedIds);
+        return rows.stream().map(ContactMapper::toDomain).toList();
+    }
+
+    @Override
     public List<Contact> findByOrganizationId(UUID organizationId) {
         return jpa.findByOrganizationId(organizationId).stream().map(ContactMapper::toDomain).toList();
     }

--- a/src/main/java/com/majordomo/adapter/out/persistence/concierge/JpaContactRepository.java
+++ b/src/main/java/com/majordomo/adapter/out/persistence/concierge/JpaContactRepository.java
@@ -3,6 +3,7 @@ package com.majordomo.adapter.out.persistence.concierge;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.UUID;
 
@@ -20,4 +21,25 @@ public interface JpaContactRepository extends JpaRepository<ContactEntity, UUID>
      * @return list of all contact entities for the organization
      */
     List<ContactEntity> findByOrganizationId(UUID organizationId);
+
+    /**
+     * Active (non-archived) contacts in an organization. The adapter calls
+     * this when no contacts need to be excluded.
+     *
+     * @param organizationId organization scope
+     * @return matching active contacts
+     */
+    List<ContactEntity> findByOrganizationIdAndArchivedAtIsNull(UUID organizationId);
+
+    /**
+     * Active (non-archived) contacts in an organization, excluding the given
+     * non-empty set of ids. Callers must check the excluded set is non-empty
+     * — the underlying SQL {@code IN ()} clause would be malformed otherwise.
+     *
+     * @param organizationId organization scope
+     * @param excludedIds    ids to omit (must be non-empty)
+     * @return matching active contacts
+     */
+    List<ContactEntity> findByOrganizationIdAndArchivedAtIsNullAndIdNotIn(
+            UUID organizationId, Collection<UUID> excludedIds);
 }

--- a/src/main/java/com/majordomo/adapter/out/persistence/steward/JpaPropertyRepository.java
+++ b/src/main/java/com/majordomo/adapter/out/persistence/steward/JpaPropertyRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDate;
+import java.util.Collection;
 import java.util.List;
 import java.util.UUID;
 
@@ -23,6 +24,26 @@ public interface JpaPropertyRepository extends JpaRepository<PropertyEntity, UUI
      * @return list of all property entities for the organization
      */
     List<PropertyEntity> findByOrganizationId(UUID organizationId);
+
+    /**
+     * Active (non-archived) properties in an organization. Adapter uses this
+     * when the link picker has no exclusions.
+     *
+     * @param organizationId organization scope
+     * @return active property entities
+     */
+    List<PropertyEntity> findByOrganizationIdAndArchivedAtIsNull(UUID organizationId);
+
+    /**
+     * Active (non-archived) properties in an organization, excluding given
+     * non-empty ids. Caller must check the excluded set is non-empty.
+     *
+     * @param organizationId organization scope
+     * @param excludedIds    ids to omit (must be non-empty)
+     * @return matching active property entities
+     */
+    List<PropertyEntity> findByOrganizationIdAndArchivedAtIsNullAndIdNotIn(
+            UUID organizationId, Collection<UUID> excludedIds);
 
     /**
      * Returns all properties with the given parent ID.

--- a/src/main/java/com/majordomo/adapter/out/persistence/steward/PropertyRepositoryAdapter.java
+++ b/src/main/java/com/majordomo/adapter/out/persistence/steward/PropertyRepositoryAdapter.java
@@ -49,6 +49,15 @@ public class PropertyRepositoryAdapter implements PropertyRepository {
     }
 
     @Override
+    public List<Property> findActiveByOrganizationIdExcluding(UUID organizationId,
+                                                              Collection<UUID> excludedIds) {
+        List<PropertyEntity> rows = (excludedIds == null || excludedIds.isEmpty())
+                ? jpa.findByOrganizationIdAndArchivedAtIsNull(organizationId)
+                : jpa.findByOrganizationIdAndArchivedAtIsNullAndIdNotIn(organizationId, excludedIds);
+        return rows.stream().map(PropertyMapper::toDomain).toList();
+    }
+
+    @Override
     public List<Property> findByOrganizationId(UUID organizationId) {
         return jpa.findByOrganizationId(organizationId).stream().map(PropertyMapper::toDomain).toList();
     }

--- a/src/main/java/com/majordomo/domain/port/out/concierge/ContactRepository.java
+++ b/src/main/java/com/majordomo/domain/port/out/concierge/ContactRepository.java
@@ -48,6 +48,17 @@ public interface ContactRepository {
     List<Contact> findByOrganizationId(UUID organizationId);
 
     /**
+     * Returns active (non-archived) contacts in an organization, excluding the
+     * given ids. Used by link-picker dropdowns that need "everyone in the org
+     * except those already linked here".
+     *
+     * @param organizationId the organization scope
+     * @param excludedIds    ids to omit from the result (may be empty)
+     * @return list of matching active contacts; empty if the org has none
+     */
+    List<Contact> findActiveByOrganizationIdExcluding(UUID organizationId, Collection<UUID> excludedIds);
+
+    /**
      * Returns contacts for an organization with cursor-based pagination.
      *
      * @param organizationId the organization ID

--- a/src/main/java/com/majordomo/domain/port/out/steward/PropertyRepository.java
+++ b/src/main/java/com/majordomo/domain/port/out/steward/PropertyRepository.java
@@ -50,6 +50,17 @@ public interface PropertyRepository {
     List<Property> findByOrganizationId(UUID organizationId);
 
     /**
+     * Returns active (non-archived) properties in an organization, excluding
+     * the given ids. Used by link-picker dropdowns that need "every property
+     * in the org except those already linked here".
+     *
+     * @param organizationId the organization scope
+     * @param excludedIds    ids to omit from the result (may be empty)
+     * @return list of matching active properties; empty if the org has none
+     */
+    List<Property> findActiveByOrganizationIdExcluding(UUID organizationId, Collection<UUID> excludedIds);
+
+    /**
      * Returns properties for an organization with cursor-based pagination.
      *
      * @param organizationId the organization ID


### PR DESCRIPTION
## Summary
Both detail handlers built their candidate-link dropdowns by loading **all** contacts/properties for the org and filtering in-memory. For an org with 100+ rows that's a full table read for what's typically a 10-row dropdown.

- New repo method `findActiveByOrganizationIdExcluding(orgId, ids)` on both `ContactRepository` and `PropertyRepository`. The adapter splits between two derived JPA queries — one for the empty-excluded path, one with `AND id NOT IN :ids` for the non-empty path — to avoid malformed `IN ()` SQL.
- `ContactPageController.detail` and `PropertyPageController.detail` use the scoped query instead of full-fetch + stream filter.
- The non-archived filter is now pushed down to SQL; the in-memory sort by name stays local since the output is tiny.

## Test plan
- [x] `./mvnw verify -DskipITs` green (543 tests, 0 failures, checkstyle clean)
- [ ] `gh pr checks` green post-push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)