### PR TITLE
refactor(web): collapse populateFormState parameter sprawl (closes #265)

### DIFF
--- a/src/main/java/com/majordomo/adapter/in/web/concierge/ContactPageController.java
+++ b/src/main/java/com/majordomo/adapter/in/web/concierge/ContactPageController.java
@@ -249,18 +249,17 @@ public class ContactPageController {
         if (ctx.organizationId() == null) {
             return "redirect:/";
         }
+        var fields = new ContactFormFields(formattedName, givenName, familyName,
+                organization, title, notes, emails, telephones, urls, nicknames);
         if (formattedName == null || formattedName.isBlank()) {
             populateFormState(model, null, null, ctx.user().getUsername(),
-                    "Formatted name is required.", formattedName, givenName, familyName,
-                    organization, title, notes, emails, telephones, urls, nicknames);
+                    "Formatted name is required.", fields);
             return "contact-form";
         }
         List<String> emailList = FormBindingHelper.splitLines(emails);
         String emailError = validateEmails(emailList);
         if (emailError != null) {
-            populateFormState(model, null, null, ctx.user().getUsername(), emailError,
-                    formattedName, givenName, familyName, organization, title, notes,
-                    emails, telephones, urls, nicknames);
+            populateFormState(model, null, null, ctx.user().getUsername(), emailError, fields);
             return "contact-form";
         }
         Contact contact = new Contact();
@@ -346,18 +345,17 @@ public class ContactPageController {
         Contact existing = contactRepository.findById(id)
                 .orElseThrow(() -> new EntityNotFoundException(EntityType.CONTACT.name(), id));
         organizationAccessService.verifyAccess(existing.getOrganizationId());
+        var fields = new ContactFormFields(formattedName, givenName, familyName,
+                organization, title, notes, emails, telephones, urls, nicknames);
         if (formattedName == null || formattedName.isBlank()) {
             populateFormState(model, id, existing, ctx.user().getUsername(),
-                    "Formatted name is required.", formattedName, givenName, familyName,
-                    organization, title, notes, emails, telephones, urls, nicknames);
+                    "Formatted name is required.", fields);
             return "contact-form";
         }
         List<String> emailList = FormBindingHelper.splitLines(emails);
         String emailError = validateEmails(emailList);
         if (emailError != null) {
-            populateFormState(model, id, existing, ctx.user().getUsername(), emailError,
-                    formattedName, givenName, familyName, organization, title, notes,
-                    emails, telephones, urls, nicknames);
+            populateFormState(model, id, existing, ctx.user().getUsername(), emailError, fields);
             return "contact-form";
         }
         Contact updated = new Contact();
@@ -418,26 +416,43 @@ public class ContactPageController {
     private static final java.util.regex.Pattern EMAIL_PATTERN =
             java.util.regex.Pattern.compile("^[^\\s@]+@[^\\s@.]+(\\.[^\\s@.]+)+$");
 
+    /**
+     * Bundle of contact-form field strings echoed back when re-rendering on
+     * a validation failure. Reduces what was a 14-arg call into a record.
+     *
+     * @param formattedName submitted formatted name (display)
+     * @param givenName     submitted given name
+     * @param familyName    submitted family name
+     * @param organization  submitted organization
+     * @param title         submitted title
+     * @param notes         submitted notes
+     * @param emails        submitted multi-line emails (raw)
+     * @param telephones    submitted multi-line phones (raw)
+     * @param urls          submitted multi-line URLs (raw)
+     * @param nicknames     submitted multi-line nicknames (raw)
+     */
+    private record ContactFormFields(String formattedName, String givenName, String familyName,
+                                     String organization, String title, String notes,
+                                     String emails, String telephones, String urls,
+                                     String nicknames) { }
+
     private static void populateFormState(Model model, UUID editingId, Contact existing,
                                           String username, String formError,
-                                          String formattedName, String givenName, String familyName,
-                                          String organization, String title, String notes,
-                                          String emails, String telephones, String urls,
-                                          String nicknames) {
+                                          ContactFormFields fields) {
         model.addAttribute("editingId", editingId);
         model.addAttribute("existing", existing);
         model.addAttribute("username", username);
         model.addAttribute("formError", formError);
-        model.addAttribute("formFormattedName", formattedName);
-        model.addAttribute("formGivenName", givenName);
-        model.addAttribute("formFamilyName", familyName);
-        model.addAttribute("formOrganization", organization);
-        model.addAttribute("formTitle", title);
-        model.addAttribute("formNotes", notes);
-        model.addAttribute("formEmails", emails);
-        model.addAttribute("formTelephones", telephones);
-        model.addAttribute("formUrls", urls);
-        model.addAttribute("formNicknames", nicknames);
+        model.addAttribute("formFormattedName", fields.formattedName());
+        model.addAttribute("formGivenName", fields.givenName());
+        model.addAttribute("formFamilyName", fields.familyName());
+        model.addAttribute("formOrganization", fields.organization());
+        model.addAttribute("formTitle", fields.title());
+        model.addAttribute("formNotes", fields.notes());
+        model.addAttribute("formEmails", fields.emails());
+        model.addAttribute("formTelephones", fields.telephones());
+        model.addAttribute("formUrls", fields.urls());
+        model.addAttribute("formNicknames", fields.nicknames());
     }
 
     private static boolean matchesQuery(Contact c, String qLower) {

--- a/src/main/java/com/majordomo/adapter/in/web/steward/PropertyPageController.java
+++ b/src/main/java/com/majordomo/adapter/in/web/steward/PropertyPageController.java
@@ -216,9 +216,10 @@ public class PropertyPageController {
         if (ctx.organizationId() == null) {
             return "redirect:/";
         }
+        var fields = new PropertyFormFields(name, category, description, location, purchasePrice);
         if (name == null || name.isBlank()) {
             populateFormState(model, null, null, ctx.user().getUsername(),
-                    "Name is required.", name, category, description, location, purchasePrice);
+                    "Name is required.", fields);
             return "property-form";
         }
         java.math.BigDecimal price;
@@ -226,7 +227,7 @@ public class PropertyPageController {
             price = parsePrice(purchasePrice);
         } catch (PriceFormatException ex) {
             populateFormState(model, null, null, ctx.user().getUsername(),
-                    ex.getMessage(), name, category, description, location, purchasePrice);
+                    ex.getMessage(), fields);
             return "property-form";
         }
         Property property = new Property();
@@ -292,19 +293,31 @@ public class PropertyPageController {
         }
     }
 
+    /**
+     * Bundle of property-form field strings echoed back when re-rendering on
+     * a validation failure. Reduces what was a 9-arg call into a small record.
+     *
+     * @param name          submitted name
+     * @param category      submitted category
+     * @param description   submitted description
+     * @param location      submitted location
+     * @param purchasePrice submitted purchase-price string (raw, unparsed)
+     */
+    private record PropertyFormFields(String name, String category, String description,
+                                      String location, String purchasePrice) { }
+
     private static void populateFormState(Model model, UUID editingId, Property existing,
                                           String username, String formError,
-                                          String name, String category, String description,
-                                          String location, String purchasePrice) {
+                                          PropertyFormFields fields) {
         model.addAttribute("editingId", editingId);
         model.addAttribute("existing", existing);
         model.addAttribute("username", username);
         model.addAttribute("formError", formError);
-        model.addAttribute("formName", name);
-        model.addAttribute("formCategory", category);
-        model.addAttribute("formDescription", description);
-        model.addAttribute("formLocation", location);
-        model.addAttribute("formPurchasePrice", purchasePrice);
+        model.addAttribute("formName", fields.name());
+        model.addAttribute("formCategory", fields.category());
+        model.addAttribute("formDescription", fields.description());
+        model.addAttribute("formLocation", fields.location());
+        model.addAttribute("formPurchasePrice", fields.purchasePrice());
     }
 
     /**
@@ -339,9 +352,10 @@ public class PropertyPageController {
                 .orElseThrow(() -> new com.majordomo.domain.model.EntityNotFoundException(
                         com.majordomo.domain.model.EntityType.PROPERTY.name(), id));
         organizationAccessService.verifyAccess(existing.getOrganizationId());
+        var fields = new PropertyFormFields(name, category, description, location, purchasePrice);
         if (name == null || name.isBlank()) {
             populateFormState(model, id, existing, ctx.user().getUsername(),
-                    "Name is required.", name, category, description, location, purchasePrice);
+                    "Name is required.", fields);
             return "property-form";
         }
         java.math.BigDecimal price;
@@ -349,7 +363,7 @@ public class PropertyPageController {
             price = parsePrice(purchasePrice);
         } catch (PriceFormatException ex) {
             populateFormState(model, id, existing, ctx.user().getUsername(),
-                    ex.getMessage(), name, category, description, location, purchasePrice);
+                    ex.getMessage(), fields);
             return "property-form";
         }
         Property updated = new Property();


### PR DESCRIPTION
## Summary
Both `populateFormState` methods carried their form fields as positional parameters — 9 in `PropertyPageController`, 14 in `ContactPageController`. Easy to misalign on edits.

Each controller now defines a small private record (`PropertyFormFields`, `ContactFormFields`) bundling the form-field strings. Call sites construct the record once at the top of each handler and pass it through to the validation re-renders. The helper signature drops to `(Model, UUID, T existing, String, String, FormFields)`.

## Test plan
- [x] `./mvnw verify -DskipITs` green (543 tests, 0 failures, checkstyle clean)
- [x] No behavior change — refactor only.
- [ ] `gh pr checks` green post-push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)