### PR TITLE
feat(web): OrgContext argument resolver (closes #270)

### DIFF
--- a/src/main/java/com/majordomo/adapter/in/web/DashboardPageController.java
+++ b/src/main/java/com/majordomo/adapter/in/web/DashboardPageController.java
@@ -1,12 +1,10 @@
 package com.majordomo.adapter.in.web;
 
-import com.majordomo.application.identity.CurrentOrganizationResolver;
+import com.majordomo.adapter.in.web.config.OrgContext;
 import com.majordomo.domain.port.in.DashboardUseCase;
 import com.majordomo.domain.port.in.envoy.GetRecentApplyNowPostingsUseCase;
 import com.majordomo.domain.port.in.ledger.QuerySpendUseCase;
 
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -20,7 +18,6 @@ public class DashboardPageController {
     private static final int APPLY_NOW_PANEL_LIMIT = 5;
 
     private final DashboardUseCase dashboardUseCase;
-    private final CurrentOrganizationResolver currentOrg;
     private final GetRecentApplyNowPostingsUseCase recentApplyNowUseCase;
     private final QuerySpendUseCase spendUseCase;
 
@@ -28,16 +25,13 @@ public class DashboardPageController {
      * Constructs the dashboard page controller.
      *
      * @param dashboardUseCase      the inbound port for dashboard data retrieval
-     * @param currentOrg            resolves the authenticated user's first organization
      * @param recentApplyNowUseCase inbound port for recent APPLY_NOW postings
      * @param spendUseCase          inbound port for ledger spend queries
      */
     public DashboardPageController(DashboardUseCase dashboardUseCase,
-                                   CurrentOrganizationResolver currentOrg,
                                    GetRecentApplyNowPostingsUseCase recentApplyNowUseCase,
                                    QuerySpendUseCase spendUseCase) {
         this.dashboardUseCase = dashboardUseCase;
-        this.currentOrg = currentOrg;
         this.recentApplyNowUseCase = recentApplyNowUseCase;
         this.spendUseCase = spendUseCase;
     }
@@ -45,20 +39,16 @@ public class DashboardPageController {
     /**
      * Renders the dashboard page for the authenticated user's organization.
      *
-     * @param principal the authenticated user
-     * @param model     the Thymeleaf model
-     * @return the dashboard template name, or a redirect if the user has no organization
+     * @param orgContext authenticated user + organization, resolved by
+     *                   {@link com.majordomo.adapter.in.web.config.OrgContextArgumentResolver}
+     * @param model      the Thymeleaf model
+     * @return the dashboard template name
      */
     @GetMapping("/dashboard")
-    public String dashboard(@AuthenticationPrincipal UserDetails principal, Model model) {
-        var resolved = currentOrg.resolve(principal);
-        if (resolved.organizationId() == null) {
-            return "redirect:/";
-        }
-        var orgId = resolved.organizationId();
-        var summary = dashboardUseCase.getSummary(orgId);
-        model.addAttribute("summary", summary);
-        model.addAttribute("username", resolved.user().getUsername());
+    public String dashboard(OrgContext orgContext, Model model) {
+        var orgId = orgContext.organizationId();
+        model.addAttribute("summary", dashboardUseCase.getSummary(orgId));
+        model.addAttribute("username", orgContext.username());
         model.addAttribute("applyNowPostings",
                 recentApplyNowUseCase.getRecentApplyNow(orgId, APPLY_NOW_PANEL_LIMIT));
         model.addAttribute("projectedAnnualSpend", spendUseCase.projectedAnnualSpend(orgId));

--- a/src/main/java/com/majordomo/adapter/in/web/config/GlobalExceptionHandler.java
+++ b/src/main/java/com/majordomo/adapter/in/web/config/GlobalExceptionHandler.java
@@ -41,6 +41,20 @@ public class GlobalExceptionHandler {
     }
 
     /**
+     * Handles {@link MissingOrganizationException} thrown by the {@code OrgContext}
+     * argument resolver when an authenticated user has no organization
+     * membership. Redirects the user home rather than surfacing an error page.
+     *
+     * @param ex the exception (logged for diagnostics)
+     * @return view name {@code redirect:/}
+     */
+    @ExceptionHandler(MissingOrganizationException.class)
+    public String handleMissingOrganization(MissingOrganizationException ex) {
+        LOG.debug("Missing organization for authenticated user: {}", ex.getMessage());
+        return "redirect:/";
+    }
+
+    /**
      * Handles illegal argument exceptions.
      *
      * @param ex      the exception

--- a/src/main/java/com/majordomo/adapter/in/web/config/MissingOrganizationException.java
+++ b/src/main/java/com/majordomo/adapter/in/web/config/MissingOrganizationException.java
@@ -1,0 +1,19 @@
+package com.majordomo.adapter.in.web.config;
+
+/**
+ * Thrown by {@link OrgContextArgumentResolver} when the authenticated user has
+ * no organization membership. Caught by {@code GlobalExceptionHandler} and
+ * mapped to a redirect home — handlers don't need to special-case this.
+ */
+public class MissingOrganizationException extends RuntimeException {
+
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Constructs the exception with a constant message; the redirect handler
+     * doesn't surface the message but logs it for debugging.
+     */
+    public MissingOrganizationException() {
+        super("Authenticated user has no organization membership");
+    }
+}

--- a/src/main/java/com/majordomo/adapter/in/web/config/OrgContext.java
+++ b/src/main/java/com/majordomo/adapter/in/web/config/OrgContext.java
@@ -1,0 +1,26 @@
+package com.majordomo.adapter.in.web.config;
+
+import com.majordomo.domain.model.identity.User;
+
+import java.util.UUID;
+
+/**
+ * Authentication context for a Thymeleaf page handler — the resolved user
+ * plus the {@link UUID} of their first organization. Always non-null on both
+ * fields when injected by {@link OrgContextArgumentResolver}; if the user has
+ * no membership the resolver throws {@link MissingOrganizationException}
+ * before the handler runs.
+ *
+ * @param user           authenticated user
+ * @param organizationId user's first organization id (non-null)
+ */
+public record OrgContext(User user, UUID organizationId) {
+    /**
+     * Convenience accessor matching {@code ctx.user().getUsername()}.
+     *
+     * @return the user's username
+     */
+    public String username() {
+        return user.getUsername();
+    }
+}

--- a/src/main/java/com/majordomo/adapter/in/web/config/OrgContextArgumentResolver.java
+++ b/src/main/java/com/majordomo/adapter/in/web/config/OrgContextArgumentResolver.java
@@ -1,0 +1,65 @@
+package com.majordomo.adapter.in.web.config;
+
+import com.majordomo.application.identity.CurrentOrganizationResolver;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import java.util.Optional;
+
+/**
+ * Spring MVC argument resolver that produces an {@link OrgContext} for any
+ * handler parameter of that type. Resolves the authenticated principal to a
+ * user + first-org pair via {@link CurrentOrganizationResolver}; throws
+ * {@link MissingOrganizationException} when the user has no membership so the
+ * caller doesn't need to null-check on every handler.
+ */
+@Component
+public class OrgContextArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private final Optional<CurrentOrganizationResolver> currentOrg;
+
+    /**
+     * Constructs the resolver. {@code currentOrg} is wrapped in {@link Optional}
+     * so REST slice tests that don't load the application layer can still
+     * autowire the resolver bean — {@link #supportsParameter} returns
+     * {@code false} when the application resolver is absent, so Spring falls
+     * back to its default argument-handling and never invokes {@code resolveArgument}.
+     *
+     * @param currentOrg application-layer resolver, present iff the
+     *                   application context registers it
+     */
+    public OrgContextArgumentResolver(Optional<CurrentOrganizationResolver> currentOrg) {
+        this.currentOrg = currentOrg;
+    }
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return currentOrg.isPresent()
+                && OrgContext.class.equals(parameter.getParameterType());
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter,
+                                  ModelAndViewContainer mavContainer,
+                                  NativeWebRequest webRequest,
+                                  WebDataBinderFactory binderFactory) {
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        Object principal = auth != null ? auth.getPrincipal() : null;
+        if (!(principal instanceof UserDetails userDetails)) {
+            throw new MissingOrganizationException();
+        }
+        var resolved = currentOrg.orElseThrow().resolve(userDetails);
+        if (resolved.user() == null || resolved.organizationId() == null) {
+            throw new MissingOrganizationException();
+        }
+        return new OrgContext(resolved.user(), resolved.organizationId());
+    }
+}

--- a/src/main/java/com/majordomo/adapter/in/web/config/WebConfig.java
+++ b/src/main/java/com/majordomo/adapter/in/web/config/WebConfig.java
@@ -1,8 +1,11 @@
 package com.majordomo.adapter.in.web.config;
 
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
 
 /**
  * Spring MVC configuration for the Majordomo web layer.
@@ -15,14 +18,20 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 public class WebConfig implements WebMvcConfigurer {
 
     private final ApiVersionInterceptor apiVersionInterceptor;
+    private final OrgContextArgumentResolver orgContextArgumentResolver;
 
     /**
-     * Constructs a {@code WebConfig} with the API version interceptor to register.
+     * Constructs a {@code WebConfig} with the interceptors and argument
+     * resolvers to register.
      *
-     * @param apiVersionInterceptor the interceptor that echoes the API version header
+     * @param apiVersionInterceptor      the interceptor that echoes the API version header
+     * @param orgContextArgumentResolver resolves {@link OrgContext} on web handlers
+     *                                   (no-ops when the application layer isn't loaded)
      */
-    public WebConfig(ApiVersionInterceptor apiVersionInterceptor) {
+    public WebConfig(ApiVersionInterceptor apiVersionInterceptor,
+                     OrgContextArgumentResolver orgContextArgumentResolver) {
         this.apiVersionInterceptor = apiVersionInterceptor;
+        this.orgContextArgumentResolver = orgContextArgumentResolver;
     }
 
     /**
@@ -34,5 +43,16 @@ public class WebConfig implements WebMvcConfigurer {
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(apiVersionInterceptor)
                 .addPathPatterns("/api/**");
+    }
+
+    /**
+     * Registers the {@link OrgContextArgumentResolver} so any web handler can
+     * declare an {@link OrgContext} parameter and have it auto-injected.
+     *
+     * @param resolvers the argument-resolver list provided by Spring MVC
+     */
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(orgContextArgumentResolver);
     }
 }

--- a/src/test/java/com/majordomo/adapter/in/web/config/OrgContextArgumentResolverTest.java
+++ b/src/test/java/com/majordomo/adapter/in/web/config/OrgContextArgumentResolverTest.java
@@ -1,0 +1,69 @@
+package com.majordomo.adapter.in.web.config;
+
+import com.majordomo.application.identity.CurrentOrganizationResolver;
+import com.majordomo.domain.model.UuidFactory;
+import com.majordomo.domain.model.identity.User;
+import com.majordomo.domain.port.out.identity.ApiKeyRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
+
+/** Slice tests for {@link OrgContextArgumentResolver} via a tiny test-only controller. */
+@WebMvcTest(controllers = OrgContextProbeController.class)
+@Import({SecurityConfig.class, WebConfig.class, OrgContextArgumentResolver.class,
+        GlobalExceptionHandler.class})
+class OrgContextArgumentResolverTest {
+
+    @Autowired MockMvc mvc;
+
+    @MockitoBean CurrentOrganizationResolver currentOrg;
+    @MockitoBean ApiKeyRepository apiKeyRepository;
+    @MockitoBean OAuth2UserService oAuth2UserService;
+
+    private static final UUID ORG_ID = UuidFactory.newId();
+
+    @BeforeEach
+    void seedAuth() {
+        User user = new User(UuidFactory.newId(), "robsartin", "rob@example.com");
+        when(currentOrg.resolve(any(UserDetails.class)))
+                .thenReturn(new CurrentOrganizationResolver.Resolved(user, ORG_ID));
+    }
+
+    /** Cycle 1: handler taking OrgContext gets a populated record. */
+    @Test
+    @WithMockUser
+    void handlerReceivesOrgContext() throws Exception {
+        mvc.perform(get("/__test__/org-probe"))
+                .andExpect(status().isOk())
+                .andExpect(content().string("orgId=" + ORG_ID + ",user=robsartin"));
+    }
+
+    /** Cycle 2: when the resolver returns null orgId the handler short-circuits to redirect. */
+    @Test
+    @WithMockUser
+    void handlerRedirectsWhenNoOrg() throws Exception {
+        User user = new User(UuidFactory.newId(), "lonely", "lonely@example.com");
+        when(currentOrg.resolve(any(UserDetails.class)))
+                .thenReturn(new CurrentOrganizationResolver.Resolved(user, null));
+
+        mvc.perform(get("/__test__/org-probe"))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(view().name("redirect:/"));
+    }
+
+}

--- a/src/test/java/com/majordomo/adapter/in/web/config/OrgContextProbeController.java
+++ b/src/test/java/com/majordomo/adapter/in/web/config/OrgContextProbeController.java
@@ -1,0 +1,27 @@
+package com.majordomo.adapter.in.web.config;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+/**
+ * Test-only controller that echoes the resolved {@link OrgContext}. Used
+ * exclusively by {@link OrgContextArgumentResolverTest} to verify the
+ * argument-resolver wiring without dragging in any production controller.
+ */
+@Controller
+public class OrgContextProbeController {
+
+    /**
+     * Returns a plaintext rendering of the resolved {@link OrgContext}.
+     *
+     * @param orgContext resolved by {@link OrgContextArgumentResolver}
+     * @return {@code "orgId=...,user=..."}
+     */
+    @GetMapping(value = "/__test__/org-probe", produces = "text/plain")
+    @ResponseBody
+    public String probe(OrgContext orgContext) {
+        return "orgId=" + orgContext.organizationId()
+                + ",user=" + orgContext.user().getUsername();
+    }
+}


### PR DESCRIPTION
## Summary
Centralizes user+org resolution that 13+ page handlers were doing by hand. Handlers can declare an `OrgContext` parameter and have it auto-injected.

- `OrgContext(User user, UUID organizationId)` record — non-null on both fields when injected.
- `MissingOrganizationException` thrown when user has no membership; `GlobalExceptionHandler` maps it to `redirect:/`.
- `OrgContextArgumentResolver` (`HandlerMethodArgumentResolver`). Takes `Optional<CurrentOrganizationResolver>` so REST slice tests that don't load the application layer can autowire the bean — `supportsParameter` returns `false` when application resolver is absent, Spring's default argument handling kicks in. **Zero impact on existing REST tests.**
- Registered via `WebConfig.addArgumentResolvers`.
- Slice test covers happy path + no-org redirect via tiny test-only `OrgContextProbeController`.
- `DashboardPageController` migrated as proof — principal + resolve + null-check → one `OrgContext` parameter, ~7 lines lighter. Existing slice tests stay green via the same `@MockitoBean CurrentOrganizationResolver`.

## Test plan
- [x] `./mvnw verify -DskipITs` green (545 tests, 0 failures, checkstyle clean)
- [x] No regression in REST slice tests (16 of them auto-load `WebConfig` via `@WebMvcTest`).
- [ ] `gh pr checks` green post-push.

## Follow-up
- **#275** — migrate the remaining 12 page controllers off the manual pattern, one batch per service.

🤖 Generated with [Claude Code](https://claude.com/claude-code)