### PR TITLE
refactor(steward): extract PropertyQueryService (closes #274)

### DIFF
--- a/src/main/java/com/majordomo/adapter/in/web/steward/PropertyPageController.java
+++ b/src/main/java/com/majordomo/adapter/in/web/steward/PropertyPageController.java
@@ -6,6 +6,8 @@ import com.majordomo.application.identity.CurrentOrganizationResolver;
 import com.majordomo.application.identity.OrganizationAccessService;
 import com.majordomo.application.steward.PropertyDetailView;
 import com.majordomo.application.steward.PropertyDetailViewService;
+import com.majordomo.application.steward.PropertyFilters;
+import com.majordomo.application.steward.PropertyQueryService;
 import com.majordomo.domain.model.concierge.ContactRole;
 import com.majordomo.domain.model.steward.Property;
 import com.majordomo.domain.port.in.steward.ManagePropertyUseCase;
@@ -39,6 +41,7 @@ public class PropertyPageController {
 
     private final ManagePropertyUseCase propertyUseCase;
     private final PropertyRepository propertyRepository;
+    private final PropertyQueryService propertyQueryService;
     private final PropertyDetailViewService propertyDetailViewService;
     private final CurrentOrganizationResolver currentOrg;
     private final OrganizationAccessService organizationAccessService;
@@ -47,18 +50,21 @@ public class PropertyPageController {
      * Constructs the property page controller.
      *
      * @param propertyUseCase           the inbound port for property management
-     * @param propertyRepository        the outbound port for property reads (used by the list view)
+     * @param propertyRepository        the outbound port for property reads (used by parent picker)
+     * @param propertyQueryService      application service for the list view's filter+sort
      * @param propertyDetailViewService application service that assembles the detail view
      * @param currentOrg                resolves the authenticated user's organization
      * @param organizationAccessService verifies the caller has access to a given organization
      */
     public PropertyPageController(ManagePropertyUseCase propertyUseCase,
                                   PropertyRepository propertyRepository,
+                                  PropertyQueryService propertyQueryService,
                                   PropertyDetailViewService propertyDetailViewService,
                                   CurrentOrganizationResolver currentOrg,
                                   OrganizationAccessService organizationAccessService) {
         this.propertyUseCase = propertyUseCase;
         this.propertyRepository = propertyRepository;
+        this.propertyQueryService = propertyQueryService;
         this.propertyDetailViewService = propertyDetailViewService;
         this.currentOrg = currentOrg;
         this.organizationAccessService = organizationAccessService;
@@ -84,43 +90,13 @@ public class PropertyPageController {
         if (ctx.organizationId() == null) {
             return "redirect:/";
         }
-        UUID orgId = ctx.organizationId();
-        List<Property> raw = new ArrayList<>(propertyRepository.findByOrganizationId(orgId));
-
-        String categoryFilter = (category == null || category.isBlank()) ? null : category.trim();
-        String qLower = (q == null || q.isBlank()) ? null : q.trim().toLowerCase();
-
-        List<Property> rows = new ArrayList<>();
-        for (Property p : raw) {
-            if (p.getArchivedAt() != null) {
-                continue;
-            }
-            if (categoryFilter != null && !categoryFilter.equalsIgnoreCase(p.getCategory())) {
-                continue;
-            }
-            if (qLower != null && !matchesQuery(p, qLower)) {
-                continue;
-            }
-            rows.add(p);
-        }
-        rows.sort(Comparator.comparing(
-                Property::getName, Comparator.nullsLast(String.CASE_INSENSITIVE_ORDER)));
-
+        List<Property> rows = propertyQueryService.list(ctx.organizationId(),
+                new PropertyFilters(category, q));
         model.addAttribute("rows", rows);
         model.addAttribute("category", category);
         model.addAttribute("q", q);
         model.addAttribute("username", ctx.user().getUsername());
         return "properties";
-    }
-
-    private static boolean matchesQuery(Property p, String qLower) {
-        if (p.getName() != null && p.getName().toLowerCase().contains(qLower)) {
-            return true;
-        }
-        if (p.getDescription() != null && p.getDescription().toLowerCase().contains(qLower)) {
-            return true;
-        }
-        return false;
     }
 
     /**

--- a/src/main/java/com/majordomo/application/steward/PropertyFilters.java
+++ b/src/main/java/com/majordomo/application/steward/PropertyFilters.java
@@ -1,0 +1,16 @@
+package com.majordomo.application.steward;
+
+/**
+ * Filter set for {@link PropertyQueryService#list}. Both fields are nullable;
+ * {@code null} or blank means "no filter on that dimension".
+ *
+ * @param category exact-match category filter (case-insensitive); null/blank = any
+ * @param q        free-text query matched against name + description (case-insensitive); null/blank = any
+ */
+public record PropertyFilters(String category, String q) {
+
+    /** @return filters with no constraints. */
+    public static PropertyFilters none() {
+        return new PropertyFilters(null, null);
+    }
+}

--- a/src/main/java/com/majordomo/application/steward/PropertyQueryService.java
+++ b/src/main/java/com/majordomo/application/steward/PropertyQueryService.java
@@ -1,0 +1,64 @@
+package com.majordomo.application.steward;
+
+import com.majordomo.domain.model.steward.Property;
+import com.majordomo.domain.port.out.steward.PropertyRepository;
+
+import org.springframework.stereotype.Service;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Read-side query service for the property list page. Pulls the org's
+ * properties through the repository, applies optional in-memory filters, and
+ * returns a sorted result (case-insensitive by name, nulls last).
+ *
+ * <p>Lives in the application layer so the controller stays thin and the
+ * filter logic is unit-testable without Spring.</p>
+ */
+@Service
+public class PropertyQueryService {
+
+    private final PropertyRepository propertyRepository;
+
+    /**
+     * Constructs the query service.
+     *
+     * @param propertyRepository outbound port for property reads
+     */
+    public PropertyQueryService(PropertyRepository propertyRepository) {
+        this.propertyRepository = propertyRepository;
+    }
+
+    /**
+     * Lists active (non-archived) properties in the given organization,
+     * narrowed by the supplied filters.
+     *
+     * @param organizationId the organization to query
+     * @param filters        category + q filters (use {@link PropertyFilters#none()} for none)
+     * @return matching properties, sorted by name (case-insensitive, nulls last)
+     */
+    public List<Property> list(UUID organizationId, PropertyFilters filters) {
+        String categoryFilter = blank(filters.category()) ? null : filters.category().trim();
+        String qLower = blank(filters.q()) ? null : filters.q().trim().toLowerCase();
+
+        return propertyRepository.findByOrganizationId(organizationId).stream()
+                .filter(p -> p.getArchivedAt() == null)
+                .filter(p -> categoryFilter == null
+                        || categoryFilter.equalsIgnoreCase(p.getCategory()))
+                .filter(p -> qLower == null || matchesQuery(p, qLower))
+                .sorted(Comparator.comparing(Property::getName,
+                        Comparator.nullsLast(String.CASE_INSENSITIVE_ORDER)))
+                .toList();
+    }
+
+    private static boolean matchesQuery(Property p, String qLower) {
+        return (p.getName() != null && p.getName().toLowerCase().contains(qLower))
+                || (p.getDescription() != null && p.getDescription().toLowerCase().contains(qLower));
+    }
+
+    private static boolean blank(String s) {
+        return s == null || s.isBlank();
+    }
+}

--- a/src/test/java/com/majordomo/adapter/in/web/steward/PropertyPageControllerTest.java
+++ b/src/test/java/com/majordomo/adapter/in/web/steward/PropertyPageControllerTest.java
@@ -47,6 +47,7 @@ class PropertyPageControllerTest {
 
     @MockitoBean ManagePropertyUseCase propertyUseCase;
     @MockitoBean PropertyRepository propertyRepository;
+    @MockitoBean com.majordomo.application.steward.PropertyQueryService propertyQueryService;
     @MockitoBean PropertyDetailViewService propertyDetailViewService;
     @MockitoBean CurrentOrganizationResolver currentOrg;
     @MockitoBean OrganizationAccessService organizationAccessService;

--- a/src/test/java/com/majordomo/adapter/in/web/steward/PropertyPageFormTest.java
+++ b/src/test/java/com/majordomo/adapter/in/web/steward/PropertyPageFormTest.java
@@ -39,6 +39,7 @@ class PropertyPageFormTest {
 
     @MockitoBean ManagePropertyUseCase propertyUseCase;
     @MockitoBean PropertyRepository propertyRepository;
+    @MockitoBean com.majordomo.application.steward.PropertyQueryService propertyQueryService;
     @MockitoBean com.majordomo.application.steward.PropertyDetailViewService propertyDetailViewService;
     @MockitoBean CurrentOrganizationResolver currentOrg;
     @MockitoBean OrganizationAccessService organizationAccessService;

--- a/src/test/java/com/majordomo/adapter/in/web/steward/PropertyPageListTest.java
+++ b/src/test/java/com/majordomo/adapter/in/web/steward/PropertyPageListTest.java
@@ -3,6 +3,8 @@ package com.majordomo.adapter.in.web.steward;
 import com.majordomo.adapter.in.web.config.OAuth2UserService;
 import com.majordomo.adapter.in.web.config.SecurityConfig;
 import com.majordomo.application.identity.CurrentOrganizationResolver;
+import com.majordomo.application.steward.PropertyFilters;
+import com.majordomo.application.steward.PropertyQueryService;
 import com.majordomo.domain.model.UuidFactory;
 import com.majordomo.domain.model.identity.User;
 import com.majordomo.domain.model.steward.Property;
@@ -19,14 +21,14 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.MvcResult;
 
-import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
@@ -34,7 +36,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
 
 /**
- * Slice tests for {@link PropertyPageController#list}: list + filter at {@code /properties}.
+ * Slice tests for {@link PropertyPageController#list}. Filter/sort behavior
+ * itself is covered by {@link com.majordomo.application.steward.PropertyQueryServiceTest}.
  */
 @WebMvcTest(PropertyPageController.class)
 @Import(SecurityConfig.class)
@@ -44,6 +47,7 @@ class PropertyPageListTest {
 
     @MockitoBean ManagePropertyUseCase propertyUseCase;
     @MockitoBean PropertyRepository propertyRepository;
+    @MockitoBean PropertyQueryService propertyQueryService;
     @MockitoBean com.majordomo.application.steward.PropertyDetailViewService propertyDetailViewService;
     @MockitoBean CurrentOrganizationResolver currentOrg;
     @MockitoBean com.majordomo.application.identity.OrganizationAccessService organizationAccessService;
@@ -59,92 +63,43 @@ class PropertyPageListTest {
                 .thenReturn(new CurrentOrganizationResolver.Resolved(user, ORG_ID));
     }
 
-    /** Renders properties sorted by name with category, status, and location. */
+    /** Controller delegates to the service and renders its rows. */
     @Test
     @WithMockUser
-    void listRendersPropertiesSortedByName() throws Exception {
-        when(propertyRepository.findByOrganizationId(ORG_ID)).thenReturn(List.of(
-                property("Beach House", "vacation", PropertyStatus.ACTIVE, "Cape Cod", null),
-                property("Apartment", "rental", PropertyStatus.IN_SERVICE, "Boston", null)));
+    void listDelegatesToServiceAndRendersRows() throws Exception {
+        Property apartment = property("Apartment");
+        Property beach = property("Beach House");
+        when(propertyQueryService.list(eq(ORG_ID), any(PropertyFilters.class)))
+                .thenReturn(List.of(apartment, beach));
 
-        MvcResult result = mvc.perform(get("/properties"))
+        var result = mvc.perform(get("/properties"))
                 .andExpect(status().isOk())
                 .andExpect(view().name("properties"))
                 .andReturn();
 
-        String body = result.getResponse().getContentAsString();
-        assertThat(body).contains("Beach House").contains("Apartment");
-        assertThat(body).contains("vacation").contains("rental");
-        assertThat(body).contains("ACTIVE").contains("IN_SERVICE");
-        // Apartment sorts before Beach House alphabetically.
-        int apt = body.indexOf("Apartment");
-        int beach = body.indexOf("Beach House");
-        assertThat(apt).isPositive().isLessThan(beach);
+        assertThat(result.getResponse().getContentAsString())
+                .contains("Apartment").contains("Beach House");
     }
 
-    /** Archived properties are filtered out. */
+    /** Filter parameters propagate to the service call. */
     @Test
     @WithMockUser
-    void listSkipsArchivedProperties() throws Exception {
-        when(propertyRepository.findByOrganizationId(ORG_ID)).thenReturn(List.of(
-                property("Active", "rental", PropertyStatus.ACTIVE, "x", null),
-                property("Archived old", "rental", PropertyStatus.DISPOSED, "y",
-                        Instant.parse("2025-01-01T00:00:00Z"))));
+    void listForwardsFiltersToService() throws Exception {
+        when(propertyQueryService.list(eq(ORG_ID), any(PropertyFilters.class)))
+                .thenReturn(List.of());
 
-        MvcResult result = mvc.perform(get("/properties"))
-                .andExpect(status().isOk())
-                .andReturn();
+        mvc.perform(get("/properties").param("category", "rental").param("q", "apt"))
+                .andExpect(status().isOk());
 
-        String body = result.getResponse().getContentAsString();
-        assertThat(body).contains("Active").doesNotContain("Archived old");
+        verify(propertyQueryService).list(eq(ORG_ID), eq(new PropertyFilters("rental", "apt")));
     }
 
-    /** Free-text query narrows results across name + description. */
+    /** Empty state renders when service returns no rows. */
     @Test
     @WithMockUser
-    void searchFiltersAcrossNameAndDescription() throws Exception {
-        Property cabin = property("Cabin", "vacation", PropertyStatus.ACTIVE, "Maine", null);
-        cabin.setDescription("Lakeside retreat with HVAC");
-        Property apartment = property("Apartment", "rental", PropertyStatus.ACTIVE, "Boston", null);
-        apartment.setDescription("City rental");
-        when(propertyRepository.findByOrganizationId(ORG_ID)).thenReturn(List.of(cabin, apartment));
-
-        // Match against description.
-        MvcResult lakeResult = mvc.perform(get("/properties").param("q", "lakeside"))
-                .andExpect(status().isOk())
-                .andReturn();
-        assertThat(lakeResult.getResponse().getContentAsString())
-                .contains("Cabin").doesNotContain("Apartment");
-
-        // Match against name.
-        MvcResult aptResult = mvc.perform(get("/properties").param("q", "apartment"))
-                .andExpect(status().isOk())
-                .andReturn();
-        assertThat(aptResult.getResponse().getContentAsString())
-                .contains("Apartment").doesNotContain("Cabin");
-    }
-
-    /** Category filter narrows results (case-insensitive exact match). */
-    @Test
-    @WithMockUser
-    void filterByCategoryNarrowsResults() throws Exception {
-        when(propertyRepository.findByOrganizationId(ORG_ID)).thenReturn(List.of(
-                property("Cabin", "vacation", PropertyStatus.ACTIVE, "Maine", null),
-                property("Apartment", "rental", PropertyStatus.ACTIVE, "Boston", null)));
-
-        MvcResult result = mvc.perform(get("/properties").param("category", "rental"))
-                .andExpect(status().isOk())
-                .andReturn();
-
-        String body = result.getResponse().getContentAsString();
-        assertThat(body).contains("Apartment").doesNotContain("Cabin");
-    }
-
-    /** Empty state renders when no properties match. */
-    @Test
-    @WithMockUser
-    void emptyStateRendersWhenNoMatches() throws Exception {
-        when(propertyRepository.findByOrganizationId(ORG_ID)).thenReturn(List.of());
+    void emptyStateRendersWhenNoRows() throws Exception {
+        when(propertyQueryService.list(eq(ORG_ID), any(PropertyFilters.class)))
+                .thenReturn(List.of());
 
         mvc.perform(get("/properties"))
                 .andExpect(status().isOk())
@@ -172,16 +127,12 @@ class PropertyPageListTest {
                 .andExpect(status().is3xxRedirection());
     }
 
-    private static Property property(String name, String category, PropertyStatus status,
-                                     String location, Instant archivedAt) {
+    private static Property property(String name) {
         Property p = new Property();
         p.setId(UuidFactory.newId());
         p.setOrganizationId(ORG_ID);
         p.setName(name);
-        p.setCategory(category);
-        p.setStatus(status);
-        p.setLocation(location);
-        p.setArchivedAt(archivedAt);
+        p.setStatus(PropertyStatus.ACTIVE);
         return p;
     }
 }

--- a/src/test/java/com/majordomo/application/steward/PropertyQueryServiceTest.java
+++ b/src/test/java/com/majordomo/application/steward/PropertyQueryServiceTest.java
@@ -1,0 +1,108 @@
+package com.majordomo.application.steward;
+
+import com.majordomo.domain.model.UuidFactory;
+import com.majordomo.domain.model.steward.Property;
+import com.majordomo.domain.model.steward.PropertyStatus;
+import com.majordomo.domain.port.out.steward.PropertyRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/** Plain JUnit unit tests for {@link PropertyQueryService} — no Spring. */
+class PropertyQueryServiceTest {
+
+    private PropertyRepository propertyRepository;
+    private PropertyQueryService service;
+
+    private static final UUID ORG_ID = UuidFactory.newId();
+
+    @BeforeEach
+    void setUp() {
+        propertyRepository = mock(PropertyRepository.class);
+        service = new PropertyQueryService(propertyRepository);
+    }
+
+    /** Cycle 1: returns active rows for the org, sorted by name (case-insensitive, nulls last). */
+    @Test
+    void listSortsByNameCaseInsensitive() {
+        Property beach = property("Beach House", "vacation", "Cape Cod", null);
+        Property apt = property("apartment", "rental", "Boston", null);
+        when(propertyRepository.findByOrganizationId(ORG_ID))
+                .thenReturn(List.of(beach, apt));
+
+        List<Property> rows = service.list(ORG_ID, PropertyFilters.none());
+
+        assertThat(rows).extracting(Property::getName)
+                .containsExactly("apartment", "Beach House");
+    }
+
+    /** Cycle 2: archived properties are filtered. */
+    @Test
+    void listSkipsArchived() {
+        Property active = property("Active", "rental", "x", null);
+        Property archived = property("Archived", "rental", "y",
+                Instant.parse("2025-01-01T00:00:00Z"));
+        when(propertyRepository.findByOrganizationId(ORG_ID))
+                .thenReturn(List.of(active, archived));
+
+        List<Property> rows = service.list(ORG_ID, PropertyFilters.none());
+
+        assertThat(rows).extracting(Property::getName).containsExactly("Active");
+    }
+
+    /** Cycle 3: category filter is exact-match, case-insensitive. */
+    @Test
+    void categoryFilterNarrowsResults() {
+        Property cabin = property("Cabin", "vacation", "Maine", null);
+        Property apt = property("Apt", "rental", "Boston", null);
+        when(propertyRepository.findByOrganizationId(ORG_ID))
+                .thenReturn(List.of(cabin, apt));
+
+        List<Property> rows = service.list(ORG_ID, new PropertyFilters("RENTAL", null));
+
+        assertThat(rows).extracting(Property::getName).containsExactly("Apt");
+    }
+
+    /** Cycle 4: q matches across name + description. */
+    @Test
+    void qFilterMatchesNameOrDescription() {
+        Property cabin = property("Cabin", "vacation", "Maine", null);
+        cabin.setDescription("Lakeside retreat with HVAC");
+        Property apt = property("Apt", "rental", "Boston", null);
+        apt.setDescription("City rental");
+        when(propertyRepository.findByOrganizationId(ORG_ID))
+                .thenReturn(List.of(cabin, apt));
+
+        // Match by description.
+        assertThat(service.list(ORG_ID, new PropertyFilters(null, "lakeside")))
+                .extracting(Property::getName).containsExactly("Cabin");
+
+        // Match by name.
+        assertThat(service.list(ORG_ID, new PropertyFilters(null, "apt")))
+                .extracting(Property::getName).containsExactly("Apt");
+
+        // No match.
+        assertThat(service.list(ORG_ID, new PropertyFilters(null, "nonexistent")))
+                .isEmpty();
+    }
+
+    private static Property property(String name, String category, String location,
+                                     Instant archivedAt) {
+        Property p = new Property();
+        p.setId(UuidFactory.newId());
+        p.setOrganizationId(ORG_ID);
+        p.setName(name);
+        p.setCategory(category);
+        p.setLocation(location);
+        p.setStatus(PropertyStatus.ACTIVE);
+        p.setArchivedAt(archivedAt);
+        return p;
+    }
+}


### PR DESCRIPTION
## Summary
Same shape as `PropertyDetailViewService` (#271): the list page's filter+sort logic was 25+ lines inside `PropertyPageController.list()`. Moved to the application layer.

- **`PropertyFilters(category, q)`** record + `none()` factory.
- **`PropertyQueryService.list(orgId, filters)`** returns sorted, non-archived properties for the org. Filter logic: archived out → category exact-match (case-insensitive) → q contains-match across name + description → sort name (case-insensitive, nulls last).
- Plain JUnit unit tests (no Spring) cover sort, archived filter, category narrow, q match across name/description.
- `PropertyPageController.list` shrinks from 35 lines to 12: build filters, call service, expose rows.
- Slice tests refocused on delegation; filter coverage moves to the service test.

## Test plan
- [x] `./mvnw verify -DskipITs` green (545 tests, 0 failures, checkstyle clean)
- [ ] `gh pr checks` green post-push.

## Notes
- Same pattern can apply to Contact / Schedule / Audit list views as follow-ups (lower priority).

🤖 Generated with [Claude Code](https://claude.com/claude-code)