### PR TITLE
tech-debt: migrate page controllers to OrgContext (closes #275)

### DIFF
--- a/src/main/java/com/majordomo/adapter/in/web/audit/AuditPageController.java
+++ b/src/main/java/com/majordomo/adapter/in/web/audit/AuditPageController.java
@@ -1,14 +1,12 @@
 package com.majordomo.adapter.in.web.audit;
 
 import com.majordomo.adapter.in.web.FormBindingHelper;
-import com.majordomo.application.identity.CurrentOrganizationResolver;
+import com.majordomo.adapter.in.web.config.OrgContext;
 import com.majordomo.domain.model.AuditLogEntry;
 import com.majordomo.domain.model.identity.User;
 import com.majordomo.domain.port.out.AuditLogRepository;
 import com.majordomo.domain.port.out.identity.UserRepository;
 
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -34,7 +32,6 @@ public class AuditPageController {
 
     private final AuditLogRepository auditLogRepository;
     private final UserRepository userRepository;
-    private final CurrentOrganizationResolver currentOrg;
 
     /**
      * View-model row pairing an audit entry with the resolved actor username.
@@ -49,14 +46,11 @@ public class AuditPageController {
      *
      * @param auditLogRepository outbound port for audit-log queries
      * @param userRepository     outbound port for user lookups (actor resolution)
-     * @param currentOrg         resolves the authenticated user's organization
      */
     public AuditPageController(AuditLogRepository auditLogRepository,
-                               UserRepository userRepository,
-                               CurrentOrganizationResolver currentOrg) {
+                               UserRepository userRepository) {
         this.auditLogRepository = auditLogRepository;
         this.userRepository = userRepository;
-        this.currentOrg = currentOrg;
     }
 
     /**
@@ -66,22 +60,18 @@ public class AuditPageController {
      * @param actor      optional actor-username filter
      * @param since      optional inclusive lower-bound date (yyyy-MM-dd)
      * @param until      optional exclusive upper-bound date (yyyy-MM-dd)
-     * @param principal  authenticated user
+     * @param orgContext authenticated user + organization
      * @param model      Thymeleaf model
-     * @return the {@code audit} template, or a redirect home if no org
+     * @return the {@code audit} template
      */
     @GetMapping("/audit")
     public String list(@RequestParam(required = false) String entityType,
                        @RequestParam(required = false) String actor,
                        @RequestParam(required = false) String since,
                        @RequestParam(required = false) String until,
-                       @AuthenticationPrincipal UserDetails principal,
+                       OrgContext orgContext,
                        Model model) {
-        var ctx = currentOrg.resolve(principal);
-        if (ctx.organizationId() == null) {
-            return "redirect:/";
-        }
-        UUID orgId = ctx.organizationId();
+        UUID orgId = orgContext.organizationId();
 
         String entityTypeFilter = FormBindingHelper.blankToNull(entityType);
         UUID actorId = resolveActor(actor);
@@ -108,7 +98,7 @@ public class AuditPageController {
         model.addAttribute("since", since);
         model.addAttribute("until", until);
         model.addAttribute("entityTypeOptions", entityTypeOptions(entries));
-        model.addAttribute("username", ctx.user().getUsername());
+        model.addAttribute("username", orgContext.username());
         return "audit";
     }
 

--- a/src/main/java/com/majordomo/adapter/in/web/concierge/ContactPageController.java
+++ b/src/main/java/com/majordomo/adapter/in/web/concierge/ContactPageController.java
@@ -1,7 +1,7 @@
 package com.majordomo.adapter.in.web.concierge;
 
 import com.majordomo.adapter.in.web.FormBindingHelper;
-import com.majordomo.application.identity.CurrentOrganizationResolver;
+import com.majordomo.adapter.in.web.config.OrgContext;
 import com.majordomo.application.identity.OrganizationAccessService;
 import com.majordomo.domain.model.EntityNotFoundException;
 import com.majordomo.domain.model.EntityType;
@@ -15,8 +15,6 @@ import com.majordomo.domain.port.out.concierge.ContactRepository;
 import com.majordomo.domain.port.out.steward.PropertyContactRepository;
 import com.majordomo.domain.port.out.steward.PropertyRepository;
 
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -43,7 +41,6 @@ public class ContactPageController {
     private final ContactRepository contactRepository;
     private final PropertyRepository propertyRepository;
     private final PropertyContactRepository propertyContactRepository;
-    private final CurrentOrganizationResolver currentOrg;
     private final OrganizationAccessService organizationAccessService;
 
     /**
@@ -53,20 +50,17 @@ public class ContactPageController {
      * @param contactRepository         outbound port for contact reads (used by list view)
      * @param propertyRepository        outbound port for property reads (link picker, batch hydration)
      * @param propertyContactRepository outbound port for property–contact associations
-     * @param currentOrg                resolves the authenticated user's organization
      * @param organizationAccessService verifies caller has access to a given organization
      */
     public ContactPageController(ManageContactUseCase contactUseCase,
                                  ContactRepository contactRepository,
                                  PropertyRepository propertyRepository,
                                  PropertyContactRepository propertyContactRepository,
-                                 CurrentOrganizationResolver currentOrg,
                                  OrganizationAccessService organizationAccessService) {
         this.contactUseCase = contactUseCase;
         this.contactRepository = contactRepository;
         this.propertyRepository = propertyRepository;
         this.propertyContactRepository = propertyContactRepository;
-        this.currentOrg = currentOrg;
         this.organizationAccessService = organizationAccessService;
     }
 
@@ -76,20 +70,16 @@ public class ContactPageController {
      *
      * @param organization optional exact-match organization filter
      * @param q            optional case-insensitive query (name + organization + emails)
-     * @param principal    authenticated user
+     * @param orgContext   authenticated user + organization
      * @param model        Thymeleaf model
      * @return the {@code contacts} template
      */
     @GetMapping
     public String list(@RequestParam(required = false) String organization,
                        @RequestParam(required = false) String q,
-                       @AuthenticationPrincipal UserDetails principal,
+                       OrgContext orgContext,
                        Model model) {
-        var ctx = currentOrg.resolve(principal);
-        if (ctx.organizationId() == null) {
-            return "redirect:/";
-        }
-        UUID orgId = ctx.organizationId();
+        UUID orgId = orgContext.organizationId();
         List<Contact> raw = new ArrayList<>(contactRepository.findByOrganizationId(orgId));
 
         String organizationFilter =
@@ -126,7 +116,7 @@ public class ContactPageController {
         model.addAttribute("organizations", organizations);
         model.addAttribute("organization", organization);
         model.addAttribute("q", q);
-        model.addAttribute("username", ctx.user().getUsername());
+        model.addAttribute("username", orgContext.username());
         return "contacts";
     }
 
@@ -134,18 +124,14 @@ public class ContactPageController {
      * Renders the contact detail page.
      *
      * @param id        contact UUID
-     * @param principal authenticated user
+     * @param orgContext authenticated user + organization
      * @param model     Thymeleaf model
      * @return the {@code contact-detail} template
      */
     @GetMapping("/{id}")
     public String detail(@PathVariable UUID id,
-                         @AuthenticationPrincipal UserDetails principal,
+                         OrgContext orgContext,
                          Model model) {
-        var ctx = currentOrg.resolve(principal);
-        if (ctx.organizationId() == null) {
-            return "redirect:/";
-        }
         Contact contact = contactRepository.findById(id)
                 .filter(c -> c.getArchivedAt() == null)
                 .orElseThrow(() -> new EntityNotFoundException(EntityType.CONTACT.name(), id));
@@ -179,7 +165,7 @@ public class ContactPageController {
         model.addAttribute("propertyCandidates", propertyCandidates);
         model.addAttribute("contactRoles",
                 com.majordomo.domain.model.concierge.ContactRole.values());
-        model.addAttribute("username", ctx.user().getUsername());
+        model.addAttribute("username", orgContext.username());
         return "contact-detail";
     }
 
@@ -195,19 +181,15 @@ public class ContactPageController {
     /**
      * Renders the new-contact form.
      *
-     * @param principal authenticated user
+     * @param orgContext authenticated user + organization
      * @param model     Thymeleaf model
      * @return the {@code contact-form} template
      */
     @GetMapping("/new")
-    public String newForm(@AuthenticationPrincipal UserDetails principal, Model model) {
-        var ctx = currentOrg.resolve(principal);
-        if (ctx.organizationId() == null) {
-            return "redirect:/";
-        }
+    public String newForm(OrgContext orgContext, Model model) {
         model.addAttribute("editingId", null);
         model.addAttribute("existing", null);
-        model.addAttribute("username", ctx.user().getUsername());
+        model.addAttribute("username", orgContext.username());
         return "contact-form";
     }
 
@@ -225,7 +207,7 @@ public class ContactPageController {
      * @param urls          newline-separated URLs
      * @param nicknames     newline-separated nicknames
      * @param command       indexed addresses sub-form
-     * @param principal     authenticated user
+     * @param orgContext    authenticated user + organization
      * @param model         Thymeleaf model
      * @return redirect to the new contact's detail page on success
      */
@@ -241,27 +223,23 @@ public class ContactPageController {
                          @RequestParam(required = false) String urls,
                          @RequestParam(required = false) String nicknames,
                          @ModelAttribute ContactFormCommand command,
-                         @AuthenticationPrincipal UserDetails principal,
+                         OrgContext orgContext,
                          Model model) {
-        var ctx = currentOrg.resolve(principal);
-        if (ctx.organizationId() == null) {
-            return "redirect:/";
-        }
         var fields = new ContactFormFields(formattedName, givenName, familyName,
                 organization, title, notes, emails, telephones, urls, nicknames);
         if (formattedName == null || formattedName.isBlank()) {
-            populateFormState(model, null, null, ctx.user().getUsername(),
+            populateFormState(model, null, null, orgContext.username(),
                     "Formatted name is required.", fields);
             return "contact-form";
         }
         List<String> emailList = FormBindingHelper.splitLines(emails);
         String emailError = validateEmails(emailList);
         if (emailError != null) {
-            populateFormState(model, null, null, ctx.user().getUsername(), emailError, fields);
+            populateFormState(model, null, null, orgContext.username(), emailError, fields);
             return "contact-form";
         }
         Contact contact = new Contact();
-        contact.setOrganizationId(ctx.organizationId());
+        contact.setOrganizationId(orgContext.organizationId());
         contact.setFormattedName(formattedName);
         contact.setGivenName(FormBindingHelper.blankToNull(givenName));
         contact.setFamilyName(FormBindingHelper.blankToNull(familyName));
@@ -281,24 +259,20 @@ public class ContactPageController {
      * Renders the edit-contact form, pre-populated.
      *
      * @param id        the contact's UUID
-     * @param principal authenticated user
+     * @param orgContext authenticated user + organization
      * @param model     Thymeleaf model
      * @return the {@code contact-form} template
      */
     @GetMapping("/{id}/edit")
     public String editForm(@PathVariable UUID id,
-                           @AuthenticationPrincipal UserDetails principal,
+                           OrgContext orgContext,
                            Model model) {
-        var ctx = currentOrg.resolve(principal);
-        if (ctx.organizationId() == null) {
-            return "redirect:/";
-        }
         Contact existing = contactRepository.findById(id)
                 .orElseThrow(() -> new EntityNotFoundException(EntityType.CONTACT.name(), id));
         organizationAccessService.verifyAccess(existing.getOrganizationId());
         model.addAttribute("editingId", id);
         model.addAttribute("existing", existing);
-        model.addAttribute("username", ctx.user().getUsername());
+        model.addAttribute("username", orgContext.username());
         return "contact-form";
     }
 
@@ -317,7 +291,7 @@ public class ContactPageController {
      * @param urls          newline-separated URLs
      * @param nicknames     newline-separated nicknames
      * @param command       indexed addresses sub-form
-     * @param principal     authenticated user
+     * @param orgContext    authenticated user + organization
      * @param model         Thymeleaf model
      * @return redirect to the contact's detail page on success
      */
@@ -334,26 +308,22 @@ public class ContactPageController {
                          @RequestParam(required = false) String urls,
                          @RequestParam(required = false) String nicknames,
                          @ModelAttribute ContactFormCommand command,
-                         @AuthenticationPrincipal UserDetails principal,
+                         OrgContext orgContext,
                          Model model) {
-        var ctx = currentOrg.resolve(principal);
-        if (ctx.organizationId() == null) {
-            return "redirect:/";
-        }
         Contact existing = contactRepository.findById(id)
                 .orElseThrow(() -> new EntityNotFoundException(EntityType.CONTACT.name(), id));
         organizationAccessService.verifyAccess(existing.getOrganizationId());
         var fields = new ContactFormFields(formattedName, givenName, familyName,
                 organization, title, notes, emails, telephones, urls, nicknames);
         if (formattedName == null || formattedName.isBlank()) {
-            populateFormState(model, id, existing, ctx.user().getUsername(),
+            populateFormState(model, id, existing, orgContext.username(),
                     "Formatted name is required.", fields);
             return "contact-form";
         }
         List<String> emailList = FormBindingHelper.splitLines(emails);
         String emailError = validateEmails(emailList);
         if (emailError != null) {
-            populateFormState(model, id, existing, ctx.user().getUsername(), emailError, fields);
+            populateFormState(model, id, existing, orgContext.username(), emailError, fields);
             return "contact-form";
         }
         Contact updated = new Contact();

--- a/src/main/java/com/majordomo/adapter/in/web/concierge/ContactPropertyLinkController.java
+++ b/src/main/java/com/majordomo/adapter/in/web/concierge/ContactPropertyLinkController.java
@@ -1,7 +1,7 @@
 package com.majordomo.adapter.in.web.concierge;
 
 import com.majordomo.adapter.in.web.FormBindingHelper;
-import com.majordomo.application.identity.CurrentOrganizationResolver;
+import com.majordomo.adapter.in.web.config.OrgContext;
 import com.majordomo.application.identity.OrganizationAccessService;
 import com.majordomo.domain.model.EntityNotFoundException;
 import com.majordomo.domain.model.EntityType;
@@ -13,8 +13,6 @@ import com.majordomo.domain.port.in.steward.ManagePropertyUseCase;
 import com.majordomo.domain.port.out.concierge.ContactRepository;
 import com.majordomo.domain.port.out.steward.PropertyContactRepository;
 
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -36,7 +34,6 @@ public class ContactPropertyLinkController {
     private final ContactRepository contactRepository;
     private final ManagePropertyUseCase propertyUseCase;
     private final PropertyContactRepository propertyContactRepository;
-    private final CurrentOrganizationResolver currentOrg;
     private final OrganizationAccessService organizationAccessService;
 
     /**
@@ -45,18 +42,15 @@ public class ContactPropertyLinkController {
      * @param contactRepository         outbound port for contact reads
      * @param propertyUseCase           inbound port for property lookups
      * @param propertyContactRepository outbound port for property–contact rows
-     * @param currentOrg                resolves the authenticated user's organization
      * @param organizationAccessService verifies caller has access to a given organization
      */
     public ContactPropertyLinkController(ContactRepository contactRepository,
                                          ManagePropertyUseCase propertyUseCase,
                                          PropertyContactRepository propertyContactRepository,
-                                         CurrentOrganizationResolver currentOrg,
                                          OrganizationAccessService organizationAccessService) {
         this.contactRepository = contactRepository;
         this.propertyUseCase = propertyUseCase;
         this.propertyContactRepository = propertyContactRepository;
-        this.currentOrg = currentOrg;
         this.organizationAccessService = organizationAccessService;
     }
 
@@ -67,7 +61,7 @@ public class ContactPropertyLinkController {
      * @param propertyId property to link
      * @param role       role classification (defaults to OTHER if blank/unknown)
      * @param notes      optional free-form notes
-     * @param principal  authenticated user
+     * @param orgContext authenticated user + organization
      * @return redirect to the contact detail page
      */
     @PostMapping("/{id}/properties")
@@ -75,11 +69,7 @@ public class ContactPropertyLinkController {
                        @RequestParam UUID propertyId,
                        @RequestParam(required = false) String role,
                        @RequestParam(required = false) String notes,
-                       @AuthenticationPrincipal UserDetails principal) {
-        var ctx = currentOrg.resolve(principal);
-        if (ctx.organizationId() == null) {
-            return "redirect:/";
-        }
+                       OrgContext orgContext) {
         Contact contact = contactRepository.findById(id)
                 .orElseThrow(() -> new EntityNotFoundException(EntityType.CONTACT.name(), id));
         organizationAccessService.verifyAccess(contact.getOrganizationId());
@@ -100,19 +90,15 @@ public class ContactPropertyLinkController {
     /**
      * Unlinks (soft-deletes) a property association from this contact.
      *
-     * @param id        contact UUID
-     * @param linkId    PropertyContact row UUID
-     * @param principal authenticated user
+     * @param id         contact UUID
+     * @param linkId     PropertyContact row UUID
+     * @param orgContext authenticated user + organization
      * @return redirect to the contact detail page
      */
     @PostMapping("/{id}/properties/{linkId}/unlink")
     public String unlink(@PathVariable UUID id,
                          @PathVariable UUID linkId,
-                         @AuthenticationPrincipal UserDetails principal) {
-        var ctx = currentOrg.resolve(principal);
-        if (ctx.organizationId() == null) {
-            return "redirect:/";
-        }
+                         OrgContext orgContext) {
         Contact contact = contactRepository.findById(id)
                 .orElseThrow(() -> new EntityNotFoundException(EntityType.CONTACT.name(), id));
         organizationAccessService.verifyAccess(contact.getOrganizationId());

--- a/src/main/java/com/majordomo/adapter/in/web/envoy/EnvoyComparatorController.java
+++ b/src/main/java/com/majordomo/adapter/in/web/envoy/EnvoyComparatorController.java
@@ -1,6 +1,6 @@
 package com.majordomo.adapter.in.web.envoy;
 
-import com.majordomo.application.identity.CurrentOrganizationResolver;
+import com.majordomo.adapter.in.web.config.OrgContext;
 import com.majordomo.domain.model.envoy.Category;
 import com.majordomo.domain.model.envoy.CategoryScore;
 import com.majordomo.domain.model.envoy.JobPosting;
@@ -9,8 +9,6 @@ import com.majordomo.domain.model.envoy.ScoreReport;
 import com.majordomo.domain.port.in.envoy.QueryScoreReportsUseCase;
 import com.majordomo.domain.port.out.envoy.JobPostingRepository;
 import com.majordomo.domain.port.out.envoy.RubricRepository;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -42,7 +40,6 @@ public class EnvoyComparatorController {
     private final QueryScoreReportsUseCase reports;
     private final RubricRepository rubricRepository;
     private final JobPostingRepository jobPostingRepository;
-    private final CurrentOrganizationResolver currentOrg;
 
     /**
      * One column in the comparator table — a posting plus (optionally) the
@@ -93,16 +90,13 @@ public class EnvoyComparatorController {
      * @param reports              inbound port for report queries
      * @param rubricRepository     outbound port for rubric lookups
      * @param jobPostingRepository outbound port for posting lookups
-     * @param currentOrg           resolves the authenticated user's first organization
      */
     public EnvoyComparatorController(QueryScoreReportsUseCase reports,
                                      RubricRepository rubricRepository,
-                                     JobPostingRepository jobPostingRepository,
-                                     CurrentOrganizationResolver currentOrg) {
+                                     JobPostingRepository jobPostingRepository) {
         this.reports = reports;
         this.rubricRepository = rubricRepository;
         this.jobPostingRepository = jobPostingRepository;
-        this.currentOrg = currentOrg;
     }
 
     /**
@@ -120,26 +114,20 @@ public class EnvoyComparatorController {
      *       (the user still sees the company / title / location).</li>
      * </ul>
      *
-     * @param idsParam  comma-separated report ids
-     * @param rubric    rubric name to compare against (default {@code default})
-     * @param principal authenticated user
-     * @param model     Thymeleaf model
-     * @return the {@code envoy-compare} template name, or a redirect to {@code /}
-     *         when the user has no organization
+     * @param idsParam   comma-separated report ids
+     * @param rubric     rubric name to compare against (default {@code default})
+     * @param orgContext authenticated user + organization
+     * @param model      Thymeleaf model
+     * @return the {@code envoy-compare} template name
      */
     @GetMapping("/envoy/compare")
     public String compare(@RequestParam(name = "ids") String idsParam,
                           @RequestParam(name = "rubric", defaultValue = DEFAULT_RUBRIC)
                           String rubric,
-                          @AuthenticationPrincipal UserDetails principal,
+                          OrgContext orgContext,
                           Model model) {
         List<UUID> ids = parseIds(idsParam);
-
-        var ctx = currentOrg.resolve(principal);
-        if (ctx.organizationId() == null) {
-            return "redirect:/";
-        }
-        UUID orgId = ctx.organizationId();
+        UUID orgId = orgContext.organizationId();
 
         Rubric activeRubric = rubricRepository.findActiveByName(rubric, orgId)
                 .orElseThrow(() -> new IllegalArgumentException(
@@ -157,7 +145,7 @@ public class EnvoyComparatorController {
         model.addAttribute("columns", columns);
         model.addAttribute("rows", rows);
         model.addAttribute("organizationId", orgId);
-        model.addAttribute("username", ctx.user().getUsername());
+        model.addAttribute("username", orgContext.username());
         return "envoy-compare";
     }
 

--- a/src/main/java/com/majordomo/adapter/in/web/envoy/EnvoyPageController.java
+++ b/src/main/java/com/majordomo/adapter/in/web/envoy/EnvoyPageController.java
@@ -1,7 +1,7 @@
 package com.majordomo.adapter.in.web.envoy;
 
+import com.majordomo.adapter.in.web.config.OrgContext;
 import com.majordomo.application.envoy.LlmScoringException;
-import com.majordomo.application.identity.CurrentOrganizationResolver;
 import com.majordomo.domain.model.envoy.JobPosting;
 import com.majordomo.domain.model.envoy.JobSourceRequest;
 import com.majordomo.domain.model.envoy.Recommendation;
@@ -16,8 +16,6 @@ import com.majordomo.domain.port.out.envoy.JobPostingRepository;
 import jakarta.servlet.http.HttpServletResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -53,7 +51,6 @@ public class EnvoyPageController {
     private final MarkPostingConversionUseCase conversionUseCase;
     private final GetApplyNowConversionStatUseCase conversionStatUseCase;
     private final JobPostingRepository jobPostingRepository;
-    private final CurrentOrganizationResolver currentOrg;
 
     /**
      * View-model row binding a {@link ScoreReport} to its source {@link JobPosting}.
@@ -74,22 +71,19 @@ public class EnvoyPageController {
      * @param conversionUseCase     inbound port for marking APPLY_NOW conversion outcome
      * @param conversionStatUseCase inbound port for the APPLY_NOW conversion rollup
      * @param jobPostingRepository  outbound port for posting lookups
-     * @param currentOrg            resolves the authenticated user's first organization
      */
     public EnvoyPageController(QueryScoreReportsUseCase reports,
                                IngestJobPostingUseCase ingestUseCase,
                                ScoreJobPostingUseCase scoreUseCase,
                                MarkPostingConversionUseCase conversionUseCase,
                                GetApplyNowConversionStatUseCase conversionStatUseCase,
-                               JobPostingRepository jobPostingRepository,
-                               CurrentOrganizationResolver currentOrg) {
+                               JobPostingRepository jobPostingRepository) {
         this.reports = reports;
         this.ingestUseCase = ingestUseCase;
         this.scoreUseCase = scoreUseCase;
         this.conversionUseCase = conversionUseCase;
         this.conversionStatUseCase = conversionStatUseCase;
         this.jobPostingRepository = jobPostingRepository;
-        this.currentOrg = currentOrg;
     }
 
     /**
@@ -109,21 +103,16 @@ public class EnvoyPageController {
      *
      * @param minFinalScore  optional min score lower bound (null = no filter)
      * @param recommendation optional recommendation tier filter (null = any)
-     * @param principal      the authenticated user
+     * @param orgContext     authenticated user + organization
      * @param model          the Thymeleaf model
-     * @return the {@code envoy} template name, or a redirect to {@code /} if
-     *         the user has no organization
+     * @return the {@code envoy} template name
      */
     @GetMapping("/envoy")
     public String envoy(@RequestParam(required = false) Integer minFinalScore,
                         @RequestParam(required = false) Recommendation recommendation,
-                        @AuthenticationPrincipal UserDetails principal,
+                        OrgContext orgContext,
                         Model model) {
-        var ctx = currentOrg.resolve(principal);
-        if (ctx.organizationId() == null) {
-            return "redirect:/";
-        }
-        renderEnvoyPage(ctx, minFinalScore, recommendation, model);
+        renderEnvoyPage(orgContext, minFinalScore, recommendation, model);
         return "envoy";
     }
 
@@ -145,16 +134,15 @@ public class EnvoyPageController {
      * filtered out, so the LLM extractor only sees hints the caller actually
      * provided.</p>
      *
-     * @param type      source discriminator (defaults to {@code "manual"})
-     * @param payload   raw posting text / URL / source-specific id
-     * @param company   optional company hint
-     * @param title     optional title hint
-     * @param location  optional location hint
-     * @param principal the authenticated user
-     * @param model     the Thymeleaf model
+     * @param type       source discriminator (defaults to {@code "manual"})
+     * @param payload    raw posting text / URL / source-specific id
+     * @param company    optional company hint
+     * @param title      optional title hint
+     * @param location   optional location hint
+     * @param orgContext authenticated user + organization
+     * @param model      the Thymeleaf model
      * @return {@code redirect:/envoy} on success; {@code envoy} (with an
-     *         {@code ingestError} attribute) on a handled failure;
-     *         {@code redirect:/} if the user has no organization
+     *         {@code ingestError} attribute) on a handled failure
      */
     @PostMapping("/envoy")
     public String submitIngest(@RequestParam(defaultValue = "manual") String type,
@@ -162,16 +150,12 @@ public class EnvoyPageController {
                                @RequestParam(required = false) String company,
                                @RequestParam(required = false) String title,
                                @RequestParam(required = false) String location,
-                               @AuthenticationPrincipal UserDetails principal,
+                               OrgContext orgContext,
                                Model model) {
-        var ctx = currentOrg.resolve(principal);
-        if (ctx.organizationId() == null) {
-            return "redirect:/";
-        }
-        UUID orgId = ctx.organizationId();
+        UUID orgId = orgContext.organizationId();
 
         if (payload == null || payload.isBlank()) {
-            renderEnvoyPage(ctx, null, null, model);
+            renderEnvoyPage(orgContext, null, null, model);
             model.addAttribute("ingestError", "Payload is required.");
             return "envoy";
         }
@@ -186,7 +170,7 @@ public class EnvoyPageController {
         } catch (IllegalArgumentException | LlmScoringException ex) {
             LOG.warn("Inline ingest+score failed for org {} (type={}): {}",
                     orgId, type, ex.getMessage());
-            renderEnvoyPage(ctx, null, null, model);
+            renderEnvoyPage(orgContext, null, null, model);
             model.addAttribute("ingestError", ex.getMessage());
             return "envoy";
         }
@@ -197,11 +181,11 @@ public class EnvoyPageController {
      * (rows, filter echo values, org id, username). Shared between the GET
      * handler and the POST handler's error path.
      */
-    private void renderEnvoyPage(CurrentOrganizationResolver.Resolved ctx,
+    private void renderEnvoyPage(OrgContext orgContext,
                                  Integer minFinalScore,
                                  Recommendation recommendation,
                                  Model model) {
-        UUID orgId = ctx.organizationId();
+        UUID orgId = orgContext.organizationId();
         List<ScoreReport> recent = reports
                 .query(orgId, new ScoreReportFilter(minFinalScore, recommendation),
                         null, DEFAULT_LIMIT)
@@ -219,7 +203,7 @@ public class EnvoyPageController {
         model.addAttribute("minFinalScore", minFinalScore);
         model.addAttribute("recommendation", recommendation);
         model.addAttribute("organizationId", orgId);
-        model.addAttribute("username", ctx.user().getUsername());
+        model.addAttribute("username", orgContext.username());
         model.addAttribute("applyNowTotal", stat.total());
         model.addAttribute("applyNowApplied", stat.applied());
     }
@@ -247,20 +231,16 @@ public class EnvoyPageController {
     /**
      * Marks a posting as applied (APPLY_NOW conversion path). Idempotent.
      *
-     * @param postingId the posting id (path variable)
-     * @param principal the authenticated user
+     * @param postingId  the posting id (path variable)
+     * @param orgContext authenticated user + organization
      * @return redirect back to the report detail page if the posting has any
      *         report; otherwise to the envoy list
      */
     @PostMapping("/envoy/postings/{postingId}/applied")
     public String markPostingApplied(@PathVariable UUID postingId,
-                                     @AuthenticationPrincipal UserDetails principal) {
-        var ctx = currentOrg.resolve(principal);
-        if (ctx.organizationId() == null) {
-            return "redirect:/";
-        }
+                                     OrgContext orgContext) {
         try {
-            conversionUseCase.markApplied(postingId, ctx.organizationId());
+            conversionUseCase.markApplied(postingId, orgContext.organizationId());
         } catch (IllegalArgumentException ignored) {
             // Posting not in user's org — silently swallow; the redirect target
             // will naturally 404 if the report id is not theirs.
@@ -271,19 +251,15 @@ public class EnvoyPageController {
     /**
      * Marks a posting as dismissed (not interested). Idempotent.
      *
-     * @param postingId the posting id (path variable)
-     * @param principal the authenticated user
+     * @param postingId  the posting id (path variable)
+     * @param orgContext authenticated user + organization
      * @return redirect to the envoy list
      */
     @PostMapping("/envoy/postings/{postingId}/dismissed")
     public String dismissPosting(@PathVariable UUID postingId,
-                                 @AuthenticationPrincipal UserDetails principal) {
-        var ctx = currentOrg.resolve(principal);
-        if (ctx.organizationId() == null) {
-            return "redirect:/";
-        }
+                                 OrgContext orgContext) {
         try {
-            conversionUseCase.dismiss(postingId, ctx.organizationId());
+            conversionUseCase.dismiss(postingId, orgContext.organizationId());
         } catch (IllegalArgumentException ignored) {
             // Same rationale as markPostingApplied.
         }
@@ -301,23 +277,18 @@ public class EnvoyPageController {
      * deleted from underneath the report we still render — the {@code posting}
      * model attribute is simply absent and the template degrades gracefully.</p>
      *
-     * @param id        the report id
-     * @param principal the authenticated user
-     * @param model     the Thymeleaf model
-     * @param response  used to set the 404 status when no report is found
-     * @return the {@code envoy-report} template, {@code error} on 404, or a
-     *         redirect to {@code /} if the user has no organization
+     * @param id         the report id
+     * @param orgContext authenticated user + organization
+     * @param model      the Thymeleaf model
+     * @param response   used to set the 404 status when no report is found
+     * @return the {@code envoy-report} template, or {@code error} on 404
      */
     @GetMapping("/envoy/reports/{id}")
     public String getReport(@PathVariable UUID id,
-                            @AuthenticationPrincipal UserDetails principal,
+                            OrgContext orgContext,
                             Model model,
                             HttpServletResponse response) {
-        var ctx = currentOrg.resolve(principal);
-        if (ctx.organizationId() == null) {
-            return "redirect:/";
-        }
-        UUID orgId = ctx.organizationId();
+        UUID orgId = orgContext.organizationId();
 
         Optional<ScoreReport> reportOpt = reports.findById(id, orgId);
         if (reportOpt.isEmpty()) {
@@ -332,7 +303,7 @@ public class EnvoyPageController {
 
         model.addAttribute("report", report);
         model.addAttribute("organizationId", orgId);
-        model.addAttribute("username", ctx.user().getUsername());
+        model.addAttribute("username", orgContext.username());
         return "envoy-report";
     }
 

--- a/src/main/java/com/majordomo/adapter/in/web/envoy/RubricAuthorController.java
+++ b/src/main/java/com/majordomo/adapter/in/web/envoy/RubricAuthorController.java
@@ -1,6 +1,6 @@
 package com.majordomo.adapter.in.web.envoy;
 
-import com.majordomo.application.identity.CurrentOrganizationResolver;
+import com.majordomo.adapter.in.web.config.OrgContext;
 import com.majordomo.domain.model.UuidFactory;
 import com.majordomo.domain.model.envoy.Category;
 import com.majordomo.domain.model.envoy.Rubric;
@@ -8,8 +8,6 @@ import com.majordomo.domain.model.envoy.Thresholds;
 import com.majordomo.domain.model.envoy.Tier;
 import com.majordomo.domain.port.in.envoy.ManageRubricUseCase;
 import com.majordomo.domain.port.out.envoy.RubricRepository;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.util.StringUtils;
@@ -41,21 +39,17 @@ public class RubricAuthorController {
 
     private final ManageRubricUseCase rubrics;
     private final RubricRepository rubricRepository;
-    private final CurrentOrganizationResolver currentOrg;
 
     /**
      * Constructs the controller.
      *
      * @param rubrics          inbound port for rubric authoring
      * @param rubricRepository outbound port for rubric reads
-     * @param currentOrg       resolves the authenticated user's first organization
      */
     public RubricAuthorController(ManageRubricUseCase rubrics,
-                                  RubricRepository rubricRepository,
-                                  CurrentOrganizationResolver currentOrg) {
+                                  RubricRepository rubricRepository) {
         this.rubrics = rubrics;
         this.rubricRepository = rubricRepository;
-        this.currentOrg = currentOrg;
     }
 
     /**
@@ -63,22 +57,17 @@ public class RubricAuthorController {
      * first organization (org-specific actives plus system-default rubrics
      * the org has not yet authored).
      *
-     * @param principal the authenticated user
-     * @param model     the Thymeleaf model
-     * @return the {@code rubrics-list} template, or a redirect home if the
-     *         user has no organization
+     * @param orgContext authenticated user + organization
+     * @param model      the Thymeleaf model
+     * @return the {@code rubrics-list} template
      */
     @GetMapping("/envoy/rubrics")
-    public String list(@AuthenticationPrincipal UserDetails principal, Model model) {
-        var ctx = currentOrg.resolve(principal);
-        if (ctx.organizationId() == null) {
-            return "redirect:/";
-        }
-        UUID orgId = ctx.organizationId();
+    public String list(OrgContext orgContext, Model model) {
+        UUID orgId = orgContext.organizationId();
         List<Rubric> activeRubrics = rubricRepository.findActiveRubricsForOrg(orgId);
         model.addAttribute("rubrics", activeRubrics);
         model.addAttribute("organizationId", orgId);
-        model.addAttribute("username", ctx.user().getUsername());
+        model.addAttribute("username", orgContext.username());
         return "rubrics-list";
     }
 
@@ -87,21 +76,16 @@ public class RubricAuthorController {
      * rubric for the org if one exists; otherwise renders a blank form for
      * authoring a new rubric under that name.
      *
-     * @param name      logical rubric name (path variable)
-     * @param principal the authenticated user
-     * @param model     the Thymeleaf model
-     * @return the {@code rubric-edit} template, or a redirect home if the
-     *         user has no organization
+     * @param name       logical rubric name (path variable)
+     * @param orgContext authenticated user + organization
+     * @param model      the Thymeleaf model
+     * @return the {@code rubric-edit} template
      */
     @GetMapping("/envoy/rubrics/{name}/edit")
     public String editForm(@PathVariable String name,
-                           @AuthenticationPrincipal UserDetails principal,
+                           OrgContext orgContext,
                            Model model) {
-        var ctx = currentOrg.resolve(principal);
-        if (ctx.organizationId() == null) {
-            return "redirect:/";
-        }
-        UUID orgId = ctx.organizationId();
+        UUID orgId = orgContext.organizationId();
         Optional<Rubric> existing = rubricRepository.findActiveByName(name, orgId);
         RubricFormDto form = existing.map(RubricAuthorController::toForm)
                 .orElseGet(RubricFormDto::new);
@@ -110,7 +94,7 @@ public class RubricAuthorController {
         model.addAttribute("rubricName", name);
         model.addAttribute("isNew", existing.isEmpty());
         model.addAttribute("organizationId", orgId);
-        model.addAttribute("username", ctx.user().getUsername());
+        model.addAttribute("username", orgContext.username());
         return "rubric-edit";
     }
 
@@ -120,34 +104,29 @@ public class RubricAuthorController {
      * redirects to the list page with a flash message; on failure re-renders
      * the form with the submitted values and field-level errors preserved.
      *
-     * @param name      logical rubric name (path variable)
-     * @param form      the submitted form (auto-bound)
-     * @param result    binding/validation result
-     * @param principal the authenticated user
-     * @param model     the Thymeleaf model used for re-render on error
-     * @param redirect  flash attribute target on success
-     * @return the list redirect on success, or {@code rubric-edit} on error;
-     *         redirect home if user has no organization
+     * @param name       logical rubric name (path variable)
+     * @param form       the submitted form (auto-bound)
+     * @param result     binding/validation result
+     * @param orgContext authenticated user + organization
+     * @param model      the Thymeleaf model used for re-render on error
+     * @param redirect   flash attribute target on success
+     * @return the list redirect on success, or {@code rubric-edit} on error
      */
     @PostMapping("/envoy/rubrics/{name}")
     public String submit(@PathVariable String name,
                          @ModelAttribute("form") RubricFormDto form,
                          BindingResult result,
-                         @AuthenticationPrincipal UserDetails principal,
+                         OrgContext orgContext,
                          Model model,
                          RedirectAttributes redirect) {
-        var ctx = currentOrg.resolve(principal);
-        if (ctx.organizationId() == null) {
-            return "redirect:/";
-        }
-        UUID orgId = ctx.organizationId();
+        UUID orgId = orgContext.organizationId();
 
         validate(form, result);
         if (result.hasErrors()) {
             model.addAttribute("rubricName", name);
             model.addAttribute("isNew", rubricRepository.findActiveByName(name, orgId).isEmpty());
             model.addAttribute("organizationId", orgId);
-            model.addAttribute("username", ctx.user().getUsername());
+            model.addAttribute("username", orgContext.username());
             return "rubric-edit";
         }
 

--- a/src/main/java/com/majordomo/adapter/in/web/envoy/RubricComparatorController.java
+++ b/src/main/java/com/majordomo/adapter/in/web/envoy/RubricComparatorController.java
@@ -1,10 +1,8 @@
 package com.majordomo.adapter.in.web.envoy;
 
-import com.majordomo.application.identity.CurrentOrganizationResolver;
+import com.majordomo.adapter.in.web.config.OrgContext;
 import com.majordomo.domain.model.envoy.RubricComparison;
 import com.majordomo.domain.port.in.envoy.CompareRubricVersionsUseCase;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -27,44 +25,35 @@ public class RubricComparatorController {
     private static final int MAX_LIMIT = 50;
 
     private final CompareRubricVersionsUseCase comparisonUseCase;
-    private final CurrentOrganizationResolver currentOrg;
 
     /**
      * Constructs the controller.
      *
      * @param comparisonUseCase inbound port for rubric comparison
-     * @param currentOrg        resolves the authenticated user's first organization
      */
-    public RubricComparatorController(CompareRubricVersionsUseCase comparisonUseCase,
-                                      CurrentOrganizationResolver currentOrg) {
+    public RubricComparatorController(CompareRubricVersionsUseCase comparisonUseCase) {
         this.comparisonUseCase = comparisonUseCase;
-        this.currentOrg = currentOrg;
     }
 
     /**
      * Renders the comparison view.
      *
-     * @param name      rubric name (path variable)
-     * @param from      older version (required)
-     * @param to        newer version (required)
-     * @param limit     posting set size (default 10, capped at 50)
-     * @param principal authenticated user
-     * @param model     Thymeleaf model
-     * @return the {@code rubric-compare} template, or {@code redirect:/} if
-     *         the user has no organization
+     * @param name       rubric name (path variable)
+     * @param from       older version (required)
+     * @param to         newer version (required)
+     * @param limit      posting set size (default 10, capped at 50)
+     * @param orgContext authenticated user + organization
+     * @param model      Thymeleaf model
+     * @return the {@code rubric-compare} template
      */
     @GetMapping("/envoy/rubrics/{name}/compare")
     public String compare(@PathVariable String name,
                           @RequestParam("from") int from,
                           @RequestParam("to") int to,
                           @RequestParam(value = "limit", defaultValue = "" + DEFAULT_LIMIT) int limit,
-                          @AuthenticationPrincipal UserDetails principal,
+                          OrgContext orgContext,
                           Model model) {
-        var ctx = currentOrg.resolve(principal);
-        if (ctx.organizationId() == null) {
-            return "redirect:/";
-        }
-        UUID orgId = ctx.organizationId();
+        UUID orgId = orgContext.organizationId();
         int clamped = Math.max(1, Math.min(limit, MAX_LIMIT));
 
         RubricComparison result = comparisonUseCase.compare(name, from, to, clamped, orgId);
@@ -75,7 +64,7 @@ public class RubricComparatorController {
         model.addAttribute("limit", clamped);
         model.addAttribute("result", result);
         model.addAttribute("organizationId", orgId);
-        model.addAttribute("username", ctx.user().getUsername());
+        model.addAttribute("username", orgContext.username());
         return "rubric-compare";
     }
 }

--- a/src/main/java/com/majordomo/adapter/in/web/herald/SchedulePageController.java
+++ b/src/main/java/com/majordomo/adapter/in/web/herald/SchedulePageController.java
@@ -1,7 +1,7 @@
 package com.majordomo.adapter.in.web.herald;
 
+import com.majordomo.adapter.in.web.config.OrgContext;
 import com.majordomo.application.herald.ScheduleAccessGuard;
-import com.majordomo.application.identity.CurrentOrganizationResolver;
 import com.majordomo.domain.model.EntityNotFoundException;
 import com.majordomo.domain.model.EntityType;
 import com.majordomo.domain.model.herald.Frequency;
@@ -11,8 +11,6 @@ import com.majordomo.domain.model.steward.Property;
 import com.majordomo.domain.port.in.herald.ManageScheduleUseCase;
 import com.majordomo.domain.port.out.herald.MaintenanceScheduleRepository;
 import com.majordomo.domain.port.out.steward.PropertyRepository;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -39,7 +37,6 @@ import java.util.UUID;
 @Controller
 public class SchedulePageController {
 
-    private final CurrentOrganizationResolver currentOrg;
     private final ScheduleAccessGuard guard;
     private final ManageScheduleUseCase scheduleUseCase;
     private final MaintenanceScheduleRepository scheduleRepository;
@@ -60,18 +57,15 @@ public class SchedulePageController {
     /**
      * Constructs the controller.
      *
-     * @param currentOrg         resolves the authenticated user's organizations
      * @param guard              authorization helper for property-scoped reads
      * @param scheduleUseCase    inbound port for schedule writes (record-add)
      * @param scheduleRepository outbound port for schedule reads
      * @param propertyRepository outbound port for property reads
      */
-    public SchedulePageController(CurrentOrganizationResolver currentOrg,
-                                  ScheduleAccessGuard guard,
+    public SchedulePageController(ScheduleAccessGuard guard,
                                   ManageScheduleUseCase scheduleUseCase,
                                   MaintenanceScheduleRepository scheduleRepository,
                                   PropertyRepository propertyRepository) {
-        this.currentOrg = currentOrg;
         this.guard = guard;
         this.scheduleUseCase = scheduleUseCase;
         this.scheduleRepository = scheduleRepository;
@@ -83,7 +77,7 @@ public class SchedulePageController {
      *
      * @param frequency      optional Frequency filter (null = any)
      * @param dueWithinDays  optional "due within N days" filter (null = any)
-     * @param principal      authenticated user
+     * @param orgContext     authenticated user + organization
      * @param model          Thymeleaf model
      * @return the {@code schedules} template, or a redirect to {@code /} when
      *         the user has no organization
@@ -91,13 +85,8 @@ public class SchedulePageController {
     @GetMapping("/schedules")
     public String list(@RequestParam(required = false) Frequency frequency,
                        @RequestParam(required = false) Integer dueWithinDays,
-                       @AuthenticationPrincipal UserDetails principal,
+                       OrgContext orgContext,
                        Model model) {
-        var ctx = currentOrg.resolve(principal);
-        if (ctx.organizationId() == null) {
-            return "redirect:/";
-        }
-
         Set<UUID> orgIds = guard.currentUserOrganizationIds();
         // Pull all properties + their schedules (N+1 by property is fine at personal scale).
         List<Property> properties = new ArrayList<>();
@@ -133,7 +122,7 @@ public class SchedulePageController {
         model.addAttribute("frequency", frequency);
         model.addAttribute("dueWithinDays", dueWithinDays);
         model.addAttribute("frequencies", Frequency.values());
-        model.addAttribute("username", ctx.user().getUsername());
+        model.addAttribute("username", orgContext.username());
         return "schedules";
     }
 
@@ -143,21 +132,17 @@ public class SchedulePageController {
      * new service event.
      *
      * @param id        schedule id
-     * @param principal authenticated user
+     * @param orgContext authenticated user + organization
      * @param model     Thymeleaf model
      * @return the {@code schedule-detail} template, or {@code redirect:/} if
      *         the user has no organization
      */
     @GetMapping("/schedules/{id}")
     public String detail(@PathVariable UUID id,
-                         @AuthenticationPrincipal UserDetails principal,
+                         OrgContext orgContext,
                          Model model) {
-        var ctx = currentOrg.resolve(principal);
-        if (ctx.organizationId() == null) {
-            return "redirect:/";
-        }
         guard.verifyForSchedule(id);
-        renderDetail(id, ctx.user().getUsername(), model);
+        renderDetail(id, orgContext.username(), model);
         return "schedule-detail";
     }
 
@@ -172,7 +157,7 @@ public class SchedulePageController {
      * @param description short description (required, non-blank)
      * @param cost        optional cost
      * @param notes       optional free-form notes
-     * @param principal   authenticated user
+     * @param orgContext  authenticated user + organization
      * @param model       Thymeleaf model
      * @return redirect to the detail page on success; {@code schedule-detail}
      *         on a handled validation failure; {@code redirect:/} if no org
@@ -183,17 +168,13 @@ public class SchedulePageController {
                             @RequestParam(required = false) String description,
                             @RequestParam(required = false) BigDecimal cost,
                             @RequestParam(required = false) String notes,
-                            @AuthenticationPrincipal UserDetails principal,
+                            OrgContext orgContext,
                             Model model) {
-        var ctx = currentOrg.resolve(principal);
-        if (ctx.organizationId() == null) {
-            return "redirect:/";
-        }
         guard.verifyForSchedule(id);
 
         String error = validateRecordInputs(performedOn, description);
         if (error != null) {
-            renderDetail(id, ctx.user().getUsername(), model);
+            renderDetail(id, orgContext.username(), model);
             model.addAttribute("recordError", error);
             // Echo posted values back so the form keeps state.
             model.addAttribute("formPerformedOn", performedOn);
@@ -218,18 +199,14 @@ public class SchedulePageController {
      * "Add schedule" buttons.
      *
      * @param propertyId optional property id to pre-select in the picker
-     * @param principal  authenticated user
+     * @param orgContext authenticated user + organization
      * @param model      Thymeleaf model
      * @return the {@code schedule-form} template, or {@code redirect:/} if no org
      */
     @GetMapping("/schedules/new")
     public String newForm(@RequestParam(required = false) UUID propertyId,
-                          @AuthenticationPrincipal UserDetails principal, Model model) {
-        var ctx = currentOrg.resolve(principal);
-        if (ctx.organizationId() == null) {
-            return "redirect:/";
-        }
-        renderForm(null, null, ctx.user().getUsername(), model);
+                          OrgContext orgContext, Model model) {
+        renderForm(null, null, orgContext.username(), model);
         if (propertyId != null) {
             model.addAttribute("formPropertyId", propertyId);
         }
@@ -240,23 +217,19 @@ public class SchedulePageController {
      * Renders the edit form pre-populated for an existing schedule.
      *
      * @param id        schedule id
-     * @param principal authenticated user
+     * @param orgContext authenticated user + organization
      * @param model     Thymeleaf model
      * @return the {@code schedule-form} template, or {@code redirect:/} if no org
      */
     @GetMapping("/schedules/{id}/edit")
     public String editForm(@PathVariable UUID id,
-                           @AuthenticationPrincipal UserDetails principal,
+                           OrgContext orgContext,
                            Model model) {
-        var ctx = currentOrg.resolve(principal);
-        if (ctx.organizationId() == null) {
-            return "redirect:/";
-        }
         guard.verifyForSchedule(id);
         MaintenanceSchedule existing = scheduleRepository.findById(id)
                 .orElseThrow(() -> new EntityNotFoundException(
                         EntityType.MAINTENANCE_SCHEDULE.name(), id));
-        renderForm(id, existing, ctx.user().getUsername(), model);
+        renderForm(id, existing, orgContext.username(), model);
         return "schedule-form";
     }
 
@@ -272,7 +245,7 @@ public class SchedulePageController {
      * @param contactId           optional service-contact id
      * @param customIntervalDays  optional, only meaningful with {@link Frequency#CUSTOM}
      * @param estimatedCost       optional cost-per-occurrence
-     * @param principal           authenticated user
+     * @param orgContext          authenticated user + organization
      * @param model               Thymeleaf model
      * @return redirect to the new schedule's detail page on success;
      *         {@code schedule-form} on a handled validation failure;
@@ -286,14 +259,10 @@ public class SchedulePageController {
                          @RequestParam(required = false) UUID contactId,
                          @RequestParam(required = false) Integer customIntervalDays,
                          @RequestParam(required = false) BigDecimal estimatedCost,
-                         @AuthenticationPrincipal UserDetails principal,
+                         OrgContext orgContext,
                          Model model) {
-        var ctx = currentOrg.resolve(principal);
-        if (ctx.organizationId() == null) {
-            return "redirect:/";
-        }
         if (propertyId == null) {
-            renderForm(null, null, ctx.user().getUsername(), model);
+            renderForm(null, null, orgContext.username(), model);
             model.addAttribute("formError", "Property is required.");
             echoFormState(model, propertyId, description, frequency, nextDue,
                     contactId, customIntervalDays, estimatedCost);
@@ -303,7 +272,7 @@ public class SchedulePageController {
 
         String error = validateFormInputs(description, frequency, nextDue);
         if (error != null) {
-            renderForm(null, null, ctx.user().getUsername(), model);
+            renderForm(null, null, orgContext.username(), model);
             model.addAttribute("formError", error);
             echoFormState(model, propertyId, description, frequency, nextDue,
                     contactId, customIntervalDays, estimatedCost);
@@ -335,7 +304,7 @@ public class SchedulePageController {
      * @param contactId           optional service-contact id
      * @param customIntervalDays  optional, only meaningful with {@link Frequency#CUSTOM}
      * @param estimatedCost       optional cost-per-occurrence
-     * @param principal           authenticated user
+     * @param orgContext          authenticated user + organization
      * @param model               Thymeleaf model
      * @return redirect to the schedule's detail page on success;
      *         {@code schedule-form} on a handled validation failure;
@@ -350,19 +319,15 @@ public class SchedulePageController {
                          @RequestParam(required = false) UUID contactId,
                          @RequestParam(required = false) Integer customIntervalDays,
                          @RequestParam(required = false) BigDecimal estimatedCost,
-                         @AuthenticationPrincipal UserDetails principal,
+                         OrgContext orgContext,
                          Model model) {
-        var ctx = currentOrg.resolve(principal);
-        if (ctx.organizationId() == null) {
-            return "redirect:/";
-        }
         guard.verifyForSchedule(id);
         MaintenanceSchedule existing = scheduleRepository.findById(id)
                 .orElseThrow(() -> new EntityNotFoundException(
                         EntityType.MAINTENANCE_SCHEDULE.name(), id));
 
         if (propertyId == null) {
-            renderForm(id, existing, ctx.user().getUsername(), model);
+            renderForm(id, existing, orgContext.username(), model);
             model.addAttribute("formError", "Property is required.");
             echoFormState(model, propertyId, description, frequency, nextDue,
                     contactId, customIntervalDays, estimatedCost);
@@ -376,7 +341,7 @@ public class SchedulePageController {
 
         String error = validateFormInputs(description, frequency, nextDue);
         if (error != null) {
-            renderForm(id, existing, ctx.user().getUsername(), model);
+            renderForm(id, existing, orgContext.username(), model);
             model.addAttribute("formError", error);
             echoFormState(model, propertyId, description, frequency, nextDue,
                     contactId, customIntervalDays, estimatedCost);

--- a/src/main/java/com/majordomo/adapter/in/web/identity/AccountApiKeyPageController.java
+++ b/src/main/java/com/majordomo/adapter/in/web/identity/AccountApiKeyPageController.java
@@ -1,13 +1,11 @@
 package com.majordomo.adapter.in.web.identity;
 
 import com.majordomo.adapter.in.web.config.ApiKeyAuthenticationFilter;
-import com.majordomo.application.identity.CurrentOrganizationResolver;
+import com.majordomo.adapter.in.web.config.OrgContext;
 import com.majordomo.domain.model.UuidFactory;
 import com.majordomo.domain.model.identity.ApiKey;
 import com.majordomo.domain.port.out.identity.ApiKeyRepository;
 
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -37,38 +35,30 @@ public class AccountApiKeyPageController {
     private static final SecureRandom SECURE_RANDOM = new SecureRandom();
 
     private final ApiKeyRepository apiKeyRepository;
-    private final CurrentOrganizationResolver currentOrg;
 
     /**
      * Constructs the API key page controller.
      *
      * @param apiKeyRepository outbound port for API key persistence
-     * @param currentOrg       resolves the authenticated user's organization
      */
-    public AccountApiKeyPageController(ApiKeyRepository apiKeyRepository,
-                                       CurrentOrganizationResolver currentOrg) {
+    public AccountApiKeyPageController(ApiKeyRepository apiKeyRepository) {
         this.apiKeyRepository = apiKeyRepository;
-        this.currentOrg = currentOrg;
     }
 
     /**
      * Renders the API key list for the user's organization.
      *
-     * @param principal authenticated user
-     * @param model     Thymeleaf model
-     * @return the {@code account-api-keys} template, or a redirect home if no org
+     * @param orgContext authenticated user + organization
+     * @param model      Thymeleaf model
+     * @return the {@code account-api-keys} template
      */
     @GetMapping
-    public String list(@AuthenticationPrincipal UserDetails principal, Model model) {
-        var ctx = currentOrg.resolve(principal);
-        if (ctx.organizationId() == null) {
-            return "redirect:/";
-        }
-        List<ApiKey> keys = apiKeyRepository.findByOrganizationId(ctx.organizationId()).stream()
+    public String list(OrgContext orgContext, Model model) {
+        List<ApiKey> keys = apiKeyRepository.findByOrganizationId(orgContext.organizationId()).stream()
                 .filter(k -> k.getArchivedAt() == null)
                 .toList();
         model.addAttribute("keys", keys);
-        model.addAttribute("username", ctx.user().getUsername());
+        model.addAttribute("username", orgContext.username());
         return "account-api-keys";
     }
 
@@ -79,18 +69,14 @@ public class AccountApiKeyPageController {
      * never stored.
      *
      * @param name       the key label (required)
-     * @param principal  authenticated user
+     * @param orgContext authenticated user + organization
      * @param redirect   redirect attributes (used as flash for one-shot plaintext)
      * @return redirect back to the list
      */
     @PostMapping
     public String create(@RequestParam(required = false) String name,
-                         @AuthenticationPrincipal UserDetails principal,
+                         OrgContext orgContext,
                          RedirectAttributes redirect) {
-        var ctx = currentOrg.resolve(principal);
-        if (ctx.organizationId() == null) {
-            return "redirect:/";
-        }
         if (name == null || name.isBlank()) {
             redirect.addFlashAttribute("formError", "Name is required.");
             return "redirect:/account/api-keys";
@@ -98,7 +84,7 @@ public class AccountApiKeyPageController {
         String plaintext = generateRawKey();
         String hashed = ApiKeyAuthenticationFilter.sha256(plaintext);
         Instant now = Instant.now();
-        ApiKey key = new ApiKey(UuidFactory.newId(), ctx.organizationId(), name.trim(), hashed);
+        ApiKey key = new ApiKey(UuidFactory.newId(), orgContext.organizationId(), name.trim(), hashed);
         key.setCreatedAt(now);
         key.setUpdatedAt(now);
         apiKeyRepository.save(key);
@@ -112,18 +98,13 @@ public class AccountApiKeyPageController {
      * Cross-organization revokes are silently ignored — the redirect lands on
      * the same list, which won't contain the foreign key.
      *
-     * @param id        the key UUID
-     * @param principal authenticated user
+     * @param id         the key UUID
+     * @param orgContext authenticated user + organization
      * @return redirect back to the list
      */
     @PostMapping("/{id}/revoke")
-    public String revoke(@PathVariable UUID id,
-                         @AuthenticationPrincipal UserDetails principal) {
-        var ctx = currentOrg.resolve(principal);
-        if (ctx.organizationId() == null) {
-            return "redirect:/";
-        }
-        UUID orgId = ctx.organizationId();
+    public String revoke(@PathVariable UUID id, OrgContext orgContext) {
+        UUID orgId = orgContext.organizationId();
         apiKeyRepository.findById(id).ifPresent(k -> {
             if (orgId.equals(k.getOrganizationId())) {
                 Instant now = Instant.now();

--- a/src/main/java/com/majordomo/adapter/in/web/ledger/LedgerPageController.java
+++ b/src/main/java/com/majordomo/adapter/in/web/ledger/LedgerPageController.java
@@ -1,13 +1,11 @@
 package com.majordomo.adapter.in.web.ledger;
 
-import com.majordomo.application.identity.CurrentOrganizationResolver;
+import com.majordomo.adapter.in.web.config.OrgContext;
 import com.majordomo.domain.model.ledger.SpendSummary;
 import com.majordomo.domain.model.steward.Property;
 import com.majordomo.domain.port.in.ledger.QuerySpendUseCase;
 import com.majordomo.domain.port.out.steward.PropertyRepository;
 
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -29,7 +27,6 @@ public class LedgerPageController {
 
     private final QuerySpendUseCase spendUseCase;
     private final PropertyRepository propertyRepository;
-    private final CurrentOrganizationResolver currentOrg;
 
     /**
      * One row in the per-property spend table.
@@ -44,30 +41,23 @@ public class LedgerPageController {
      *
      * @param spendUseCase       inbound port for spend queries
      * @param propertyRepository outbound port for property reads
-     * @param currentOrg         resolves the authenticated user's organization
      */
     public LedgerPageController(QuerySpendUseCase spendUseCase,
-                                PropertyRepository propertyRepository,
-                                CurrentOrganizationResolver currentOrg) {
+                                PropertyRepository propertyRepository) {
         this.spendUseCase = spendUseCase;
         this.propertyRepository = propertyRepository;
-        this.currentOrg = currentOrg;
     }
 
     /**
      * Renders the spend dashboard for the user's organization.
      *
-     * @param principal authenticated user
-     * @param model     Thymeleaf model
-     * @return the {@code ledger} template, or a redirect home if no org
+     * @param orgContext authenticated user + organization
+     * @param model      Thymeleaf model
+     * @return the {@code ledger} template
      */
     @GetMapping
-    public String dashboard(@AuthenticationPrincipal UserDetails principal, Model model) {
-        var ctx = currentOrg.resolve(principal);
-        if (ctx.organizationId() == null) {
-            return "redirect:/";
-        }
-        UUID orgId = ctx.organizationId();
+    public String dashboard(OrgContext orgContext, Model model) {
+        UUID orgId = orgContext.organizationId();
 
         SpendSummary orgSpend = spendUseCase.spendForOrganization(orgId);
         BigDecimal projected = spendUseCase.projectedAnnualSpend(orgId);
@@ -86,7 +76,7 @@ public class LedgerPageController {
         model.addAttribute("orgSpend", orgSpend);
         model.addAttribute("projectedAnnualSpend", projected);
         model.addAttribute("rows", rows);
-        model.addAttribute("username", ctx.user().getUsername());
+        model.addAttribute("username", orgContext.username());
         return "ledger";
     }
 

--- a/src/main/java/com/majordomo/adapter/in/web/steward/PropertyContactLinkController.java
+++ b/src/main/java/com/majordomo/adapter/in/web/steward/PropertyContactLinkController.java
@@ -1,7 +1,7 @@
 package com.majordomo.adapter.in.web.steward;
 
 import com.majordomo.adapter.in.web.FormBindingHelper;
-import com.majordomo.application.identity.CurrentOrganizationResolver;
+import com.majordomo.adapter.in.web.config.OrgContext;
 import com.majordomo.application.identity.OrganizationAccessService;
 import com.majordomo.domain.model.EntityNotFoundException;
 import com.majordomo.domain.model.EntityType;
@@ -13,8 +13,6 @@ import com.majordomo.domain.port.in.steward.ManagePropertyUseCase;
 import com.majordomo.domain.port.out.concierge.ContactRepository;
 import com.majordomo.domain.port.out.steward.PropertyContactRepository;
 
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -36,7 +34,6 @@ public class PropertyContactLinkController {
     private final ManagePropertyUseCase propertyUseCase;
     private final ContactRepository contactRepository;
     private final PropertyContactRepository propertyContactRepository;
-    private final CurrentOrganizationResolver currentOrg;
     private final OrganizationAccessService organizationAccessService;
 
     /**
@@ -45,29 +42,27 @@ public class PropertyContactLinkController {
      * @param propertyUseCase           inbound port for property lookups
      * @param contactRepository         outbound port for contact reads
      * @param propertyContactRepository outbound port for property–contact rows
-     * @param currentOrg                resolves the authenticated user's organization
      * @param organizationAccessService verifies caller has access to a given organization
      */
     public PropertyContactLinkController(ManagePropertyUseCase propertyUseCase,
                                          ContactRepository contactRepository,
                                          PropertyContactRepository propertyContactRepository,
-                                         CurrentOrganizationResolver currentOrg,
                                          OrganizationAccessService organizationAccessService) {
         this.propertyUseCase = propertyUseCase;
         this.contactRepository = contactRepository;
         this.propertyContactRepository = propertyContactRepository;
-        this.currentOrg = currentOrg;
         this.organizationAccessService = organizationAccessService;
     }
 
     /**
      * Links a contact to a property.
      *
-     * @param id        property UUID
-     * @param contactId the contact to link
-     * @param role      role classification (defaults to OTHER if blank/unknown)
-     * @param notes     optional free-form notes
-     * @param principal authenticated user
+     * @param id         property UUID
+     * @param contactId  the contact to link
+     * @param role       role classification (defaults to OTHER if blank/unknown)
+     * @param notes      optional free-form notes
+     * @param orgContext authenticated user + organization (presence ensures
+     *                   the caller is authenticated and has an org)
      * @return redirect to the property detail page
      */
     @PostMapping("/{id}/contacts")
@@ -75,11 +70,7 @@ public class PropertyContactLinkController {
                        @RequestParam UUID contactId,
                        @RequestParam(required = false) String role,
                        @RequestParam(required = false) String notes,
-                       @AuthenticationPrincipal UserDetails principal) {
-        var ctx = currentOrg.resolve(principal);
-        if (ctx.organizationId() == null) {
-            return "redirect:/";
-        }
+                       OrgContext orgContext) {
         Property property = propertyUseCase.findById(id)
                 .orElseThrow(() -> new EntityNotFoundException(EntityType.PROPERTY.name(), id));
         organizationAccessService.verifyAccess(property.getOrganizationId());
@@ -100,19 +91,15 @@ public class PropertyContactLinkController {
     /**
      * Unlinks (soft-deletes) a contact association.
      *
-     * @param id        property UUID
-     * @param linkId    PropertyContact row UUID
-     * @param principal authenticated user
+     * @param id         property UUID
+     * @param linkId     PropertyContact row UUID
+     * @param orgContext authenticated user + organization
      * @return redirect to the property detail page
      */
     @PostMapping("/{id}/contacts/{linkId}/unlink")
     public String unlink(@PathVariable UUID id,
                          @PathVariable UUID linkId,
-                         @AuthenticationPrincipal UserDetails principal) {
-        var ctx = currentOrg.resolve(principal);
-        if (ctx.organizationId() == null) {
-            return "redirect:/";
-        }
+                         OrgContext orgContext) {
         Property property = propertyUseCase.findById(id)
                 .orElseThrow(() -> new EntityNotFoundException(EntityType.PROPERTY.name(), id));
         organizationAccessService.verifyAccess(property.getOrganizationId());

--- a/src/main/java/com/majordomo/adapter/in/web/steward/PropertyPageController.java
+++ b/src/main/java/com/majordomo/adapter/in/web/steward/PropertyPageController.java
@@ -2,7 +2,6 @@ package com.majordomo.adapter.in.web.steward;
 
 import com.majordomo.adapter.in.web.FormBindingHelper;
 import com.majordomo.adapter.in.web.config.OrgContext;
-import com.majordomo.application.identity.CurrentOrganizationResolver;
 import com.majordomo.application.identity.OrganizationAccessService;
 import com.majordomo.application.steward.PropertyDetailView;
 import com.majordomo.application.steward.PropertyDetailViewService;
@@ -13,8 +12,6 @@ import com.majordomo.domain.model.steward.Property;
 import com.majordomo.domain.port.in.steward.ManagePropertyUseCase;
 import com.majordomo.domain.port.out.steward.PropertyRepository;
 
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -43,7 +40,6 @@ public class PropertyPageController {
     private final PropertyRepository propertyRepository;
     private final PropertyQueryService propertyQueryService;
     private final PropertyDetailViewService propertyDetailViewService;
-    private final CurrentOrganizationResolver currentOrg;
     private final OrganizationAccessService organizationAccessService;
 
     /**
@@ -53,20 +49,17 @@ public class PropertyPageController {
      * @param propertyRepository        the outbound port for property reads (used by parent picker)
      * @param propertyQueryService      application service for the list view's filter+sort
      * @param propertyDetailViewService application service that assembles the detail view
-     * @param currentOrg                resolves the authenticated user's organization
      * @param organizationAccessService verifies the caller has access to a given organization
      */
     public PropertyPageController(ManagePropertyUseCase propertyUseCase,
                                   PropertyRepository propertyRepository,
                                   PropertyQueryService propertyQueryService,
                                   PropertyDetailViewService propertyDetailViewService,
-                                  CurrentOrganizationResolver currentOrg,
                                   OrganizationAccessService organizationAccessService) {
         this.propertyUseCase = propertyUseCase;
         this.propertyRepository = propertyRepository;
         this.propertyQueryService = propertyQueryService;
         this.propertyDetailViewService = propertyDetailViewService;
-        this.currentOrg = currentOrg;
         this.organizationAccessService = organizationAccessService;
     }
 
@@ -76,46 +69,37 @@ public class PropertyPageController {
      *
      * @param category  optional exact-match category filter
      * @param q         optional case-insensitive query across name + description
-     * @param principal authenticated user
+     * @param orgContext authenticated user + organization
      * @param model     Thymeleaf model
-     * @return the {@code properties} template, or a redirect home if the user
-     *         has no organization
+     * @return the {@code properties} template
      */
     @GetMapping
     public String list(@RequestParam(required = false) String category,
                        @RequestParam(required = false) String q,
-                       @AuthenticationPrincipal UserDetails principal,
+                       OrgContext orgContext,
                        Model model) {
-        var ctx = currentOrg.resolve(principal);
-        if (ctx.organizationId() == null) {
-            return "redirect:/";
-        }
-        List<Property> rows = propertyQueryService.list(ctx.organizationId(),
+        List<Property> rows = propertyQueryService.list(orgContext.organizationId(),
                 new PropertyFilters(category, q));
         model.addAttribute("rows", rows);
         model.addAttribute("category", category);
         model.addAttribute("q", q);
-        model.addAttribute("username", ctx.user().getUsername());
+        model.addAttribute("username", orgContext.username());
         return "properties";
     }
 
     /**
      * Renders the new-property form.
      *
-     * @param principal authenticated user
-     * @param model     Thymeleaf model
+     * @param orgContext authenticated user + organization
+     * @param model      Thymeleaf model
      * @return the {@code property-form} template
      */
     @GetMapping("/new")
-    public String newForm(@AuthenticationPrincipal UserDetails principal, Model model) {
-        var ctx = currentOrg.resolve(principal);
-        if (ctx.organizationId() == null) {
-            return "redirect:/";
-        }
+    public String newForm(OrgContext orgContext, Model model) {
         model.addAttribute("editingId", null);
         model.addAttribute("existing", null);
-        model.addAttribute("username", ctx.user().getUsername());
-        model.addAttribute("parentCandidates", candidateParents(ctx.organizationId(), null));
+        model.addAttribute("username", orgContext.username());
+        model.addAttribute("parentCandidates", candidateParents(orgContext.organizationId(), null));
         return "property-form";
     }
 
@@ -128,7 +112,7 @@ public class PropertyPageController {
      * @param location      optional address / location
      * @param purchasePrice optional purchase price (decimal)
      * @param parentId      optional parent property ID
-     * @param principal     authenticated user
+     * @param orgContext    authenticated user + organization
      * @param model         Thymeleaf model
      * @return redirect to the new property's detail page on success
      */
@@ -139,15 +123,11 @@ public class PropertyPageController {
                          @RequestParam(required = false) String location,
                          @RequestParam(required = false) String purchasePrice,
                          @RequestParam(required = false) String parentId,
-                         @AuthenticationPrincipal UserDetails principal,
+                         OrgContext orgContext,
                          Model model) {
-        var ctx = currentOrg.resolve(principal);
-        if (ctx.organizationId() == null) {
-            return "redirect:/";
-        }
         var fields = new PropertyFormFields(name, category, description, location, purchasePrice);
         if (name == null || name.isBlank()) {
-            populateFormState(model, null, null, ctx.user().getUsername(),
+            populateFormState(model, null, null, orgContext.username(),
                     "Name is required.", fields);
             return "property-form";
         }
@@ -155,12 +135,12 @@ public class PropertyPageController {
         try {
             price = parsePrice(purchasePrice);
         } catch (PriceFormatException ex) {
-            populateFormState(model, null, null, ctx.user().getUsername(),
+            populateFormState(model, null, null, orgContext.username(),
                     ex.getMessage(), fields);
             return "property-form";
         }
         Property property = new Property();
-        property.setOrganizationId(ctx.organizationId());
+        property.setOrganizationId(orgContext.organizationId());
         property.setName(name);
         property.setCategory(category);
         property.setDescription(FormBindingHelper.blankToNull(description));
@@ -259,7 +239,7 @@ public class PropertyPageController {
      * @param location      optional address / location
      * @param purchasePrice optional purchase price (decimal)
      * @param parentId      optional parent property ID
-     * @param principal     authenticated user
+     * @param orgContext    authenticated user + organization
      * @param model         Thymeleaf model
      * @return redirect to the property's detail page on success
      */
@@ -271,19 +251,15 @@ public class PropertyPageController {
                          @RequestParam(required = false) String location,
                          @RequestParam(required = false) String purchasePrice,
                          @RequestParam(required = false) String parentId,
-                         @AuthenticationPrincipal UserDetails principal,
+                         OrgContext orgContext,
                          Model model) {
-        var ctx = currentOrg.resolve(principal);
-        if (ctx.organizationId() == null) {
-            return "redirect:/";
-        }
         Property existing = propertyUseCase.findById(id)
                 .orElseThrow(() -> new com.majordomo.domain.model.EntityNotFoundException(
                         com.majordomo.domain.model.EntityType.PROPERTY.name(), id));
         organizationAccessService.verifyAccess(existing.getOrganizationId());
         var fields = new PropertyFormFields(name, category, description, location, purchasePrice);
         if (name == null || name.isBlank()) {
-            populateFormState(model, id, existing, ctx.user().getUsername(),
+            populateFormState(model, id, existing, orgContext.username(),
                     "Name is required.", fields);
             return "property-form";
         }
@@ -291,7 +267,7 @@ public class PropertyPageController {
         try {
             price = parsePrice(purchasePrice);
         } catch (PriceFormatException ex) {
-            populateFormState(model, id, existing, ctx.user().getUsername(),
+            populateFormState(model, id, existing, orgContext.username(),
                     ex.getMessage(), fields);
             return "property-form";
         }
@@ -311,26 +287,22 @@ public class PropertyPageController {
     /**
      * Renders the edit form for an existing property, pre-populated.
      *
-     * @param id        the UUID of the property to edit
-     * @param principal authenticated user
-     * @param model     Thymeleaf model
+     * @param id         the UUID of the property to edit
+     * @param orgContext authenticated user + organization
+     * @param model      Thymeleaf model
      * @return the {@code property-form} template
      */
     @GetMapping("/{id}/edit")
     public String editForm(@PathVariable UUID id,
-                           @AuthenticationPrincipal UserDetails principal,
+                           OrgContext orgContext,
                            Model model) {
-        var ctx = currentOrg.resolve(principal);
-        if (ctx.organizationId() == null) {
-            return "redirect:/";
-        }
         Property existing = propertyUseCase.findById(id)
                 .orElseThrow(() -> new com.majordomo.domain.model.EntityNotFoundException(
                         com.majordomo.domain.model.EntityType.PROPERTY.name(), id));
         organizationAccessService.verifyAccess(existing.getOrganizationId());
         model.addAttribute("editingId", id);
         model.addAttribute("existing", existing);
-        model.addAttribute("username", ctx.user().getUsername());
+        model.addAttribute("username", orgContext.username());
         model.addAttribute("parentCandidates",
                 candidateParents(existing.getOrganizationId(), id));
         return "property-form";

--- a/src/test/java/com/majordomo/architecture/EnvoyAuthorizationArchitectureTest.java
+++ b/src/test/java/com/majordomo/architecture/EnvoyAuthorizationArchitectureTest.java
@@ -30,6 +30,10 @@ import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.methods;
  *       {@link com.majordomo.application.identity.OrganizationAccessService}.</li>
  *   <li>The method takes a parameter annotated
  *       {@code @org.springframework.security.core.annotation.AuthenticationPrincipal}.</li>
+ *   <li>The method takes a parameter of type
+ *       {@link com.majordomo.adapter.in.web.config.OrgContext}, which is resolved
+ *       by an argument resolver that throws {@code MissingOrganizationException}
+ *       (mapped to {@code redirect:/}) when the user has no membership.</li>
  * </ul>
  *
  * <p>HTTP-mapped means annotated with {@code @RequestMapping},
@@ -58,6 +62,9 @@ class EnvoyAuthorizationArchitectureTest {
     private static final String ORG_ACCESS_SERVICE =
             "com.majordomo.application.identity.OrganizationAccessService";
 
+    private static final String ORG_CONTEXT =
+            "com.majordomo.adapter.in.web.config.OrgContext";
+
     private static final Set<String> HTTP_MAPPING_ANNOTATIONS = Set.of(
             "org.springframework.web.bind.annotation.RequestMapping",
             "org.springframework.web.bind.annotation.GetMapping",
@@ -77,15 +84,16 @@ class EnvoyAuthorizationArchitectureTest {
 
     /**
      * Every HTTP-mapped method on an /envoy controller must be gated by
-     * {@code OrganizationAccessService} on the owning class or
-     * {@code @AuthenticationPrincipal} on the method.
+     * {@code OrganizationAccessService} on the owning class,
+     * {@code @AuthenticationPrincipal} on the method, or an {@code OrgContext}
+     * parameter on the method.
      */
     @Test
     void everyEnvoyControllerRouteIsAuthorized() {
         ArchRule rule = methods()
                 .that(areDeclaredInEnvoyController())
                 .and(areHttpMapped())
-                .should(beGatedByOrgAccessOrAuthenticationPrincipal());
+                .should(beGatedByOrgAccessOrAuthenticationPrincipalOrOrgContext());
 
         rule.check(classes);
     }
@@ -117,24 +125,26 @@ class EnvoyAuthorizationArchitectureTest {
         };
     }
 
-    private static ArchCondition<JavaMethod> beGatedByOrgAccessOrAuthenticationPrincipal() {
+    private static ArchCondition<JavaMethod> beGatedByOrgAccessOrAuthenticationPrincipalOrOrgContext() {
         return new ArchCondition<>(
                 "have an OrganizationAccessService field on the owner OR an "
-                        + "@AuthenticationPrincipal parameter") {
+                        + "@AuthenticationPrincipal parameter OR an OrgContext parameter") {
             @Override
             public void check(JavaMethod method, ConditionEvents events) {
                 boolean ownerHasOrgAccess = ownerHasOrgAccessField(method.getOwner());
                 boolean methodHasPrincipal = methodHasAuthenticationPrincipalParam(method);
+                boolean methodHasOrgContext = methodHasOrgContextParam(method);
 
-                if (ownerHasOrgAccess || methodHasPrincipal) {
+                if (ownerHasOrgAccess || methodHasPrincipal || methodHasOrgContext) {
                     return;
                 }
 
                 String message = String.format(
                         "Method %s.%s on /envoy controller is not gated: "
-                                + "owner has no OrganizationAccessService field "
-                                + "and method has no @AuthenticationPrincipal "
-                                + "parameter (declared in %s)",
+                                + "owner has no OrganizationAccessService field, "
+                                + "method has no @AuthenticationPrincipal parameter, "
+                                + "and method has no OrgContext parameter "
+                                + "(declared in %s)",
                         method.getOwner().getSimpleName(),
                         method.getName(),
                         method.getSourceCodeLocation());
@@ -155,5 +165,10 @@ class EnvoyAuthorizationArchitectureTest {
     private static boolean methodHasAuthenticationPrincipalParam(JavaMethod method) {
         return method.getParameters().stream()
                 .anyMatch(p -> p.isAnnotatedWith(AUTHENTICATION_PRINCIPAL_ANNOTATION));
+    }
+
+    private static boolean methodHasOrgContextParam(JavaMethod method) {
+        return method.getParameters().stream()
+                .anyMatch(p -> p.getRawType().getFullName().equals(ORG_CONTEXT));
     }
 }


### PR DESCRIPTION
## Summary

- Sweeps the 12 remaining Thymeleaf page controllers off `CurrentOrganizationResolver` + `@AuthenticationPrincipal` and onto the `OrgContext` argument resolver introduced in #270 / #276.
- Removes the per-handler `var ctx = currentOrg.resolve(principal); if (ctx.organizationId() == null) return "redirect:/";` boilerplate — the resolver throws `MissingOrganizationException` (mapped to `redirect:/`) when the user has no membership.
- Extends `EnvoyAuthorizationArchitectureTest` to accept an `OrgContext` parameter as a valid gating mechanism alongside the existing `OrganizationAccessService` field and `@AuthenticationPrincipal` parameter checks.

Net diff: **229 insertions, 446 deletions** across 13 files. `CurrentOrganizationResolver` is now used only by the argument resolver itself.

Closes #275.

## Controllers migrated

- `audit/AuditPageController`
- `concierge/ContactPageController`, `ContactPropertyLinkController`
- `envoy/EnvoyPageController`, `EnvoyComparatorController`, `RubricAuthorController`, `RubricComparatorController`
- `herald/SchedulePageController`
- `identity/AccountApiKeyPageController`
- `ledger/LedgerPageController`
- `steward/PropertyPageController`, `PropertyContactLinkController`

## Test plan

- [x] `./mvnw test -DskipITs` — 548 tests pass
- [x] `./mvnw validate` — 0 checkstyle violations
- [ ] CI green (CodeQL + full verify)

🤖 Generated with [Claude Code](https://claude.com/claude-code)