### PR TITLE
refactor(event): registry-driven CacheEvictionListener (closes #199)

### DIFF
--- a/src/main/java/com/majordomo/adapter/in/event/CacheEvictionListener.java
+++ b/src/main/java/com/majordomo/adapter/in/event/CacheEvictionListener.java
@@ -10,16 +10,33 @@ import org.springframework.cache.CacheManager;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 
+import java.util.Map;
+import java.util.Set;
+
 /**
- * Evicts caches in response to domain events to ensure consistency.
+ * Evicts caches in response to domain events. A static class &rarr; cache-name
+ * registry maps each handled event type to the set of caches its arrival
+ * invalidates; a single dispatcher consumes the registered events and clears
+ * the corresponding caches.
+ *
+ * <p>Adding a new event &times; cache mapping is a one-line entry in
+ * {@link #EVICTIONS} plus a class on the {@link EventListener#classes()} array
+ * &mdash; no new method body.</p>
  */
 @Component
 public class CacheEvictionListener {
 
     private static final Logger LOG = LoggerFactory.getLogger(CacheEvictionListener.class);
 
+    private static final String SPEND_CACHE = "spend";
     private static final String APPLY_NOW_CACHE = "envoy-apply-now";
     private static final String APPLY_NOW_STAT_CACHE = "envoy-apply-now-stat";
+
+    private static final Map<Class<?>, Set<String>> EVICTIONS = Map.of(
+            ServiceRecordCreated.class, Set.of(SPEND_CACHE),
+            JobPostingScored.class, Set.of(APPLY_NOW_CACHE, APPLY_NOW_STAT_CACHE),
+            PostingMarkedApplied.class, Set.of(APPLY_NOW_STAT_CACHE),
+            PostingDismissed.class, Set.of(APPLY_NOW_STAT_CACHE));
 
     private final CacheManager cacheManager;
 
@@ -33,49 +50,26 @@ public class CacheEvictionListener {
     }
 
     /**
-     * Evicts spend cache when a service record is created.
+     * Dispatches an incoming domain event by clearing each cache registered for
+     * its concrete type. Unregistered events are a no-op so the dispatcher
+     * stays safe even if a future {@link EventListener#classes()} entry is
+     * added without a matching {@link #EVICTIONS} entry.
      *
-     * @param event the service record creation event
+     * @param event the domain event
      */
-    @EventListener
-    public void onServiceRecordCreated(ServiceRecordCreated event) {
-        LOG.debug("Evicting spend cache after service record created");
-        evict("spend");
-    }
-
-    /**
-     * Evicts the APPLY_NOW dashboard caches after a posting is scored, so
-     * newly-scored APPLY_NOW postings appear promptly on summary surfaces.
-     *
-     * @param event the scoring event
-     */
-    @EventListener
-    public void onJobPostingScored(JobPostingScored event) {
-        LOG.debug("Evicting envoy-apply-now caches after posting scored");
-        evict(APPLY_NOW_CACHE);
-        evict(APPLY_NOW_STAT_CACHE);
-    }
-
-    /**
-     * Evicts the APPLY_NOW conversion stat after a user marks a posting applied.
-     *
-     * @param event the apply event
-     */
-    @EventListener
-    public void onPostingMarkedApplied(PostingMarkedApplied event) {
-        LOG.debug("Evicting envoy-apply-now-stat cache after posting marked applied");
-        evict(APPLY_NOW_STAT_CACHE);
-    }
-
-    /**
-     * Evicts the APPLY_NOW conversion stat after a user dismisses a posting.
-     *
-     * @param event the dismiss event
-     */
-    @EventListener
-    public void onPostingDismissed(PostingDismissed event) {
-        LOG.debug("Evicting envoy-apply-now-stat cache after posting dismissed");
-        evict(APPLY_NOW_STAT_CACHE);
+    @EventListener(classes = {
+            ServiceRecordCreated.class,
+            JobPostingScored.class,
+            PostingMarkedApplied.class,
+            PostingDismissed.class
+    })
+    public void onDomainEvent(Object event) {
+        Set<String> caches = EVICTIONS.get(event.getClass());
+        if (caches == null) {
+            return;
+        }
+        LOG.debug("Evicting caches {} after {}", caches, event.getClass().getSimpleName());
+        caches.forEach(this::evict);
     }
 
     private void evict(String cacheName) {

--- a/src/test/java/com/majordomo/adapter/in/event/CacheEvictionListenerTest.java
+++ b/src/test/java/com/majordomo/adapter/in/event/CacheEvictionListenerTest.java
@@ -13,23 +13,26 @@ import java.time.Instant;
 import java.util.UUID;
 
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
- * Tests for {@link CacheEvictionListener}.
+ * Tests for {@link CacheEvictionListener}. The listener routes every supported
+ * domain event through a single dispatcher that consults a class &rarr; cache
+ * registry; these tests exercise that single entry point.
  */
 class CacheEvictionListenerTest {
 
     /** Spend cache should be cleared when a service record is created. */
     @Test
-    void onServiceRecordCreatedEvictsSpendCache() {
+    void serviceRecordCreatedEvictsSpendCache() {
         var cacheManager = mock(CacheManager.class);
         var cache = mock(Cache.class);
         when(cacheManager.getCache("spend")).thenReturn(cache);
 
         var listener = new CacheEvictionListener(cacheManager);
-        listener.onServiceRecordCreated(new ServiceRecordCreated(
+        listener.onDomainEvent(new ServiceRecordCreated(
                 UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID(), null, Instant.now()));
 
         verify(cache).clear();
@@ -37,7 +40,7 @@ class CacheEvictionListenerTest {
 
     /** APPLY_NOW dashboard caches (postings + stat) should both be cleared when a posting is scored. */
     @Test
-    void onJobPostingScoredEvictsApplyNowCaches() {
+    void jobPostingScoredEvictsApplyNowCaches() {
         var cacheManager = mock(CacheManager.class);
         var postingsCache = mock(Cache.class);
         var statCache = mock(Cache.class);
@@ -45,7 +48,7 @@ class CacheEvictionListenerTest {
         when(cacheManager.getCache("envoy-apply-now-stat")).thenReturn(statCache);
 
         var listener = new CacheEvictionListener(cacheManager);
-        listener.onJobPostingScored(new JobPostingScored(
+        listener.onDomainEvent(new JobPostingScored(
                 UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID(),
                 85, Recommendation.APPLY_NOW, Instant.now()));
 
@@ -55,13 +58,13 @@ class CacheEvictionListenerTest {
 
     /** PostingMarkedApplied should evict the conversion stat cache. */
     @Test
-    void onPostingMarkedAppliedEvictsStatCache() {
+    void postingMarkedAppliedEvictsStatCache() {
         var cacheManager = mock(CacheManager.class);
         var statCache = mock(Cache.class);
         when(cacheManager.getCache("envoy-apply-now-stat")).thenReturn(statCache);
 
         var listener = new CacheEvictionListener(cacheManager);
-        listener.onPostingMarkedApplied(new PostingMarkedApplied(
+        listener.onDomainEvent(new PostingMarkedApplied(
                 UUID.randomUUID(), UUID.randomUUID(), Instant.now()));
 
         verify(statCache).clear();
@@ -69,15 +72,29 @@ class CacheEvictionListenerTest {
 
     /** PostingDismissed should evict the conversion stat cache. */
     @Test
-    void onPostingDismissedEvictsStatCache() {
+    void postingDismissedEvictsStatCache() {
         var cacheManager = mock(CacheManager.class);
         var statCache = mock(Cache.class);
         when(cacheManager.getCache("envoy-apply-now-stat")).thenReturn(statCache);
 
         var listener = new CacheEvictionListener(cacheManager);
-        listener.onPostingDismissed(new PostingDismissed(
+        listener.onDomainEvent(new PostingDismissed(
                 UUID.randomUUID(), UUID.randomUUID(), Instant.now()));
 
         verify(statCache).clear();
+    }
+
+    /**
+     * Unmapped event types must be a no-op so the dispatcher can safely listen
+     * to a broad set of classes without misrouting.
+     */
+    @Test
+    void unmappedEventEvictsNothing() {
+        var cacheManager = mock(CacheManager.class);
+
+        var listener = new CacheEvictionListener(cacheManager);
+        listener.onDomainEvent(new Object());
+
+        verify(cacheManager, never()).getCache(org.mockito.ArgumentMatchers.anyString());
     }
 }


### PR DESCRIPTION
## Summary

Replaces the four hand-rolled `@EventListener` methods on `CacheEvictionListener` with a single class → cache-name registry consumed by one dispatcher. The trigger condition flagged in #199 ("dispatch when the third or fourth handler is about to be added") has been hit — there are now four handlers — so the refactor is timely.

## Before

```java
@EventListener public void onServiceRecordCreated(ServiceRecordCreated e) { evict("spend"); }
@EventListener public void onJobPostingScored(JobPostingScored e) { evict(...); evict(...); }
@EventListener public void onPostingMarkedApplied(PostingMarkedApplied e) { evict(...); }
@EventListener public void onPostingDismissed(PostingDismissed e) { evict(...); }
```

## After

```java
private static final Map<Class<?>, Set<String>> EVICTIONS = Map.of(
    ServiceRecordCreated.class, Set.of(SPEND_CACHE),
    JobPostingScored.class,     Set.of(APPLY_NOW_CACHE, APPLY_NOW_STAT_CACHE),
    PostingMarkedApplied.class, Set.of(APPLY_NOW_STAT_CACHE),
    PostingDismissed.class,     Set.of(APPLY_NOW_STAT_CACHE));

@EventListener(classes = { ... })
public void onDomainEvent(Object event) {
    Set<String> caches = EVICTIONS.get(event.getClass());
    if (caches == null) return;
    caches.forEach(this::evict);
}
```

Behaviour-preserving — same caches cleared on the same events.

## Test plan

- [x] `./mvnw test` — 549 tests pass (was 548; added an unmapped-event no-op test)
- [x] `./mvnw verify -DskipITs` — green
- [x] Checkstyle clean
- [ ] CI green (CodeQL + full verify)

🤖 Generated with [Claude Code](https://claude.com/claude-code)