### PR TITLE
envoy: idempotent scoring — reuse prior report for unchanged postings (#289)

### DIFF
--- a/doc/user-guide/envoy.md
+++ b/doc/user-guide/envoy.md
@@ -65,4 +65,16 @@ LLM is asked to choose from (e.g. "Excellent: 8–10 points", "Adequate:
 4–7", "Poor: 0–3"). The rubric also has **thresholds** — the score
 ranges that map to APPLY_NOW / CONSIDER / SKIP recommendations.
 
+## Idempotent scoring
+
+Scoring is cached on the posting's content. If you score a posting that
+hasn't changed against a rubric version it was already scored under,
+Envoy returns the **existing report** without calling the LLM again — so
+re-opening a posting or re-running `score-all` costs nothing. Any change
+to the posting content, or a new rubric version, produces a fresh score.
+
+`POST /api/envoy/rescore` is the exception: it **forces** a fresh score
+for every posting even when nothing changed. Use it after a model
+upgrade, when you want new opinions despite identical inputs.
+
 See ADR-0022 for the full design rationale.

--- a/src/main/java/com/majordomo/adapter/in/web/envoy/PostingController.java
+++ b/src/main/java/com/majordomo/adapter/in/web/envoy/PostingController.java
@@ -125,6 +125,11 @@ public class PostingController {
      * fan-out is acceptable; queued/chunked backpressure can be added later if
      * the workload outgrows it.</p>
      *
+     * <p>This is the explicit force path: it bypasses the idempotent-scoring cache
+     * so an unchanged posting is still re-scored (that is the point of a manual
+     * rescore after a model upgrade). The automatic {@code score}/{@code score-all}
+     * paths remain cache-aware and skip the LLM for unchanged postings.</p>
+     *
      * @param organizationId owning org (caller must be a member)
      * @param rubricName     rubric to score against (defaults to {@code "default"})
      * @return JSON body with {@code count} = number of rescores triggered
@@ -138,7 +143,7 @@ public class PostingController {
         int succeeded = 0;
         for (JobPosting p : postings) {
             try {
-                scoreUseCase.score(p.getId(), rubricName, organizationId);
+                scoreUseCase.score(p.getId(), rubricName, organizationId, true);
                 succeeded++;
             } catch (RuntimeException ex) {
                 LOG.warn("Manual rescore failed for posting {} in org {}: {}",

--- a/src/main/java/com/majordomo/adapter/out/persistence/envoy/JpaScoreReportRepository.java
+++ b/src/main/java/com/majordomo/adapter/out/persistence/envoy/JpaScoreReportRepository.java
@@ -23,6 +23,18 @@ public interface JpaScoreReportRepository extends JpaRepository<ScoreReportEntit
     Optional<ScoreReportEntity> findByIdAndOrganizationId(UUID id, UUID organizationId);
 
     /**
+     * Finds the most recent report for a (posting, rubric) pair within an org,
+     * ordered by scoring time descending.
+     *
+     * @param postingId      the scored posting
+     * @param rubricId       the rubric version used
+     * @param organizationId owning org
+     * @return the latest matching report, or empty
+     */
+    Optional<ScoreReportEntity> findFirstByPostingIdAndRubricIdAndOrganizationIdOrderByScoredAtDesc(
+            UUID postingId, UUID rubricId, UUID organizationId);
+
+    /**
      * Cursor-paginated query. Returns {@code limit + 1} rows when more pages
      * exist so the caller can construct a {@code Page} with {@code hasMore}.
      *

--- a/src/main/java/com/majordomo/adapter/out/persistence/envoy/ScoreReportMapper.java
+++ b/src/main/java/com/majordomo/adapter/out/persistence/envoy/ScoreReportMapper.java
@@ -69,7 +69,8 @@ final class ScoreReportMapper {
                     fromBody.recommendation(),
                     fromBody.llmModel(),
                     fromBody.scoredAt(),
-                    columnUsage);
+                    columnUsage,
+                    fromBody.contentHash());
         }
         return fromBody;
     }

--- a/src/main/java/com/majordomo/adapter/out/persistence/envoy/ScoreReportRepositoryAdapter.java
+++ b/src/main/java/com/majordomo/adapter/out/persistence/envoy/ScoreReportRepositoryAdapter.java
@@ -39,6 +39,14 @@ public class ScoreReportRepositoryAdapter implements ScoreReportRepository {
     }
 
     @Override
+    public Optional<ScoreReport> findLatestScored(
+            UUID postingId, UUID rubricId, UUID organizationId) {
+        return jpa.findFirstByPostingIdAndRubricIdAndOrganizationIdOrderByScoredAtDesc(
+                        postingId, rubricId, organizationId)
+                .map(ScoreReportMapper::toDomain);
+    }
+
+    @Override
     public Page<ScoreReport> query(UUID organizationId, ScoreReportFilter filter,
                                    UUID cursor, int limit) {
         int clamped = Math.max(1, Math.min(limit, 100));

--- a/src/main/java/com/majordomo/application/envoy/JobScorerService.java
+++ b/src/main/java/com/majordomo/application/envoy/JobScorerService.java
@@ -18,6 +18,7 @@ import org.springframework.stereotype.Service;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 /**
@@ -39,6 +40,7 @@ public class JobScorerService implements ScoreJobPostingUseCase {
     private final ScoreAssembler assembler;
     private final EventPublisher eventPublisher;
     private final LlmCallObserver llmObserver;
+    private final PostingContentHasher contentHasher;
 
     /**
      * Constructs the scorer with all required collaborators.
@@ -50,6 +52,7 @@ public class JobScorerService implements ScoreJobPostingUseCase {
      * @param assembler      deterministic LLM-response validator
      * @param eventPublisher domain event publisher
      * @param llmObserver    observer that wraps each LLM call with metrics
+     * @param contentHasher  fingerprints posting content for idempotent scoring
      */
     public JobScorerService(RubricRepository rubrics,
                             JobPostingRepository postings,
@@ -57,7 +60,8 @@ public class JobScorerService implements ScoreJobPostingUseCase {
                             LlmScoringPort llm,
                             ScoreAssembler assembler,
                             EventPublisher eventPublisher,
-                            LlmCallObserver llmObserver) {
+                            LlmCallObserver llmObserver,
+                            PostingContentHasher contentHasher) {
         this.rubrics = rubrics;
         this.postings = postings;
         this.reports = reports;
@@ -65,6 +69,7 @@ public class JobScorerService implements ScoreJobPostingUseCase {
         this.assembler = assembler;
         this.eventPublisher = eventPublisher;
         this.llmObserver = llmObserver;
+        this.contentHasher = contentHasher;
     }
 
     @Override
@@ -100,8 +105,16 @@ public class JobScorerService implements ScoreJobPostingUseCase {
     }
 
     private ScoreReport runOne(JobPosting posting, Rubric rubric) {
+        String contentHash = contentHasher.hash(posting);
+        Optional<ScoreReport> prior = reports.findLatestScored(
+                posting.getId(), rubric.id(), posting.getOrganizationId());
+        if (prior.isPresent() && prior.get().contentHash().equals(Optional.of(contentHash))) {
+            // Posting unchanged since the last score under this rubric version:
+            // reuse the prior report instead of re-invoking the LLM.
+            return prior.get();
+        }
         LlmScoreResponse resp = llmObserver.observe(llm, posting, rubric);
-        ScoreReport report = assembler.assemble(posting, rubric, resp, llm.modelId());
+        ScoreReport report = assembler.assemble(posting, rubric, resp, llm.modelId(), contentHash);
         ScoreReport saved = reports.save(report);
         eventPublisher.publish(new JobPostingScored(
                 saved.id(), saved.organizationId(), saved.postingId(),

--- a/src/main/java/com/majordomo/application/envoy/JobScorerService.java
+++ b/src/main/java/com/majordomo/application/envoy/JobScorerService.java
@@ -74,12 +74,18 @@ public class JobScorerService implements ScoreJobPostingUseCase {
 
     @Override
     public ScoreReport score(UUID postingId, String rubricName, UUID organizationId) {
+        return score(postingId, rubricName, organizationId, false);
+    }
+
+    @Override
+    public ScoreReport score(UUID postingId, String rubricName, UUID organizationId,
+                             boolean forceRescore) {
         JobPosting posting = postings.findById(postingId, organizationId)
                 .orElseThrow(() -> new EntityNotFoundException(
                         EntityType.JOB_POSTING.name(), postingId));
         Rubric rubric = rubrics.findActiveByName(rubricName, organizationId)
                 .orElseThrow(() -> new EntityNotFoundException("RUBRIC", rubricName));
-        return runOne(posting, rubric);
+        return runOne(posting, rubric, forceRescore);
     }
 
     @Override
@@ -99,19 +105,21 @@ public class JobScorerService implements ScoreJobPostingUseCase {
         }
         List<ScoreReport> saved = new ArrayList<>(resolved.size());
         for (Rubric rubric : resolved) {
-            saved.add(runOne(posting, rubric));
+            saved.add(runOne(posting, rubric, false));
         }
         return saved;
     }
 
-    private ScoreReport runOne(JobPosting posting, Rubric rubric) {
+    private ScoreReport runOne(JobPosting posting, Rubric rubric, boolean forceRescore) {
         String contentHash = contentHasher.hash(posting);
-        Optional<ScoreReport> prior = reports.findLatestScored(
-                posting.getId(), rubric.id(), posting.getOrganizationId());
-        if (prior.isPresent() && prior.get().contentHash().equals(Optional.of(contentHash))) {
-            // Posting unchanged since the last score under this rubric version:
-            // reuse the prior report instead of re-invoking the LLM.
-            return prior.get();
+        if (!forceRescore) {
+            Optional<ScoreReport> prior = reports.findLatestScored(
+                    posting.getId(), rubric.id(), posting.getOrganizationId());
+            if (prior.isPresent() && prior.get().contentHash().equals(Optional.of(contentHash))) {
+                // Posting unchanged since the last score under this rubric version:
+                // reuse the prior report instead of re-invoking the LLM.
+                return prior.get();
+            }
         }
         LlmScoreResponse resp = llmObserver.observe(llm, posting, rubric);
         ScoreReport report = assembler.assemble(posting, rubric, resp, llm.modelId(), contentHash);

--- a/src/main/java/com/majordomo/application/envoy/PostingContentHasher.java
+++ b/src/main/java/com/majordomo/application/envoy/PostingContentHasher.java
@@ -1,0 +1,68 @@
+package com.majordomo.application.envoy;
+
+import com.majordomo.domain.model.envoy.JobPosting;
+import org.springframework.stereotype.Component;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Map;
+import java.util.TreeMap;
+
+/**
+ * Computes a deterministic content fingerprint for a {@link JobPosting}. The hash
+ * covers only the fields that influence scoring (company, title, location, raw text,
+ * and extracted fields) — never identity or timestamp fields — so two postings with
+ * identical content hash equal and any content change flips the hash.
+ *
+ * <p>Used by {@link JobScorerService} to detect that a posting is unchanged since a
+ * prior score, allowing the previous {@code ScoreReport} to be reused instead of
+ * re-invoking the LLM.</p>
+ */
+@Component
+public class PostingContentHasher {
+
+    /** Unit-separator control char, chosen so it cannot appear in field values. */
+    private static final char FIELD_SEPARATOR = '\u001F';
+
+    /**
+     * Hashes a posting's scoring-relevant content.
+     *
+     * @param posting the posting to fingerprint
+     * @return a lowercase hex SHA-256 digest of the posting's content
+     */
+    public String hash(JobPosting posting) {
+        StringBuilder sb = new StringBuilder();
+        append(sb, posting.getCompany());
+        append(sb, posting.getTitle());
+        append(sb, posting.getLocation());
+        append(sb, posting.getRawText());
+        Map<String, String> extracted = posting.getExtracted();
+        if (extracted != null) {
+            for (Map.Entry<String, String> e : new TreeMap<>(extracted).entrySet()) {
+                append(sb, e.getKey());
+                append(sb, e.getValue());
+            }
+        }
+        return sha256Hex(sb.toString());
+    }
+
+    private static void append(StringBuilder sb, String value) {
+        sb.append(value == null ? "" : value).append(FIELD_SEPARATOR);
+    }
+
+    private static String sha256Hex(String input) {
+        try {
+            byte[] digest = MessageDigest.getInstance("SHA-256")
+                    .digest(input.getBytes(StandardCharsets.UTF_8));
+            StringBuilder hex = new StringBuilder(digest.length * 2);
+            for (byte b : digest) {
+                hex.append(Character.forDigit((b >> 4) & 0xF, 16));
+                hex.append(Character.forDigit(b & 0xF, 16));
+            }
+            return hex.toString();
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 unavailable", e);
+        }
+    }
+}

--- a/src/main/java/com/majordomo/application/envoy/ScoreAssembler.java
+++ b/src/main/java/com/majordomo/application/envoy/ScoreAssembler.java
@@ -30,14 +30,37 @@ public class ScoreAssembler {
      * Validates {@code resp} against {@code rubric} and assembles a {@code ScoreReport}.
      * Does not persist.
      *
+     * @param posting     the posting being scored
+     * @param rubric      the rubric used to prompt the LLM
+     * @param resp        the LLM's structured response
+     * @param llmModel    model identifier to record on the report
+     * @param contentHash fingerprint of the scored posting content, recorded so a
+     *                    later unchanged re-score can reuse this report
+     * @return a fully-validated report ready to persist
+     */
+    public ScoreReport assemble(JobPosting posting, Rubric rubric,
+                                LlmScoreResponse resp, String llmModel, String contentHash) {
+        return doAssemble(posting, rubric, resp, llmModel, contentHash);
+    }
+
+    /**
+     * Assembles a report with no content fingerprint. For ephemeral uses such as
+     * side-by-side rubric comparison, where the result is never persisted or reused
+     * and so needs no idempotency key.
+     *
      * @param posting  the posting being scored
      * @param rubric   the rubric used to prompt the LLM
      * @param resp     the LLM's structured response
      * @param llmModel model identifier to record on the report
-     * @return a fully-validated report ready to persist
+     * @return a fully-validated report with an empty {@code contentHash}
      */
     public ScoreReport assemble(JobPosting posting, Rubric rubric,
                                 LlmScoreResponse resp, String llmModel) {
+        return doAssemble(posting, rubric, resp, llmModel, null);
+    }
+
+    private ScoreReport doAssemble(JobPosting posting, Rubric rubric,
+                                   LlmScoreResponse resp, String llmModel, String contentHash) {
 
         if (resp.disqualifierKey().isPresent()) {
             Disqualifier dq = lookupDisqualifier(rubric, resp.disqualifierKey().get());
@@ -54,7 +77,8 @@ public class ScoreAssembler {
                     Recommendation.SKIP,
                     llmModel,
                     Instant.now(),
-                    resp.usage());
+                    resp.usage(),
+                    Optional.ofNullable(contentHash));
         }
 
         List<CategoryScore> categoryScores = new ArrayList<>();
@@ -97,7 +121,8 @@ public class ScoreAssembler {
                 recommendation,
                 llmModel,
                 Instant.now(),
-                resp.usage());
+                resp.usage(),
+                Optional.ofNullable(contentHash));
     }
 
     private Disqualifier lookupDisqualifier(Rubric rubric, String key) {

--- a/src/main/java/com/majordomo/domain/model/envoy/ScoreReport.java
+++ b/src/main/java/com/majordomo/domain/model/envoy/ScoreReport.java
@@ -36,6 +36,10 @@ import java.util.UUID;
  * @param usage           optional provider-supplied call metadata; empty when the adapter
  *                        did not capture usage data (e.g. legacy rows or providers that
  *                        omit token counts)
+ * @param contentHash     fingerprint of the posting content that produced this report;
+ *                        empty for legacy rows scored before idempotent scoring existed.
+ *                        Used to detect that a posting is unchanged so a re-score can
+ *                        reuse this report instead of re-invoking the LLM
  */
 public record ScoreReport(
         UUID id,
@@ -51,12 +55,53 @@ public record ScoreReport(
         Recommendation recommendation,
         String llmModel,
         Instant scoredAt,
-        Optional<LlmScoreResponse.Usage> usage
+        Optional<LlmScoreResponse.Usage> usage,
+        Optional<String> contentHash
 ) {
 
     /**
+     * Convenience constructor preserving the pre-{@code contentHash} signature.
+     * Equivalent to supplying {@link Optional#empty()} for {@code contentHash}.
+     *
+     * @param id              see {@link #id()}
+     * @param organizationId  see {@link #organizationId()}
+     * @param postingId       see {@link #postingId()}
+     * @param rubricId        see {@link #rubricId()}
+     * @param rubricVersion   see {@link #rubricVersion()}
+     * @param disqualifiedBy  see {@link #disqualifiedBy()}
+     * @param categoryScores  see {@link #categoryScores()}
+     * @param flagHits        see {@link #flagHits()}
+     * @param rawScore        see {@link #rawScore()}
+     * @param finalScore      see {@link #finalScore()}
+     * @param recommendation  see {@link #recommendation()}
+     * @param llmModel        see {@link #llmModel()}
+     * @param scoredAt        see {@link #scoredAt()}
+     * @param usage           see {@link #usage()}
+     */
+    public ScoreReport(
+            UUID id,
+            UUID organizationId,
+            UUID postingId,
+            UUID rubricId,
+            int rubricVersion,
+            Optional<Disqualifier> disqualifiedBy,
+            List<CategoryScore> categoryScores,
+            List<FlagHit> flagHits,
+            int rawScore,
+            int finalScore,
+            Recommendation recommendation,
+            String llmModel,
+            Instant scoredAt,
+            Optional<LlmScoreResponse.Usage> usage) {
+        this(id, organizationId, postingId, rubricId, rubricVersion,
+                disqualifiedBy, categoryScores, flagHits, rawScore, finalScore,
+                recommendation, llmModel, scoredAt, usage, Optional.empty());
+    }
+
+    /**
      * Convenience constructor for callers that have no usage data to attach.
-     * Equivalent to supplying {@link Optional#empty()} for {@code usage}.
+     * Equivalent to supplying {@link Optional#empty()} for both {@code usage}
+     * and {@code contentHash}.
      *
      * @param id              see {@link #id()}
      * @param organizationId  see {@link #organizationId()}
@@ -88,6 +133,6 @@ public record ScoreReport(
             Instant scoredAt) {
         this(id, organizationId, postingId, rubricId, rubricVersion,
                 disqualifiedBy, categoryScores, flagHits, rawScore, finalScore,
-                recommendation, llmModel, scoredAt, Optional.empty());
+                recommendation, llmModel, scoredAt, Optional.empty(), Optional.empty());
     }
 }

--- a/src/main/java/com/majordomo/domain/port/in/envoy/ScoreJobPostingUseCase.java
+++ b/src/main/java/com/majordomo/domain/port/in/envoy/ScoreJobPostingUseCase.java
@@ -19,6 +19,21 @@ public interface ScoreJobPostingUseCase {
     ScoreReport score(UUID postingId, String rubricName, UUID organizationId);
 
     /**
+     * Scores a posting, optionally forcing a fresh LLM call. When {@code forceRescore}
+     * is {@code false} and a prior report exists for an unchanged posting under the
+     * same rubric version, that report is reused and the LLM is not invoked. When
+     * {@code true}, the cache is bypassed and the LLM is always called — used by the
+     * manual rescore path (e.g. after a model upgrade with no rubric or content change).
+     *
+     * @param postingId      the posting to score
+     * @param rubricName     rubric name (e.g. "default")
+     * @param organizationId the requesting org (must own the posting)
+     * @param forceRescore   {@code true} to bypass the idempotency cache
+     * @return the score report (reused or freshly persisted)
+     */
+    ScoreReport score(UUID postingId, String rubricName, UUID organizationId, boolean forceRescore);
+
+    /**
      * Scores a posting against multiple rubrics in one operation. Each rubric
      * produces a separate persisted {@link ScoreReport} and a separate
      * {@code JobPostingScored} domain event. Fails fast: if any rubric (or the

--- a/src/main/java/com/majordomo/domain/port/out/envoy/ScoreReportRepository.java
+++ b/src/main/java/com/majordomo/domain/port/out/envoy/ScoreReportRepository.java
@@ -30,6 +30,20 @@ public interface ScoreReportRepository {
     Optional<ScoreReport> findById(UUID id, UUID organizationId);
 
     /**
+     * Finds the most recent report for a (posting, rubric) pair within an org.
+     * Because each rubric version is a distinct row with its own id, a version
+     * bump changes {@code rubricId} and so naturally misses. Used to detect an
+     * unchanged posting (via {@link ScoreReport#contentHash()}) so a re-score can
+     * reuse the prior report instead of re-invoking the LLM.
+     *
+     * @param postingId      the scored posting
+     * @param rubricId       the rubric version used
+     * @param organizationId org scope
+     * @return the latest matching report, or empty if none exists
+     */
+    Optional<ScoreReport> findLatestScored(UUID postingId, UUID rubricId, UUID organizationId);
+
+    /**
      * Cursor-paginated query over reports within an organization. Optional
      * filters are bundled into {@link ScoreReportFilter}; pass
      * {@link ScoreReportFilter#none()} for an unfiltered query.

--- a/src/test/java/com/majordomo/adapter/in/web/envoy/PostingControllerTest.java
+++ b/src/test/java/com/majordomo/adapter/in/web/envoy/PostingControllerTest.java
@@ -100,17 +100,18 @@ class PostingControllerTest {
                 UuidFactory.newId(), 1, Optional.empty(),
                 List.of(), List.of(), 70, 70, Recommendation.APPLY,
                 "claude-sonnet-4-6", Instant.now());
-        when(scoreUseCase.score(any(), eq("default"), eq(ORG_ID))).thenReturn(report);
+        when(scoreUseCase.score(any(), eq("default"), eq(ORG_ID), eq(true))).thenReturn(report);
 
         mvc.perform(post("/api/envoy/postings/rescore")
                         .param("organizationId", ORG_ID.toString()))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.count").value(2));
 
+        // Rescore is the explicit force path: it must bypass the cache (force=true).
         org.mockito.Mockito.verify(scoreUseCase)
-                .score(eq(p1.getId()), eq("default"), eq(ORG_ID));
+                .score(eq(p1.getId()), eq("default"), eq(ORG_ID), eq(true));
         org.mockito.Mockito.verify(scoreUseCase)
-                .score(eq(p2.getId()), eq("default"), eq(ORG_ID));
+                .score(eq(p2.getId()), eq("default"), eq(ORG_ID), eq(true));
     }
 
     @Test
@@ -128,7 +129,7 @@ class PostingControllerTest {
                 UuidFactory.newId(), 1, Optional.empty(),
                 List.of(), List.of(), 70, 70, Recommendation.APPLY,
                 "claude-sonnet-4-6", Instant.now());
-        when(scoreUseCase.score(any(), eq("strict"), eq(ORG_ID))).thenReturn(report);
+        when(scoreUseCase.score(any(), eq("strict"), eq(ORG_ID), eq(true))).thenReturn(report);
 
         mvc.perform(post("/api/envoy/postings/rescore")
                         .param("organizationId", ORG_ID.toString())
@@ -137,7 +138,7 @@ class PostingControllerTest {
                 .andExpect(jsonPath("$.count").value(1));
 
         org.mockito.Mockito.verify(scoreUseCase)
-                .score(eq(p1.getId()), eq("strict"), eq(ORG_ID));
+                .score(eq(p1.getId()), eq("strict"), eq(ORG_ID), eq(true));
     }
 
     @Test

--- a/src/test/java/com/majordomo/adapter/out/persistence/envoy/ScoreReportRepositoryAdapterTest.java
+++ b/src/test/java/com/majordomo/adapter/out/persistence/envoy/ScoreReportRepositoryAdapterTest.java
@@ -85,4 +85,63 @@ class ScoreReportRepositoryAdapterTest {
         ScoreReport reloaded = adapter.findById(report.id(), orgId).orElseThrow();
         assertThat(reloaded.usage()).isEmpty();
     }
+
+    @Test
+    void contentHashRoundTripsThroughJsonBody() {
+        UUID orgId = UuidFactory.newId();
+        var report = reportBuilder(orgId, UuidFactory.newId(), UuidFactory.newId(),
+                Instant.parse("2026-04-27T10:00:00Z"), "abc123hash");
+
+        adapter.save(report);
+
+        ScoreReport reloaded = adapter.findById(report.id(), orgId).orElseThrow();
+        assertThat(reloaded.contentHash()).contains("abc123hash");
+    }
+
+    @Test
+    void findLatestScoredReturnsMostRecentForPostingAndRubric() {
+        UUID orgId = UuidFactory.newId();
+        UUID postingId = UuidFactory.newId();
+        UUID rubricId = UuidFactory.newId();
+        adapter.save(reportBuilder(orgId, postingId, rubricId,
+                Instant.parse("2026-04-27T10:00:00Z"), "old"));
+        adapter.save(reportBuilder(orgId, postingId, rubricId,
+                Instant.parse("2026-04-28T10:00:00Z"), "newest"));
+
+        ScoreReport latest = adapter.findLatestScored(postingId, rubricId, orgId).orElseThrow();
+
+        assertThat(latest.contentHash()).contains("newest");
+    }
+
+    @Test
+    void findLatestScoredIsScopedToOrganization() {
+        UUID postingId = UuidFactory.newId();
+        UUID rubricId = UuidFactory.newId();
+        UUID orgA = UuidFactory.newId();
+        UUID orgB = UuidFactory.newId();
+        adapter.save(reportBuilder(orgA, postingId, rubricId,
+                Instant.parse("2026-04-27T10:00:00Z"), "org-a"));
+
+        assertThat(adapter.findLatestScored(postingId, rubricId, orgB)).isEmpty();
+    }
+
+    @Test
+    void findLatestScoredMissesWhenRubricVersionDiffers() {
+        UUID orgId = UuidFactory.newId();
+        UUID postingId = UuidFactory.newId();
+        adapter.save(reportBuilder(orgId, postingId, UuidFactory.newId(),
+                Instant.parse("2026-04-27T10:00:00Z"), "v1"));
+
+        // A different rubric version is a different rubric row (id) → no match.
+        assertThat(adapter.findLatestScored(postingId, UuidFactory.newId(), orgId)).isEmpty();
+    }
+
+    private static ScoreReport reportBuilder(
+            UUID orgId, UUID postingId, UUID rubricId, Instant scoredAt, String contentHash) {
+        return new ScoreReport(
+                UuidFactory.newId(), orgId, postingId, rubricId, 1,
+                Optional.empty(), List.of(), List.of(), 0, 0,
+                Recommendation.SKIP, "claude-sonnet-4-6", scoredAt,
+                Optional.empty(), Optional.of(contentHash));
+    }
 }

--- a/src/test/java/com/majordomo/application/envoy/JobScorerServiceTest.java
+++ b/src/test/java/com/majordomo/application/envoy/JobScorerServiceTest.java
@@ -59,7 +59,8 @@ class JobScorerServiceTest {
         meterRegistry = new SimpleMeterRegistry();
         scorer = new JobScorerService(
                 rubrics, postings, reports, llm, new ScoreAssembler(),
-                eventPublisher, new LlmCallObserver(new EnvoyMetrics(meterRegistry)));
+                eventPublisher, new LlmCallObserver(new EnvoyMetrics(meterRegistry)),
+                new PostingContentHasher());
         rubric = new Rubric(UuidFactory.newId(), Optional.empty(), 1, "default",
                 List.of(),
                 List.of(new Category("compensation", "pay", 20,
@@ -87,6 +88,66 @@ class JobScorerServiceTest {
         assertThat(r.recommendation()).isEqualTo(Recommendation.APPLY);
         assertThat(r.llmModel()).isEqualTo("claude-sonnet-4-6");
         verify(eventPublisher).publish(any(JobPostingScored.class));
+    }
+
+    @Test
+    void reusesPriorReportWithoutCallingLlmWhenPostingUnchanged() {
+        String contentHash = new PostingContentHasher().hash(posting);
+        ScoreReport prior = new ScoreReport(
+                UuidFactory.newId(), orgId, posting.getId(), rubric.id(), rubric.version(),
+                Optional.empty(), List.of(), List.of(), 15, 15,
+                Recommendation.APPLY, "claude-sonnet-4-6", Instant.now(),
+                Optional.empty(), Optional.of(contentHash));
+        when(postings.findById(posting.getId(), orgId)).thenReturn(Optional.of(posting));
+        when(rubrics.findActiveByName("default", orgId)).thenReturn(Optional.of(rubric));
+        when(reports.findLatestScored(posting.getId(), rubric.id(), orgId))
+                .thenReturn(Optional.of(prior));
+
+        ScoreReport r = scorer.score(posting.getId(), "default", orgId);
+
+        assertThat(r).isSameAs(prior);
+        verify(llm, never()).score(any(), any());
+        verify(reports, never()).save(any());
+        verify(eventPublisher, never()).publish(any());
+    }
+
+    @Test
+    void rescoresWhenPriorReportContentHashDiffers() {
+        ScoreReport stale = new ScoreReport(
+                UuidFactory.newId(), orgId, posting.getId(), rubric.id(), rubric.version(),
+                Optional.empty(), List.of(), List.of(), 15, 15,
+                Recommendation.APPLY, "claude-sonnet-4-6", Instant.now(),
+                Optional.empty(), Optional.of("stale-hash-from-old-content"));
+        when(postings.findById(posting.getId(), orgId)).thenReturn(Optional.of(posting));
+        when(rubrics.findActiveByName("default", orgId)).thenReturn(Optional.of(rubric));
+        when(reports.findLatestScored(posting.getId(), rubric.id(), orgId))
+                .thenReturn(Optional.of(stale));
+        when(llm.score(any(), any())).thenReturn(LlmScoreResponse.of(null,
+                List.of(new LlmScoreResponse.CategoryVerdict("compensation", "Good", "listed")),
+                List.of()));
+        when(llm.modelId()).thenReturn("claude-sonnet-4-6");
+        when(reports.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        ScoreReport r = scorer.score(posting.getId(), "default", orgId);
+
+        verify(llm).score(any(), any());
+        verify(reports).save(any());
+        assertThat(r.contentHash()).contains(new PostingContentHasher().hash(posting));
+    }
+
+    @Test
+    void freshScoreRecordsCurrentContentHashOnReport() {
+        when(postings.findById(posting.getId(), orgId)).thenReturn(Optional.of(posting));
+        when(rubrics.findActiveByName("default", orgId)).thenReturn(Optional.of(rubric));
+        when(llm.score(any(), any())).thenReturn(LlmScoreResponse.of(null,
+                List.of(new LlmScoreResponse.CategoryVerdict("compensation", "Good", "listed")),
+                List.of()));
+        when(llm.modelId()).thenReturn("claude-sonnet-4-6");
+        when(reports.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        ScoreReport r = scorer.score(posting.getId(), "default", orgId);
+
+        assertThat(r.contentHash()).contains(new PostingContentHasher().hash(posting));
     }
 
     @Test

--- a/src/test/java/com/majordomo/application/envoy/JobScorerServiceTest.java
+++ b/src/test/java/com/majordomo/application/envoy/JobScorerServiceTest.java
@@ -112,6 +112,31 @@ class JobScorerServiceTest {
     }
 
     @Test
+    void forceRescoreBypassesCacheAndCallsLlmEvenWhenPriorReportMatches() {
+        String contentHash = new PostingContentHasher().hash(posting);
+        ScoreReport prior = new ScoreReport(
+                UuidFactory.newId(), orgId, posting.getId(), rubric.id(), rubric.version(),
+                Optional.empty(), List.of(), List.of(), 15, 15,
+                Recommendation.APPLY, "claude-sonnet-4-6", Instant.now(),
+                Optional.empty(), Optional.of(contentHash));
+        when(postings.findById(posting.getId(), orgId)).thenReturn(Optional.of(posting));
+        when(rubrics.findActiveByName("default", orgId)).thenReturn(Optional.of(rubric));
+        when(llm.score(any(), any())).thenReturn(LlmScoreResponse.of(null,
+                List.of(new LlmScoreResponse.CategoryVerdict("compensation", "Good", "listed")),
+                List.of()));
+        when(llm.modelId()).thenReturn("claude-sonnet-4-6");
+        when(reports.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        ScoreReport r = scorer.score(posting.getId(), "default", orgId, true);
+
+        assertThat(r).isNotSameAs(prior);
+        verify(llm).score(any(), any());
+        verify(reports).save(any());
+        // Cache is never consulted on a forced rescore.
+        verify(reports, never()).findLatestScored(any(), any(), any());
+    }
+
+    @Test
     void rescoresWhenPriorReportContentHashDiffers() {
         ScoreReport stale = new ScoreReport(
                 UuidFactory.newId(), orgId, posting.getId(), rubric.id(), rubric.version(),

--- a/src/test/java/com/majordomo/application/envoy/PostingContentHasherTest.java
+++ b/src/test/java/com/majordomo/application/envoy/PostingContentHasherTest.java
@@ -1,0 +1,50 @@
+package com.majordomo.application.envoy;
+
+import com.majordomo.domain.model.UuidFactory;
+import com.majordomo.domain.model.envoy.JobPosting;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PostingContentHasherTest {
+
+    private final PostingContentHasher hasher = new PostingContentHasher();
+
+    private JobPosting posting(String rawText) {
+        JobPosting p = new JobPosting();
+        p.setId(UuidFactory.newId());
+        p.setOrganizationId(UuidFactory.newId());
+        p.setCompany("Acme");
+        p.setTitle("Staff Engineer");
+        p.setLocation("Remote");
+        p.setRawText(rawText);
+        p.setExtracted(Map.of("salary", "$220k"));
+        return p;
+    }
+
+    @Test
+    void identicalContentProducesSameHash() {
+        assertThat(hasher.hash(posting("We pay $220k")))
+                .isEqualTo(hasher.hash(posting("We pay $220k")));
+    }
+
+    @Test
+    void changedRawTextProducesDifferentHash() {
+        assertThat(hasher.hash(posting("We pay $220k")))
+                .isNotEqualTo(hasher.hash(posting("We pay $180k")));
+    }
+
+    @Test
+    void hashIsIndependentOfIdentityFieldsAndDependsOnContent() {
+        // Two postings with different ids but identical content hash equal;
+        // changing a content field (company) changes the hash.
+        JobPosting a = posting("Same body");
+        JobPosting b = posting("Same body");
+        assertThat(hasher.hash(a)).isEqualTo(hasher.hash(b));
+
+        b.setCompany("Different");
+        assertThat(hasher.hash(a)).isNotEqualTo(hasher.hash(b));
+    }
+}


### PR DESCRIPTION
Closes #289.

## What & why
Envoy re-invoked the LLM on every `score` / `score-all` / `rescore`, even when the posting content and rubric version were unchanged — burning tokens for no new information. This adds content-fingerprinted idempotent scoring.

## How it works
- **`PostingContentHasher`** — deterministic SHA-256 over a posting's scoring-relevant content (company, title, location, raw text, extracted fields). Identity/timestamp fields are excluded, so identical content hashes equal and any content change flips the hash.
- **`ScoreReport`** gains a trailing `Optional<String> contentHash`. It rides in the existing JSONB `body`, so **no schema migration**. Prior constructors are preserved as delegating overloads, so the 28 existing construction sites are untouched.
- **`JobScorerService.runOne`** computes the hash and, before calling the LLM, looks up the latest report for the `(posting, rubricId)` pair via `ScoreReportRepository.findLatestScored`. On a content-hash match it returns that report as-is — **no LLM call, no new persistence, no event**. A changed posting or a rubric version bump (new `rubricId`) misses and rescores.
- **Force path:** `POST /api/envoy/rescore` exists specifically to re-score unchanged postings (e.g. after a model upgrade), so it now passes `forceRescore=true` to bypass the cache. The automatic `score` / `score-all` paths stay cache-aware.

## Acceptance criteria
- [x] Scoring an unchanged `(posting, rubric-version)` pair returns the cached report without an LLM call
- [x] Changing posting content OR bumping rubric version triggers a fresh score
- [x] Explicit force path (`/rescore`) bypasses the cache
- [x] Test asserts the LLM port is **not** called on a cache hit
- [x] No cross-org leakage of cached reports (`findLatestScored` is org-scoped; slice-tested)

## Testing
- TDD throughout (red → green → commit per ADR-0003).
- Full unit suite: **566 pass**, Checkstyle clean.
- New: `PostingContentHasherTest`, service-level cache-hit / miss / force / hash-recorded tests, and `ScoreReportRepositoryAdapter` slice tests (latest-wins, org scope, rubric-version miss, JSONB `contentHash` round-trip).

## Note
`EnvoyVerticalSliceIntegrationTest` fails locally in `seedDefaultRubric` with a duplicate-rubric key — **pre-existing on `main`** (reproduced there), an environmental/test-infra issue unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)