### PR TITLE
envoy: cache hit/miss metric for idempotent scoring (#295)

### DIFF
--- a/src/main/java/com/majordomo/application/envoy/EnvoyMetrics.java
+++ b/src/main/java/com/majordomo/application/envoy/EnvoyMetrics.java
@@ -30,6 +30,9 @@ public class EnvoyMetrics {
     /** Counter: APPLY_NOW conversions, by outcome (applied / dismissed). */
     static final String APPLY_NOW_CONVERSION = "envoy_apply_now_conversion_total";
 
+    /** Counter: idempotent-scoring cache lookups, by outcome (hit / miss). */
+    static final String SCORE_CACHE = "envoy_score_cache_total";
+
     static final String TAG_ORG = "org";
     static final String TAG_MODEL = "model";
     static final String TAG_RUBRIC = "rubric";
@@ -43,6 +46,24 @@ public class EnvoyMetrics {
         private final String tag;
 
         ConversionOutcome(String tag) {
+            this.tag = tag;
+        }
+
+        String tag() {
+            return tag;
+        }
+    }
+
+    /** Outcome tag values for {@link #SCORE_CACHE}. */
+    public enum ScoreCacheOutcome {
+        /** A prior report for an unchanged posting was reused; no LLM call. */
+        HIT("hit"),
+        /** No reusable report existed; the LLM was invoked. */
+        MISS("miss");
+
+        private final String tag;
+
+        ScoreCacheOutcome(String tag) {
             this.tag = tag;
         }
 
@@ -115,6 +136,25 @@ public class EnvoyMetrics {
         Counter.builder(APPLY_NOW_CONVERSION)
                 .description("APPLY_NOW posting conversions, by outcome")
                 .tag(TAG_ORG, organizationId.toString())
+                .tag(TAG_OUTCOME, outcome.tag())
+                .register(meterRegistry)
+                .increment();
+    }
+
+    /**
+     * Records the outcome of an idempotent-scoring cache lookup. A {@code HIT}
+     * means a prior report was reused and no LLM call was made; a {@code MISS}
+     * means the LLM was invoked. The hit rate over these two is the token-cost
+     * saving from idempotent scoring. Forced rescores never consult the cache
+     * and so are not recorded here.
+     *
+     * @param rubricName the rubric name the lookup was scoped to
+     * @param outcome    {@link ScoreCacheOutcome#HIT} or {@link ScoreCacheOutcome#MISS}
+     */
+    public void recordScoreCacheOutcome(String rubricName, ScoreCacheOutcome outcome) {
+        Counter.builder(SCORE_CACHE)
+                .description("Idempotent-scoring cache lookups, by outcome")
+                .tag(TAG_RUBRIC, rubricName)
                 .tag(TAG_OUTCOME, outcome.tag())
                 .register(meterRegistry)
                 .increment();

--- a/src/main/java/com/majordomo/application/envoy/JobScorerService.java
+++ b/src/main/java/com/majordomo/application/envoy/JobScorerService.java
@@ -41,6 +41,7 @@ public class JobScorerService implements ScoreJobPostingUseCase {
     private final EventPublisher eventPublisher;
     private final LlmCallObserver llmObserver;
     private final PostingContentHasher contentHasher;
+    private final EnvoyMetrics metrics;
 
     /**
      * Constructs the scorer with all required collaborators.
@@ -53,6 +54,7 @@ public class JobScorerService implements ScoreJobPostingUseCase {
      * @param eventPublisher domain event publisher
      * @param llmObserver    observer that wraps each LLM call with metrics
      * @param contentHasher  fingerprints posting content for idempotent scoring
+     * @param metrics        envoy metrics helper (records cache hit/miss)
      */
     public JobScorerService(RubricRepository rubrics,
                             JobPostingRepository postings,
@@ -61,7 +63,8 @@ public class JobScorerService implements ScoreJobPostingUseCase {
                             ScoreAssembler assembler,
                             EventPublisher eventPublisher,
                             LlmCallObserver llmObserver,
-                            PostingContentHasher contentHasher) {
+                            PostingContentHasher contentHasher,
+                            EnvoyMetrics metrics) {
         this.rubrics = rubrics;
         this.postings = postings;
         this.reports = reports;
@@ -70,6 +73,7 @@ public class JobScorerService implements ScoreJobPostingUseCase {
         this.eventPublisher = eventPublisher;
         this.llmObserver = llmObserver;
         this.contentHasher = contentHasher;
+        this.metrics = metrics;
     }
 
     @Override
@@ -118,8 +122,12 @@ public class JobScorerService implements ScoreJobPostingUseCase {
             if (prior.isPresent() && prior.get().contentHash().equals(Optional.of(contentHash))) {
                 // Posting unchanged since the last score under this rubric version:
                 // reuse the prior report instead of re-invoking the LLM.
+                metrics.recordScoreCacheOutcome(
+                        rubric.name(), EnvoyMetrics.ScoreCacheOutcome.HIT);
                 return prior.get();
             }
+            metrics.recordScoreCacheOutcome(
+                    rubric.name(), EnvoyMetrics.ScoreCacheOutcome.MISS);
         }
         LlmScoreResponse resp = llmObserver.observe(llm, posting, rubric);
         ScoreReport report = assembler.assemble(posting, rubric, resp, llm.modelId(), contentHash);

--- a/src/test/java/com/majordomo/application/envoy/EnvoyMetricsTest.java
+++ b/src/test/java/com/majordomo/application/envoy/EnvoyMetricsTest.java
@@ -71,4 +71,23 @@ class EnvoyMetricsTest {
         assertThat(applied.count()).isEqualTo(1.0);
         assertThat(dismissed.count()).isEqualTo(1.0);
     }
+
+    /** Score-cache counter is tagged by rubric and outcome={hit,miss}. */
+    @Test
+    void recordScoreCacheOutcomeUsesCorrectTags() {
+        metrics.recordScoreCacheOutcome("default", EnvoyMetrics.ScoreCacheOutcome.HIT);
+        metrics.recordScoreCacheOutcome("default", EnvoyMetrics.ScoreCacheOutcome.MISS);
+        metrics.recordScoreCacheOutcome("default", EnvoyMetrics.ScoreCacheOutcome.HIT);
+
+        var hit = registry.get("envoy_score_cache_total")
+                .tag("rubric", "default")
+                .tag("outcome", "hit")
+                .counter();
+        var miss = registry.get("envoy_score_cache_total")
+                .tag("rubric", "default")
+                .tag("outcome", "miss")
+                .counter();
+        assertThat(hit.count()).isEqualTo(2.0);
+        assertThat(miss.count()).isEqualTo(1.0);
+    }
 }

--- a/src/test/java/com/majordomo/application/envoy/JobScorerServiceTest.java
+++ b/src/test/java/com/majordomo/application/envoy/JobScorerServiceTest.java
@@ -54,13 +54,16 @@ class JobScorerServiceTest {
     private Rubric rubric;
     private JobPosting posting;
 
+    private EnvoyMetrics envoyMetrics;
+
     @BeforeEach
     void setUp() {
         meterRegistry = new SimpleMeterRegistry();
+        envoyMetrics = new EnvoyMetrics(meterRegistry);
         scorer = new JobScorerService(
                 rubrics, postings, reports, llm, new ScoreAssembler(),
-                eventPublisher, new LlmCallObserver(new EnvoyMetrics(meterRegistry)),
-                new PostingContentHasher());
+                eventPublisher, new LlmCallObserver(envoyMetrics),
+                new PostingContentHasher(), envoyMetrics);
         rubric = new Rubric(UuidFactory.newId(), Optional.empty(), 1, "default",
                 List.of(),
                 List.of(new Category("compensation", "pay", 20,
@@ -109,6 +112,61 @@ class JobScorerServiceTest {
         verify(llm, never()).score(any(), any());
         verify(reports, never()).save(any());
         verify(eventPublisher, never()).publish(any());
+    }
+
+    @Test
+    void recordsCacheHitMetricWhenReusingPriorReport() {
+        String contentHash = new PostingContentHasher().hash(posting);
+        ScoreReport prior = new ScoreReport(
+                UuidFactory.newId(), orgId, posting.getId(), rubric.id(), rubric.version(),
+                Optional.empty(), List.of(), List.of(), 15, 15,
+                Recommendation.APPLY, "claude-sonnet-4-6", Instant.now(),
+                Optional.empty(), Optional.of(contentHash));
+        when(postings.findById(posting.getId(), orgId)).thenReturn(Optional.of(posting));
+        when(rubrics.findActiveByName("default", orgId)).thenReturn(Optional.of(rubric));
+        when(reports.findLatestScored(posting.getId(), rubric.id(), orgId))
+                .thenReturn(Optional.of(prior));
+
+        scorer.score(posting.getId(), "default", orgId);
+
+        assertThat(meterRegistry.get("envoy_score_cache_total")
+                .tag("outcome", "hit").tag("rubric", "default")
+                .counter().count()).isEqualTo(1.0);
+        assertThat(meterRegistry.find("envoy_score_cache_total")
+                .tag("outcome", "miss").counter()).isNull();
+    }
+
+    @Test
+    void recordsCacheMissMetricWhenScoringFresh() {
+        when(postings.findById(posting.getId(), orgId)).thenReturn(Optional.of(posting));
+        when(rubrics.findActiveByName("default", orgId)).thenReturn(Optional.of(rubric));
+        when(llm.score(any(), any())).thenReturn(LlmScoreResponse.of(null,
+                List.of(new LlmScoreResponse.CategoryVerdict("compensation", "Good", "listed")),
+                List.of()));
+        when(llm.modelId()).thenReturn("claude-sonnet-4-6");
+        when(reports.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        scorer.score(posting.getId(), "default", orgId);
+
+        assertThat(meterRegistry.get("envoy_score_cache_total")
+                .tag("outcome", "miss").tag("rubric", "default")
+                .counter().count()).isEqualTo(1.0);
+    }
+
+    @Test
+    void forcedRescoreRecordsNoCacheOutcomeMetric() {
+        when(postings.findById(posting.getId(), orgId)).thenReturn(Optional.of(posting));
+        when(rubrics.findActiveByName("default", orgId)).thenReturn(Optional.of(rubric));
+        when(llm.score(any(), any())).thenReturn(LlmScoreResponse.of(null,
+                List.of(new LlmScoreResponse.CategoryVerdict("compensation", "Good", "listed")),
+                List.of()));
+        when(llm.modelId()).thenReturn("claude-sonnet-4-6");
+        when(reports.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        scorer.score(posting.getId(), "default", orgId, true);
+
+        // A forced rescore never consults the cache, so it is neither hit nor miss.
+        assertThat(meterRegistry.find("envoy_score_cache_total").counter()).isNull();
     }
 
     @Test


### PR DESCRIPTION
Closes #295.

## Scope note
When I picked this up, most of #295's acceptance was **already satisfied**:
- `spring-boot-starter-actuator` + `micrometer-registry-prometheus` are in the pom
- `/actuator/prometheus` is already exposed (`management.endpoints.web.exposure.include`)
- ADR-0008 (Grafana) + ADR-0009 (Prometheus) already record the observability decision
- Envoy already emits LLM latency + token metrics via `EnvoyMetrics` / `LlmCallObserver`

The one genuine gap: idempotent scoring (#289) shipped **uninstrumented**, so the acceptance item "cache hits recorded distinctly / cache hit-miss counters" wasn't met. Broad per-service timers would be speculative gold-plating (no current need), so this PR is scoped to closing that real gap. If you want wider instrumentation, that's worth its own issue.

## What this adds
- `envoy_score_cache_total` counter, tagged `rubric` + `outcome` (`hit` / `miss`).
- `JobScorerService` records `HIT` when it reuses a prior report (no LLM call) and `MISS` when it falls through to the LLM. Hit-rate over these two = the token-cost saving from idempotent scoring.
- Forced rescores (`/rescore`) bypass the cache and emit **no** cache-outcome metric, so they don't distort the hit rate.
- No PII/secrets in tags (rubric name + hit/miss only).

## Acceptance criteria
- [x] `/actuator/prometheus` exposes app metrics (pre-existing; verified in config)
- [x] Envoy LLM calls emit latency + token metrics, **cache hits now recorded distinctly**
- [x] Cache hit/miss counters present
- [x] Observability decision recorded in an ADR (ADR-0008/0009, pre-existing)
- [x] No secrets/PII in metric tags

## Testing
- TDD (red → green). Full unit suite: **570 pass**, Checkstyle clean.
- New: service-level cache-hit/miss/forced tests in `JobScorerServiceTest`, and a direct `EnvoyMetricsTest` case pinning the metric name + tag contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)