### PR TITLE
steward: full-text property search over metadata + attachment filenames (#291)

### DIFF
--- a/doc/user-guide/properties.md
+++ b/doc/user-guide/properties.md
@@ -8,8 +8,13 @@ service manages them.
 
 `/properties` shows every non-archived property in your organization.
 
-- **Filter strip**: free-text search (matches name + description) and
-  an exact-match category dropdown.
+- **Filter strip**: full-text search and an exact-match category dropdown.
+  Search covers the property's name, description, manufacturer, model and
+  serial numbers, category, and location, plus the **filenames of its
+  attachments** — so searching "manual" finds a property whose uploaded
+  `furnace-manual.pdf` matches. Matching is word-based and stemmed
+  (searching "heats" also finds "heating"). Searching the *contents* of
+  attachment documents is planned separately (#298).
 - **+ New property** button (top right): opens the create form.
 - Click a property's name to jump to its detail page.
 

--- a/src/main/java/com/majordomo/adapter/out/persistence/steward/JpaPropertyRepository.java
+++ b/src/main/java/com/majordomo/adapter/out/persistence/steward/JpaPropertyRepository.java
@@ -64,4 +64,50 @@ public interface JpaPropertyRepository extends JpaRepository<PropertyEntity, UUI
             + "AND p.warrantyExpiresOn < :date "
             + "AND p.warrantyNotificationSentAt IS NULL")
     List<PropertyEntity> findWithWarrantyExpiringBefore(@Param("date") LocalDate date);
+
+    /**
+     * Cursor-paginated full-text property search within an organization. When
+     * {@code query} is null the text predicate is skipped (plain org listing with
+     * optional filters); otherwise a match is any property whose generated
+     * {@code search_vector} matches, or which has a non-archived attachment whose
+     * filename matches, the {@code plainto_tsquery}. Results are ordered by id so
+     * the {@code id > cursor} keyset pagination stays stable. Postgres-specific.
+     *
+     * @param organizationId required org scope
+     * @param query          search text (null = no text filter)
+     * @param category       optional exact category filter (null = any)
+     * @param status         optional exact status filter (null = any)
+     * @param cursor         exclusive keyset cursor (null = first page)
+     * @param limit          row cap
+     * @return matching property entities, ordered by id
+     */
+    @Query(value = """
+            SELECT p.* FROM properties p
+             WHERE p.organization_id = :organizationId
+               AND (CAST(:cursor AS uuid) IS NULL OR p.id > CAST(:cursor AS uuid))
+               AND (CAST(:category AS text) IS NULL OR p.category = CAST(:category AS text))
+               AND (CAST(:status AS text) IS NULL OR p.status = CAST(:status AS text))
+               AND (
+                    CAST(:query AS text) IS NULL
+                    OR p.search_vector @@ plainto_tsquery('english', CAST(:query AS text))
+                    OR EXISTS (
+                         SELECT 1 FROM attachments a
+                          WHERE a.entity_type = 'PROPERTY'
+                            AND a.entity_id = p.id
+                            AND a.archived_at IS NULL
+                            AND to_tsvector('english',
+                                    regexp_replace(a.filename, '[^A-Za-z0-9]+', ' ', 'g'))
+                                @@ plainto_tsquery('english', CAST(:query AS text))
+                    )
+               )
+             ORDER BY p.id
+             LIMIT :limit
+            """, nativeQuery = true)
+    List<PropertyEntity> searchFullText(
+            @Param("organizationId") UUID organizationId,
+            @Param("query") String query,
+            @Param("category") String category,
+            @Param("status") String status,
+            @Param("cursor") UUID cursor,
+            @Param("limit") int limit);
 }

--- a/src/main/java/com/majordomo/adapter/out/persistence/steward/PropertyRepositoryAdapter.java
+++ b/src/main/java/com/majordomo/adapter/out/persistence/steward/PropertyRepositoryAdapter.java
@@ -84,14 +84,12 @@ public class PropertyRepositoryAdapter implements PropertyRepository {
     @Override
     public List<Property> search(UUID organizationId, String query, String category,
                                  String status, UUID cursor, int limit) {
-        var statusEnum = status != null ? PropertyStatus.valueOf(status) : null;
-        var spec = Specification.where(
-                        CursorSpecifications.<PropertyEntity>fieldEquals("organizationId", organizationId))
-                .and(CursorSpecifications.afterCursor(cursor))
-                .and(CursorSpecifications.searchAcrossFields(query, "name", "description", "location"))
-                .and(CursorSpecifications.fieldEquals("category", category))
-                .and(CursorSpecifications.fieldEquals("status", statusEnum));
-        var page = jpa.findAll(spec, PageRequest.of(0, limit, Sort.by("id")));
-        return page.stream().map(PropertyMapper::toDomain).toList();
+        // Validate status the same way the previous implementation did (throw on
+        // an unknown value) while passing the raw string to the native query,
+        // which compares it against the stored status column.
+        var statusFilter = status != null ? PropertyStatus.valueOf(status).name() : null;
+        var textFilter = (query == null || query.isBlank()) ? null : query;
+        return jpa.searchFullText(organizationId, textFilter, category, statusFilter, cursor, limit)
+                .stream().map(PropertyMapper::toDomain).toList();
     }
 }

--- a/src/main/resources/db/migration/V19__property_search_vector.sql
+++ b/src/main/resources/db/migration/V19__property_search_vector.sql
@@ -1,0 +1,30 @@
+-- Full-text search for The Steward (#291).
+-- A generated tsvector over the property's own text fields, plus GIN indexes
+-- on it and on attachment filenames, so property search can use ranked/stemmed
+-- Postgres FTS instead of case-insensitive LIKE. Attachment *content* extraction
+-- is a separate effort (#298); only filenames are indexed here.
+
+ALTER TABLE properties
+    ADD COLUMN search_vector tsvector
+    GENERATED ALWAYS AS (
+        to_tsvector('english',
+            coalesce(name, '')          || ' ' ||
+            coalesce(description, '')    || ' ' ||
+            coalesce(serial_number, '')  || ' ' ||
+            coalesce(model_number, '')   || ' ' ||
+            coalesce(manufacturer, '')   || ' ' ||
+            coalesce(category, '')       || ' ' ||
+            coalesce(location, '')
+        )
+    ) STORED;
+
+CREATE INDEX idx_properties_search_vector
+    ON properties USING GIN (search_vector);
+
+-- Filenames like "furnace-installation-manual.pdf" tokenise as file/host tokens
+-- under the default parser, so normalise non-alphanumerics to spaces first (in
+-- both the index and the query) to index plain words like "manual".
+CREATE INDEX idx_attachments_filename_fts
+    ON attachments USING GIN (
+        to_tsvector('english', regexp_replace(filename, '[^A-Za-z0-9]+', ' ', 'g'))
+    );

--- a/src/test/java/com/majordomo/adapter/out/persistence/steward/PropertyFullTextSearchIntegrationTest.java
+++ b/src/test/java/com/majordomo/adapter/out/persistence/steward/PropertyFullTextSearchIntegrationTest.java
@@ -1,0 +1,135 @@
+package com.majordomo.adapter.out.persistence.steward;
+
+import com.majordomo.IntegrationTest;
+import com.majordomo.adapter.out.persistence.attachment.AttachmentEntity;
+import com.majordomo.adapter.out.persistence.attachment.JpaAttachmentRepository;
+import com.majordomo.domain.model.EntityType;
+import com.majordomo.domain.model.UuidFactory;
+import com.majordomo.domain.model.identity.Organization;
+import com.majordomo.domain.model.steward.Property;
+import com.majordomo.domain.model.steward.PropertyStatus;
+import com.majordomo.domain.port.out.identity.OrganizationRepository;
+import com.majordomo.domain.port.out.steward.PropertyRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Postgres full-text-search behaviour for property search. FTS (tsvector +
+ * to_tsquery) is Postgres-specific, so this must run against a real database
+ * via Testcontainers rather than the H2 slice. Every query is scoped to a
+ * freshly-generated organization id so data seeded by other tests cannot
+ * affect exact-count assertions.
+ */
+@IntegrationTest
+class PropertyFullTextSearchIntegrationTest {
+
+    @Autowired
+    private PropertyRepository properties;
+
+    @Autowired
+    private OrganizationRepository organizations;
+
+    @Autowired
+    private JpaAttachmentRepository attachments;
+
+    private UUID newOrg() {
+        UUID id = UuidFactory.newId();
+        organizations.save(new Organization(id, "org-" + id));
+        return id;
+    }
+
+    private Property property(UUID orgId, String name, String description, String manufacturer) {
+        Property p = new Property();
+        p.setId(UuidFactory.newId());
+        p.setOrganizationId(orgId);
+        p.setName(name);
+        p.setDescription(description);
+        p.setManufacturer(manufacturer);
+        p.setStatus(PropertyStatus.ACTIVE);
+        return properties.save(p);
+    }
+
+    private void attachTo(UUID propertyId, String filename) {
+        AttachmentEntity a = new AttachmentEntity();
+        a.setId(UuidFactory.newId());
+        a.setEntityType(EntityType.PROPERTY.name());
+        a.setEntityId(propertyId);
+        a.setFilename(filename);
+        a.setContentType("application/pdf");
+        a.setSizeBytes(1024L);
+        a.setStoragePath("s/" + filename);
+        a.setCreatedAt(Instant.now());
+        a.setUpdatedAt(Instant.now());
+        a.setPrimary(false);
+        a.setSortOrder(0);
+        attachments.save(a);
+    }
+
+    @Test
+    void matchesOnPropertyTextField() {
+        UUID org = newOrg();
+        Property furnace = property(org, "Furnace", "gas heating unit", "Carrier");
+        property(org, "Dishwasher", "kitchen appliance", "Bosch");
+
+        List<Property> hits = properties.search(org, "furnace", null, null, null, 20);
+
+        assertThat(hits).extracting(Property::getId).containsExactly(furnace.getId());
+    }
+
+    @Test
+    void matchesWithStemming() {
+        UUID org = newOrg();
+        Property furnace = property(org, "Furnace", "gas heating unit", "Carrier");
+
+        // "heats" stems to "heat", which also matches the stored "heating" —
+        // a substring LIKE for "heats" would not.
+        List<Property> hits = properties.search(org, "heats", null, null, null, 20);
+
+        assertThat(hits).extracting(Property::getId).containsExactly(furnace.getId());
+    }
+
+    @Test
+    void matchesOnAttachmentFilename() {
+        UUID org = newOrg();
+        Property furnace = property(org, "Furnace", "gas heating unit", "Carrier");
+        attachTo(furnace.getId(), "furnace-installation-manual.pdf");
+        property(org, "Dishwasher", "kitchen appliance", "Bosch");
+
+        List<Property> hits = properties.search(org, "manual", null, null, null, 20);
+
+        assertThat(hits).extracting(Property::getId).containsExactly(furnace.getId());
+    }
+
+    @Test
+    void noMatchReturnsEmpty() {
+        UUID org = newOrg();
+        property(org, "Furnace", "gas heating unit", "Carrier");
+
+        assertThat(properties.search(org, "refrigerator", null, null, null, 20)).isEmpty();
+    }
+
+    @Test
+    void searchIsScopedToOrganization() {
+        UUID orgA = newOrg();
+        UUID orgB = newOrg();
+        property(orgA, "Furnace", "gas heating unit", "Carrier");
+
+        assertThat(properties.search(orgB, "furnace", null, null, null, 20)).isEmpty();
+    }
+
+    @Test
+    void honoursLimit() {
+        UUID org = newOrg();
+        property(org, "Furnace one", "heating", "Carrier");
+        property(org, "Furnace two", "heating", "Carrier");
+        property(org, "Furnace three", "heating", "Carrier");
+
+        assertThat(properties.search(org, "furnace", null, null, null, 2)).hasSize(2);
+    }
+}


### PR DESCRIPTION
Closes #291. Splits out #298 (attachment text extraction).

## Scope
Confirmed with Rob: attachments store only file **metadata** (no extracted text, no OCR/PDF parsing). So this replaces the case-insensitive LIKE property search with real Postgres full-text search over **property metadata + attachment filenames**. Extracting and searching attachment *document text* is deferred to #298.

## What changed
- **V19 migration**: generated `search_vector tsvector` on `properties` (name, description, serial/model number, manufacturer, category, location) + GIN index; GIN index on normalised attachment filenames.
- **`JpaPropertyRepository.searchFullText`**: native query matching the property vector OR a non-archived attachment filename via `plainto_tsquery`, org-scoped, keyset-paginated by id.
- **`PropertyRepositoryAdapter.search`**: delegates to the native query (blank query → no text filter; status still validated). Port signature unchanged.
- Filenames are normalised (`[^A-Za-z0-9]+` → space) in **both** index and query so `furnace-manual.pdf` tokenises to searchable words like `manual` (the default parser otherwise emits a single `manual.pdf` token).

## Why an integration test (not a slice)
FTS is Postgres-specific and can't run on the H2 slice, so `PropertyFullTextSearchIntegrationTest` drives it against Testcontainers Postgres. Every query is scoped to a fresh org id so other tests' data can't perturb assertions.

## Acceptance criteria
- [x] Flyway forward-only migration adds tsvector column + GIN index
- [x] Search matches attachment text within the caller's org only — *filenames* (document-text = #298)
- [x] Cursor pagination preserved (unchanged port signature + id keyset)
- [x] Tests cover match, no-match, cross-org isolation (+ stemming, attachment-filename, limit)

## Testing
TDD (red → green). 6 FTS integration tests pass on Testcontainers Postgres; full unit suite **570 pass**, Checkstyle clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)