### PR TITLE
identity: scoped API keys (read-only / read-write) + last-used tracking (#293)

### DIFF
--- a/doc/user-guide/api-keys.md
+++ b/doc/user-guide/api-keys.md
@@ -21,10 +21,19 @@ non-interactive callers.
    `/account/api-keys` directly).
 2. Type a memorable **name** for the key (e.g. "CI runner", "iOS
    shortcut").
-3. Click **+ Create key**.
-4. The plaintext key (64 hex characters) appears in a yellow banner
+3. Choose an **access** level:
+   - **Read & write** — full access (the default).
+   - **Read only** — may perform `GET`/read requests only; any
+     state-changing request (`POST`/`PUT`/`PATCH`/`DELETE`) is rejected
+     with `403 Forbidden`. Use this for dashboards, exports, or anything
+     that should never modify data.
+4. Click **+ Create key**.
+5. The plaintext key (64 hex characters) appears in a yellow banner
    above the form: **copy it now.** Majordomo only stores the
    SHA-256 hash; once you leave the page the plaintext is gone forever.
+
+The key list shows each key's **access** badge and when it was **last
+used** (or "Never"), so you can spot stale keys.
 
 ## Using a key
 
@@ -32,7 +41,8 @@ non-interactive callers.
 curl -H "X-API-Key: <your-key>" https://your-host/api/properties
 ```
 
-The key is scoped to the organization that minted it.
+The key is scoped to the organization that minted it. A read-only key
+authenticates reads but is rejected on writes.
 
 ## Revoking
 

--- a/src/main/java/com/majordomo/adapter/in/web/config/ApiKeyAuthenticationFilter.java
+++ b/src/main/java/com/majordomo/adapter/in/web/config/ApiKeyAuthenticationFilter.java
@@ -60,6 +60,7 @@ public class ApiKeyAuthenticationFilter extends OncePerRequestFilter {
                 var auth = new UsernamePasswordAuthenticationToken(
                         "apikey:" + apiKey.getOrganizationId(), null, List.of());
                 SecurityContextHolder.getContext().setAuthentication(auth);
+                apiKeyRepository.touchLastUsed(apiKey.getId(), Instant.now());
             }
         }
         filterChain.doFilter(request, response);

--- a/src/main/java/com/majordomo/adapter/in/web/config/ApiKeyAuthenticationFilter.java
+++ b/src/main/java/com/majordomo/adapter/in/web/config/ApiKeyAuthenticationFilter.java
@@ -1,5 +1,6 @@
 package com.majordomo.adapter.in.web.config;
 
+import com.majordomo.domain.model.identity.ApiKey;
 import com.majordomo.domain.port.out.identity.ApiKeyRepository;
 
 import jakarta.servlet.FilterChain;
@@ -18,6 +19,7 @@ import java.security.NoSuchAlgorithmException;
 import java.time.Instant;
 import java.util.HexFormat;
 import java.util.List;
+import java.util.Locale;
 
 /**
  * Authenticates requests bearing an {@code X-API-Key} header by looking up
@@ -45,19 +47,37 @@ public class ApiKeyAuthenticationFilter extends OncePerRequestFilter {
                                      FilterChain filterChain) throws ServletException, IOException {
         String rawKey = request.getHeader(API_KEY_HEADER);
         if (rawKey != null && SecurityContextHolder.getContext().getAuthentication() == null) {
-            String hashed = sha256(rawKey);
-            apiKeyRepository.findByHashedKey(hashed).ifPresent(apiKey -> {
-                if (apiKey.getArchivedAt() == null
-                        && (apiKey.getExpiresAt() == null
-                            || apiKey.getExpiresAt().isAfter(Instant.now()))) {
-                    var auth = new UsernamePasswordAuthenticationToken(
-                            "apikey:" + apiKey.getOrganizationId(),
-                            null, List.of());
-                    SecurityContextHolder.getContext().setAuthentication(auth);
+            var found = apiKeyRepository.findByHashedKey(sha256(rawKey));
+            if (found.isPresent() && isActive(found.get())) {
+                var apiKey = found.get();
+                if (!apiKey.getScope().permitsWrites() && isWriteMethod(request.getMethod())) {
+                    // Read-only key attempting a state-changing request: reject with
+                    // 403 and stop — do not authenticate, do not proceed down the chain.
+                    response.sendError(HttpServletResponse.SC_FORBIDDEN,
+                            "API key is read-only and cannot perform write operations");
+                    return;
                 }
-            });
+                var auth = new UsernamePasswordAuthenticationToken(
+                        "apikey:" + apiKey.getOrganizationId(), null, List.of());
+                SecurityContextHolder.getContext().setAuthentication(auth);
+            }
         }
         filterChain.doFilter(request, response);
+    }
+
+    private static boolean isActive(ApiKey apiKey) {
+        return apiKey.getArchivedAt() == null
+                && (apiKey.getExpiresAt() == null || apiKey.getExpiresAt().isAfter(Instant.now()));
+    }
+
+    private static boolean isWriteMethod(String method) {
+        if (method == null) {
+            return false;
+        }
+        return switch (method.toUpperCase(Locale.ROOT)) {
+            case "POST", "PUT", "PATCH", "DELETE" -> true;
+            default -> false;
+        };
     }
 
     /**

--- a/src/main/java/com/majordomo/adapter/in/web/identity/AccountApiKeyPageController.java
+++ b/src/main/java/com/majordomo/adapter/in/web/identity/AccountApiKeyPageController.java
@@ -4,6 +4,7 @@ import com.majordomo.adapter.in.web.config.ApiKeyAuthenticationFilter;
 import com.majordomo.adapter.in.web.config.OrgContext;
 import com.majordomo.domain.model.UuidFactory;
 import com.majordomo.domain.model.identity.ApiKey;
+import com.majordomo.domain.model.identity.ApiKeyScope;
 import com.majordomo.domain.port.out.identity.ApiKeyRepository;
 
 import org.springframework.stereotype.Controller;
@@ -69,12 +70,15 @@ public class AccountApiKeyPageController {
      * never stored.
      *
      * @param name       the key label (required)
+     * @param scope      the key scope ({@code READ_ONLY}/{@code READ_WRITE};
+     *                   defaults to {@code READ_WRITE} when absent or unrecognised)
      * @param orgContext authenticated user + organization
      * @param redirect   redirect attributes (used as flash for one-shot plaintext)
      * @return redirect back to the list
      */
     @PostMapping
     public String create(@RequestParam(required = false) String name,
+                         @RequestParam(required = false) String scope,
                          OrgContext orgContext,
                          RedirectAttributes redirect) {
         if (name == null || name.isBlank()) {
@@ -85,12 +89,24 @@ public class AccountApiKeyPageController {
         String hashed = ApiKeyAuthenticationFilter.sha256(plaintext);
         Instant now = Instant.now();
         ApiKey key = new ApiKey(UuidFactory.newId(), orgContext.organizationId(), name.trim(), hashed);
+        key.setScope(parseScope(scope));
         key.setCreatedAt(now);
         key.setUpdatedAt(now);
         apiKeyRepository.save(key);
         redirect.addFlashAttribute("plaintextKey", plaintext);
         redirect.addFlashAttribute("plaintextKeyName", name.trim());
         return "redirect:/account/api-keys";
+    }
+
+    private static ApiKeyScope parseScope(String scope) {
+        if (scope == null) {
+            return ApiKeyScope.READ_WRITE;
+        }
+        try {
+            return ApiKeyScope.valueOf(scope.trim().toUpperCase(java.util.Locale.ROOT));
+        } catch (IllegalArgumentException e) {
+            return ApiKeyScope.READ_WRITE;
+        }
     }
 
     /**

--- a/src/main/java/com/majordomo/adapter/in/web/identity/ApiKeyController.java
+++ b/src/main/java/com/majordomo/adapter/in/web/identity/ApiKeyController.java
@@ -2,6 +2,7 @@ package com.majordomo.adapter.in.web.identity;
 
 import com.majordomo.adapter.in.web.config.ApiKeyAuthenticationFilter;
 import com.majordomo.domain.model.identity.ApiKey;
+import com.majordomo.domain.model.identity.ApiKeyScope;
 import com.majordomo.domain.port.out.identity.ApiKeyRepository;
 
 import com.majordomo.domain.model.UuidFactory;
@@ -68,6 +69,7 @@ public class ApiKeyController {
 
         var now = Instant.now();
         var apiKey = new ApiKey(UuidFactory.newId(), orgId, request.name(), hashedKey);
+        apiKey.setScope(request.scope() != null ? request.scope() : ApiKeyScope.READ_WRITE);
         apiKey.setCreatedAt(now);
         apiKey.setUpdatedAt(now);
         apiKey.setExpiresAt(request.expiresAt());
@@ -79,6 +81,7 @@ public class ApiKeyController {
                 "organizationId", saved.getOrganizationId(),
                 "name", saved.getName(),
                 "key", rawKey,
+                "scope", saved.getScope().name(),
                 "createdAt", saved.getCreatedAt(),
                 "expiresAt", saved.getExpiresAt() != null ? saved.getExpiresAt() : ""
         );
@@ -101,7 +104,8 @@ public class ApiKeyController {
         return apiKeyRepository.findByOrganizationId(orgId).stream()
                 .filter(k -> k.getArchivedAt() == null)
                 .map(k -> new ApiKeyResponse(
-                        k.getId(), k.getName(), k.getCreatedAt(), k.getExpiresAt()))
+                        k.getId(), k.getName(), k.getScope(),
+                        k.getCreatedAt(), k.getExpiresAt(), k.getLastUsedAt()))
                 .toList();
     }
 
@@ -139,17 +143,21 @@ public class ApiKeyController {
      * Request body for creating a new API key.
      *
      * @param name      display name for the key
+     * @param scope     optional permission scope (defaults to {@code READ_WRITE})
      * @param expiresAt optional expiration instant
      */
-    public record CreateApiKeyRequest(String name, Instant expiresAt) { }
+    public record CreateApiKeyRequest(String name, ApiKeyScope scope, Instant expiresAt) { }
 
     /**
      * Response record for listing API keys (no plaintext key included).
      *
-     * @param id        the key ID
-     * @param name      display name
-     * @param createdAt creation timestamp
-     * @param expiresAt optional expiration timestamp
+     * @param id         the key ID
+     * @param name       display name
+     * @param scope      permission scope
+     * @param createdAt  creation timestamp
+     * @param expiresAt  optional expiration timestamp
+     * @param lastUsedAt last time the key authenticated a request (null if never)
      */
-    public record ApiKeyResponse(UUID id, String name, Instant createdAt, Instant expiresAt) { }
+    public record ApiKeyResponse(UUID id, String name, ApiKeyScope scope,
+                                 Instant createdAt, Instant expiresAt, Instant lastUsedAt) { }
 }

--- a/src/main/java/com/majordomo/adapter/out/persistence/identity/ApiKeyEntity.java
+++ b/src/main/java/com/majordomo/adapter/out/persistence/identity/ApiKeyEntity.java
@@ -29,6 +29,12 @@ public class ApiKeyEntity {
     @Column(name = "hashed_key", nullable = false)
     private String hashedKey;
 
+    @Column(name = "scope", nullable = false)
+    private String scope;
+
+    @Column(name = "last_used_at")
+    private Instant lastUsedAt;
+
     @Column(name = "created_at", nullable = false, updatable = false)
     private Instant createdAt;
 
@@ -52,6 +58,12 @@ public class ApiKeyEntity {
 
     public String getHashedKey() { return hashedKey; }
     public void setHashedKey(String hashedKey) { this.hashedKey = hashedKey; }
+
+    public String getScope() { return scope; }
+    public void setScope(String scope) { this.scope = scope; }
+
+    public Instant getLastUsedAt() { return lastUsedAt; }
+    public void setLastUsedAt(Instant lastUsedAt) { this.lastUsedAt = lastUsedAt; }
 
     public Instant getCreatedAt() { return createdAt; }
     public void setCreatedAt(Instant createdAt) { this.createdAt = createdAt; }

--- a/src/main/java/com/majordomo/adapter/out/persistence/identity/ApiKeyMapper.java
+++ b/src/main/java/com/majordomo/adapter/out/persistence/identity/ApiKeyMapper.java
@@ -1,6 +1,7 @@
 package com.majordomo.adapter.out.persistence.identity;
 
 import com.majordomo.domain.model.identity.ApiKey;
+import com.majordomo.domain.model.identity.ApiKeyScope;
 
 final class ApiKeyMapper {
 
@@ -12,6 +13,8 @@ final class ApiKeyMapper {
         entity.setOrganizationId(apiKey.getOrganizationId());
         entity.setName(apiKey.getName());
         entity.setHashedKey(apiKey.getHashedKey());
+        entity.setScope(apiKey.getScope().name());
+        entity.setLastUsedAt(apiKey.getLastUsedAt());
         entity.setCreatedAt(apiKey.getCreatedAt());
         entity.setUpdatedAt(apiKey.getUpdatedAt());
         entity.setExpiresAt(apiKey.getExpiresAt());
@@ -22,6 +25,11 @@ final class ApiKeyMapper {
     static ApiKey toDomain(ApiKeyEntity entity) {
         var apiKey = new ApiKey(entity.getId(), entity.getOrganizationId(),
                 entity.getName(), entity.getHashedKey());
+        // Legacy rows predating the scope column map to null; treat as READ_WRITE
+        // to preserve prior behaviour (the migration also backfills READ_WRITE).
+        apiKey.setScope(entity.getScope() == null
+                ? ApiKeyScope.READ_WRITE : ApiKeyScope.valueOf(entity.getScope()));
+        apiKey.setLastUsedAt(entity.getLastUsedAt());
         apiKey.setCreatedAt(entity.getCreatedAt());
         apiKey.setUpdatedAt(entity.getUpdatedAt());
         apiKey.setExpiresAt(entity.getExpiresAt());

--- a/src/main/java/com/majordomo/adapter/out/persistence/identity/ApiKeyRepositoryAdapter.java
+++ b/src/main/java/com/majordomo/adapter/out/persistence/identity/ApiKeyRepositoryAdapter.java
@@ -4,7 +4,9 @@ import com.majordomo.domain.model.identity.ApiKey;
 import com.majordomo.domain.port.out.identity.ApiKeyRepository;
 
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -48,5 +50,11 @@ public class ApiKeyRepositoryAdapter implements ApiKeyRepository {
         return jpa.findByOrganizationId(organizationId).stream()
                 .map(ApiKeyMapper::toDomain)
                 .toList();
+    }
+
+    @Override
+    @Transactional
+    public void touchLastUsed(UUID id, Instant lastUsedAt) {
+        jpa.touchLastUsed(id, lastUsedAt);
     }
 }

--- a/src/main/java/com/majordomo/adapter/out/persistence/identity/JpaApiKeyRepository.java
+++ b/src/main/java/com/majordomo/adapter/out/persistence/identity/JpaApiKeyRepository.java
@@ -1,7 +1,11 @@
 package com.majordomo.adapter.out.persistence.identity;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -27,4 +31,17 @@ public interface JpaApiKeyRepository extends JpaRepository<ApiKeyEntity, UUID> {
      * @return a list of matching entities
      */
     List<ApiKeyEntity> findByOrganizationId(UUID organizationId);
+
+    /**
+     * Updates only the {@code lastUsedAt} column for a key. A targeted update so
+     * recording usage on every authenticated request does not load or rewrite the
+     * whole row.
+     *
+     * @param id         the API key id
+     * @param lastUsedAt the timestamp to store
+     * @return the number of rows updated (0 or 1)
+     */
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE ApiKeyEntity a SET a.lastUsedAt = :lastUsedAt WHERE a.id = :id")
+    int touchLastUsed(@Param("id") UUID id, @Param("lastUsedAt") Instant lastUsedAt);
 }

--- a/src/main/java/com/majordomo/domain/model/identity/ApiKey.java
+++ b/src/main/java/com/majordomo/domain/model/identity/ApiKey.java
@@ -13,10 +13,12 @@ public class ApiKey {
     private UUID organizationId;
     private String name;
     private String hashedKey;
+    private ApiKeyScope scope = ApiKeyScope.READ_WRITE;
     private Instant createdAt;
     private Instant updatedAt;
     private Instant expiresAt;
     private Instant archivedAt;
+    private Instant lastUsedAt;
 
     public ApiKey() { }
 
@@ -38,6 +40,12 @@ public class ApiKey {
 
     public String getHashedKey() { return hashedKey; }
     public void setHashedKey(String hashedKey) { this.hashedKey = hashedKey; }
+
+    public ApiKeyScope getScope() { return scope; }
+    public void setScope(ApiKeyScope scope) { this.scope = scope; }
+
+    public Instant getLastUsedAt() { return lastUsedAt; }
+    public void setLastUsedAt(Instant lastUsedAt) { this.lastUsedAt = lastUsedAt; }
 
     public Instant getCreatedAt() { return createdAt; }
     public void setCreatedAt(Instant createdAt) { this.createdAt = createdAt; }

--- a/src/main/java/com/majordomo/domain/model/identity/ApiKeyScope.java
+++ b/src/main/java/com/majordomo/domain/model/identity/ApiKeyScope.java
@@ -1,0 +1,24 @@
+package com.majordomo.domain.model.identity;
+
+/**
+ * Permission scope for an API key. Constrains what an authenticated key may do:
+ * a {@link #READ_ONLY} key may perform safe (read) requests only, while a
+ * {@link #READ_WRITE} key may also perform state-changing requests.
+ */
+public enum ApiKeyScope {
+
+    /** May perform safe/read requests only; state-changing requests are rejected. */
+    READ_ONLY,
+
+    /** May perform both read and state-changing requests. */
+    READ_WRITE;
+
+    /**
+     * Whether this scope permits state-changing (write) requests.
+     *
+     * @return {@code true} for {@link #READ_WRITE}, {@code false} for {@link #READ_ONLY}
+     */
+    public boolean permitsWrites() {
+        return this == READ_WRITE;
+    }
+}

--- a/src/main/java/com/majordomo/domain/port/out/identity/ApiKeyRepository.java
+++ b/src/main/java/com/majordomo/domain/port/out/identity/ApiKeyRepository.java
@@ -2,6 +2,7 @@ package com.majordomo.domain.port.out.identity;
 
 import com.majordomo.domain.model.identity.ApiKey;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -43,4 +44,14 @@ public interface ApiKeyRepository {
      * @return a list of API keys for that organization (may be empty)
      */
     List<ApiKey> findByOrganizationId(UUID organizationId);
+
+    /**
+     * Records that a key was just used to authenticate a request, updating its
+     * {@code lastUsedAt}. Intended to be cheap (a single-column update) since it
+     * runs on every authenticated API request.
+     *
+     * @param id         the API key id
+     * @param lastUsedAt the moment the key authenticated a request
+     */
+    void touchLastUsed(UUID id, Instant lastUsedAt);
 }

--- a/src/main/resources/db/migration/V20__api_key_scope_and_last_used.sql
+++ b/src/main/resources/db/migration/V20__api_key_scope_and_last_used.sql
@@ -1,0 +1,10 @@
+-- Scoped API keys + usage tracking (#293).
+-- scope constrains what a key may do (READ_ONLY vs READ_WRITE); existing keys
+-- are backfilled to READ_WRITE so their behaviour is unchanged. last_used_at is
+-- stamped by the auth filter on each authenticated request.
+
+ALTER TABLE api_keys
+    ADD COLUMN scope VARCHAR(20) NOT NULL DEFAULT 'READ_WRITE';
+
+ALTER TABLE api_keys
+    ADD COLUMN last_used_at TIMESTAMPTZ;

--- a/src/main/resources/templates/account-api-keys.html
+++ b/src/main/resources/templates/account-api-keys.html
@@ -45,6 +45,14 @@
                                class="rounded border-gray-300 text-sm px-2 py-1.5"
                                placeholder="e.g. CI runner">
                     </div>
+                    <div class="flex flex-col">
+                        <label for="scope" class="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-1">Access</label>
+                        <select id="scope" name="scope"
+                                class="rounded border-gray-300 text-sm px-2 py-1.5">
+                            <option value="READ_WRITE">Read &amp; write</option>
+                            <option value="READ_ONLY">Read only</option>
+                        </select>
+                    </div>
                     <button type="submit"
                             class="inline-flex items-center rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-indigo-700">
                         + Create key
@@ -61,19 +69,31 @@
                     <thead class="bg-gray-50">
                         <tr>
                             <th class="px-6 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider">Name</th>
+                            <th class="px-6 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider">Access</th>
                             <th class="px-6 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider">Created</th>
                             <th class="px-6 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider">Expires</th>
+                            <th class="px-6 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider">Last used</th>
                             <th class="px-6 py-3 text-right text-xs font-semibold text-gray-500 uppercase tracking-wider">Actions</th>
                         </tr>
                     </thead>
                     <tbody class="bg-white divide-y divide-gray-100">
                         <tr th:each="k : ${keys}">
                             <td class="px-6 py-3 whitespace-nowrap text-sm text-gray-900 font-medium" th:text="${k.name}">Name</td>
+                            <td class="px-6 py-3 whitespace-nowrap text-sm">
+                                <span th:if="${k.scope != null and k.scope.name() == 'READ_ONLY'}"
+                                      class="inline-flex items-center rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-700">Read only</span>
+                                <span th:unless="${k.scope != null and k.scope.name() == 'READ_ONLY'}"
+                                      class="inline-flex items-center rounded-full bg-indigo-100 px-2 py-0.5 text-xs font-medium text-indigo-700">Read &amp; write</span>
+                            </td>
                             <td class="px-6 py-3 whitespace-nowrap text-sm text-gray-700"
                                 th:text="${k.createdAt != null ? k.createdAt.toString() : ''}">created</td>
                             <td class="px-6 py-3 whitespace-nowrap text-sm text-gray-700">
                                 <span th:if="${k.expiresAt != null}" th:text="${k.expiresAt}"></span>
                                 <span th:unless="${k.expiresAt != null}" class="text-gray-400">—</span>
+                            </td>
+                            <td class="px-6 py-3 whitespace-nowrap text-sm text-gray-700">
+                                <span th:if="${k.lastUsedAt != null}" th:text="${k.lastUsedAt}"></span>
+                                <span th:unless="${k.lastUsedAt != null}" class="text-gray-400">Never</span>
                             </td>
                             <td class="px-6 py-3 whitespace-nowrap text-sm text-right">
                                 <form method="post" th:action="@{|/account/api-keys/${k.id}/revoke|}"

--- a/src/test/java/com/majordomo/adapter/in/web/config/ApiKeyAuthenticationFilterTest.java
+++ b/src/test/java/com/majordomo/adapter/in/web/config/ApiKeyAuthenticationFilterTest.java
@@ -21,6 +21,7 @@ import java.util.UUID;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -206,6 +207,34 @@ class ApiKeyAuthenticationFilterTest {
 
         assertNotNull(SecurityContextHolder.getContext().getAuthentication());
         verify(filterChain).doFilter(request, response);
+    }
+
+    @Test
+    void recordsLastUsedOnSuccessfulAuthentication() throws Exception {
+        String rawKey = "mjd_touch";
+        String hashedKey = ApiKeyAuthenticationFilter.sha256(rawKey);
+        var apiKey = new ApiKey(UUID.randomUUID(), UUID.randomUUID(), "k", hashedKey);
+        apiKey.setCreatedAt(Instant.now());
+        apiKey.setUpdatedAt(Instant.now());
+
+        when(request.getHeader("X-API-Key")).thenReturn(rawKey);
+        when(apiKeyRepository.findByHashedKey(hashedKey)).thenReturn(Optional.of(apiKey));
+
+        filter.doFilterInternal(request, response, filterChain);
+
+        verify(apiKeyRepository).touchLastUsed(eq(apiKey.getId()), any(Instant.class));
+    }
+
+    @Test
+    void doesNotRecordLastUsedForUnknownKey() throws Exception {
+        String rawKey = "mjd_nope";
+        String hashedKey = ApiKeyAuthenticationFilter.sha256(rawKey);
+        when(request.getHeader("X-API-Key")).thenReturn(rawKey);
+        when(apiKeyRepository.findByHashedKey(hashedKey)).thenReturn(Optional.empty());
+
+        filter.doFilterInternal(request, response, filterChain);
+
+        verify(apiKeyRepository, never()).touchLastUsed(any(), any());
     }
 
     private static ApiKey readOnlyKey(UUID orgId, String hashedKey) {

--- a/src/test/java/com/majordomo/adapter/in/web/config/ApiKeyAuthenticationFilterTest.java
+++ b/src/test/java/com/majordomo/adapter/in/web/config/ApiKeyAuthenticationFilterTest.java
@@ -1,6 +1,7 @@
 package com.majordomo.adapter.in.web.config;
 
 import com.majordomo.domain.model.identity.ApiKey;
+import com.majordomo.domain.model.identity.ApiKeyScope;
 import com.majordomo.domain.port.out.identity.ApiKeyRepository;
 
 import jakarta.servlet.FilterChain;
@@ -20,7 +21,9 @@ import java.util.UUID;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -149,5 +152,67 @@ class ApiKeyAuthenticationFilterTest {
         var auth = SecurityContextHolder.getContext().getAuthentication();
         assertNotNull(auth);
         assertEquals("apikey:" + orgId, auth.getPrincipal());
+    }
+
+    @Test
+    void readOnlyKeyAuthenticatesReadRequest() throws Exception {
+        String rawKey = "mjd_ro_read";
+        String hashedKey = ApiKeyAuthenticationFilter.sha256(rawKey);
+        UUID orgId = UUID.randomUUID();
+        var apiKey = readOnlyKey(orgId, hashedKey);
+
+        when(request.getMethod()).thenReturn("GET");
+        when(request.getHeader("X-API-Key")).thenReturn(rawKey);
+        when(apiKeyRepository.findByHashedKey(hashedKey)).thenReturn(Optional.of(apiKey));
+
+        filter.doFilterInternal(request, response, filterChain);
+
+        assertNotNull(SecurityContextHolder.getContext().getAuthentication());
+        verify(filterChain).doFilter(request, response);
+    }
+
+    @Test
+    void readOnlyKeyRejectsWriteRequestWithForbidden() throws Exception {
+        String rawKey = "mjd_ro_write";
+        String hashedKey = ApiKeyAuthenticationFilter.sha256(rawKey);
+        var apiKey = readOnlyKey(UUID.randomUUID(), hashedKey);
+
+        when(request.getMethod()).thenReturn("POST");
+        when(request.getHeader("X-API-Key")).thenReturn(rawKey);
+        when(apiKeyRepository.findByHashedKey(hashedKey)).thenReturn(Optional.of(apiKey));
+
+        filter.doFilterInternal(request, response, filterChain);
+
+        assertNull(SecurityContextHolder.getContext().getAuthentication());
+        verify(response).sendError(eq(HttpServletResponse.SC_FORBIDDEN), org.mockito.ArgumentMatchers.anyString());
+        verify(filterChain, never()).doFilter(request, response);
+    }
+
+    @Test
+    void readWriteKeyAuthenticatesWriteRequest() throws Exception {
+        String rawKey = "mjd_rw_write";
+        String hashedKey = ApiKeyAuthenticationFilter.sha256(rawKey);
+        UUID orgId = UUID.randomUUID();
+        var apiKey = new ApiKey(UUID.randomUUID(), orgId, "rw-key", hashedKey);
+        apiKey.setCreatedAt(Instant.now());
+        apiKey.setUpdatedAt(Instant.now());
+        apiKey.setScope(ApiKeyScope.READ_WRITE);
+
+        when(request.getMethod()).thenReturn("POST");
+        when(request.getHeader("X-API-Key")).thenReturn(rawKey);
+        when(apiKeyRepository.findByHashedKey(hashedKey)).thenReturn(Optional.of(apiKey));
+
+        filter.doFilterInternal(request, response, filterChain);
+
+        assertNotNull(SecurityContextHolder.getContext().getAuthentication());
+        verify(filterChain).doFilter(request, response);
+    }
+
+    private static ApiKey readOnlyKey(UUID orgId, String hashedKey) {
+        var apiKey = new ApiKey(UUID.randomUUID(), orgId, "ro-key", hashedKey);
+        apiKey.setCreatedAt(Instant.now());
+        apiKey.setUpdatedAt(Instant.now());
+        apiKey.setScope(ApiKeyScope.READ_ONLY);
+        return apiKey;
     }
 }

--- a/src/test/java/com/majordomo/adapter/in/web/identity/AccountApiKeyPageControllerTest.java
+++ b/src/test/java/com/majordomo/adapter/in/web/identity/AccountApiKeyPageControllerTest.java
@@ -100,6 +100,41 @@ class AccountApiKeyPageControllerTest {
         assertThat(saved.getHashedKey()).isNotEqualTo(plaintext);
     }
 
+    /** POST with scope=READ_ONLY mints a read-only key. */
+    @Test
+    @WithMockUser
+    void createWithReadOnlyScopeMintsReadOnlyKey() throws Exception {
+        when(apiKeyRepository.save(any(ApiKey.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        mvc.perform(post("/account/api-keys")
+                        .with(csrf())
+                        .param("name", "readonly runner")
+                        .param("scope", "READ_ONLY"))
+                .andExpect(status().is3xxRedirection());
+
+        ArgumentCaptor<ApiKey> captor = ArgumentCaptor.forClass(ApiKey.class);
+        verify(apiKeyRepository).save(captor.capture());
+        assertThat(captor.getValue().getScope())
+                .isEqualTo(com.majordomo.domain.model.identity.ApiKeyScope.READ_ONLY);
+    }
+
+    /** POST without a scope param defaults to READ_WRITE. */
+    @Test
+    @WithMockUser
+    void createDefaultsToReadWriteWhenScopeOmitted() throws Exception {
+        when(apiKeyRepository.save(any(ApiKey.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        mvc.perform(post("/account/api-keys")
+                        .with(csrf())
+                        .param("name", "default scope"))
+                .andExpect(status().is3xxRedirection());
+
+        ArgumentCaptor<ApiKey> captor = ArgumentCaptor.forClass(ApiKey.class);
+        verify(apiKeyRepository).save(captor.capture());
+        assertThat(captor.getValue().getScope())
+                .isEqualTo(com.majordomo.domain.model.identity.ApiKeyScope.READ_WRITE);
+    }
+
     /** POST with blank name re-renders with error (flash) and does not save. */
     @Test
     @WithMockUser

--- a/src/test/java/com/majordomo/adapter/in/web/identity/ApiKeyControllerTest.java
+++ b/src/test/java/com/majordomo/adapter/in/web/identity/ApiKeyControllerTest.java
@@ -6,6 +6,7 @@ import com.majordomo.domain.model.UuidFactory;
 import com.majordomo.domain.model.identity.ApiKey;
 import com.majordomo.domain.port.out.identity.ApiKeyRepository;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
@@ -19,6 +20,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -86,6 +88,48 @@ class ApiKeyControllerTest {
                                 """))
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.expiresAt").value("2026-12-31T00:00:00Z"));
+    }
+
+    /** POST with an explicit scope persists a read-only key and echoes it. */
+    @Test
+    @WithMockUser
+    void createWithReadOnlyScopePersistsIt() throws Exception {
+        ArgumentCaptor<ApiKey> captor = ArgumentCaptor.forClass(ApiKey.class);
+        when(apiKeyRepository.save(any(ApiKey.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        mvc.perform(post("/api/organizations/{orgId}/api-keys", ORG_ID)
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"name":"read-only key","scope":"READ_ONLY"}
+                                """))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.scope").value("READ_ONLY"));
+
+        verify(apiKeyRepository).save(captor.capture());
+        assertThat(captor.getValue().getScope())
+                .isEqualTo(com.majordomo.domain.model.identity.ApiKeyScope.READ_ONLY);
+    }
+
+    /** POST without a scope defaults to READ_WRITE. */
+    @Test
+    @WithMockUser
+    void createDefaultsToReadWriteScope() throws Exception {
+        ArgumentCaptor<ApiKey> captor = ArgumentCaptor.forClass(ApiKey.class);
+        when(apiKeyRepository.save(any(ApiKey.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        mvc.perform(post("/api/organizations/{orgId}/api-keys", ORG_ID)
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"name":"default key"}
+                                """))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.scope").value("READ_WRITE"));
+
+        verify(apiKeyRepository).save(captor.capture());
+        assertThat(captor.getValue().getScope())
+                .isEqualTo(com.majordomo.domain.model.identity.ApiKeyScope.READ_WRITE);
     }
 
     /** GET lists active keys (archived excluded), no plaintext. */

--- a/src/test/java/com/majordomo/adapter/in/web/identity/ApiKeyScopeEnforcementIntegrationTest.java
+++ b/src/test/java/com/majordomo/adapter/in/web/identity/ApiKeyScopeEnforcementIntegrationTest.java
@@ -1,0 +1,89 @@
+package com.majordomo.adapter.in.web.identity;
+
+import com.majordomo.IntegrationTest;
+import com.majordomo.adapter.in.web.config.ApiKeyAuthenticationFilter;
+import com.majordomo.domain.model.UuidFactory;
+import com.majordomo.domain.model.identity.ApiKey;
+import com.majordomo.domain.model.identity.ApiKeyScope;
+import com.majordomo.domain.model.identity.Organization;
+import com.majordomo.domain.port.out.identity.ApiKeyRepository;
+import com.majordomo.domain.port.out.identity.OrganizationRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.Instant;
+import java.util.UUID;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * End-to-end proof, through the real Spring Security chain, that API key scope
+ * is enforced (#293): a read-only key authenticates reads but is rejected with
+ * 403 on writes, while a read-write key can write. Runs against Testcontainers
+ * Postgres so the key is looked up from a real store.
+ */
+@IntegrationTest
+@AutoConfigureMockMvc
+class ApiKeyScopeEnforcementIntegrationTest {
+
+    @Autowired
+    private MockMvc mvc;
+
+    @Autowired
+    private ApiKeyRepository apiKeys;
+
+    @Autowired
+    private OrganizationRepository organizations;
+
+    private UUID seedOrg() {
+        UUID id = UuidFactory.newId();
+        organizations.save(new Organization(id, "org-" + id));
+        return id;
+    }
+
+    private String seedKey(UUID orgId, String rawKey, ApiKeyScope scope) {
+        var now = Instant.now();
+        ApiKey key = new ApiKey(UuidFactory.newId(), orgId, "k",
+                ApiKeyAuthenticationFilter.sha256(rawKey));
+        key.setScope(scope);
+        key.setCreatedAt(now);
+        key.setUpdatedAt(now);
+        apiKeys.save(key);
+        return rawKey;
+    }
+
+    @Test
+    void readOnlyKeyCanReadButNotWrite() throws Exception {
+        UUID org = seedOrg();
+        String raw = seedKey(org, "mjd_ro_" + org, ApiKeyScope.READ_ONLY);
+
+        // Read is allowed (authenticated) — not 401/403.
+        mvc.perform(get("/api/organizations/{orgId}/api-keys", org)
+                        .header("X-API-Key", raw))
+                .andExpect(status().isOk());
+
+        // Write is rejected with 403 before reaching the controller.
+        mvc.perform(post("/api/organizations/{orgId}/api-keys", org)
+                        .header("X-API-Key", raw)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"name\":\"blocked\"}"))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void readWriteKeyCanWrite() throws Exception {
+        UUID org = seedOrg();
+        String raw = seedKey(org, "mjd_rw_" + org, ApiKeyScope.READ_WRITE);
+
+        mvc.perform(post("/api/organizations/{orgId}/api-keys", org)
+                        .header("X-API-Key", raw)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"name\":\"allowed\"}"))
+                .andExpect(status().isCreated());
+    }
+}

--- a/src/test/java/com/majordomo/adapter/out/persistence/identity/ApiKeyScopeIntegrationTest.java
+++ b/src/test/java/com/majordomo/adapter/out/persistence/identity/ApiKeyScopeIntegrationTest.java
@@ -1,0 +1,87 @@
+package com.majordomo.adapter.out.persistence.identity;
+
+import com.majordomo.IntegrationTest;
+import com.majordomo.domain.model.UuidFactory;
+import com.majordomo.domain.model.identity.ApiKey;
+import com.majordomo.domain.model.identity.ApiKeyScope;
+import com.majordomo.domain.model.identity.Organization;
+import com.majordomo.domain.port.out.identity.ApiKeyRepository;
+import com.majordomo.domain.port.out.identity.OrganizationRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import java.time.Instant;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Postgres round-trip for API key scope + last-used tracking (#293): scope
+ * persists, the DEFAULT backfills rows written without a scope, and
+ * touchLastUsed updates only the timestamp.
+ */
+@IntegrationTest
+class ApiKeyScopeIntegrationTest {
+
+    @Autowired
+    private ApiKeyRepository apiKeys;
+
+    @Autowired
+    private OrganizationRepository organizations;
+
+    @Autowired
+    private JdbcTemplate jdbc;
+
+    private UUID newOrg() {
+        UUID id = UuidFactory.newId();
+        organizations.save(new Organization(id, "org-" + id));
+        return id;
+    }
+
+    private ApiKey key(UUID orgId, ApiKeyScope scope) {
+        var now = Instant.now();
+        ApiKey k = new ApiKey(UuidFactory.newId(), orgId, "k-" + UuidFactory.newId(), "hash-" + orgId);
+        k.setScope(scope);
+        k.setCreatedAt(now);
+        k.setUpdatedAt(now);
+        return k;
+    }
+
+    @Test
+    void scopePersistsAndReloads() {
+        UUID org = newOrg();
+        ApiKey saved = apiKeys.save(key(org, ApiKeyScope.READ_ONLY));
+
+        assertThat(apiKeys.findById(saved.getId()).orElseThrow().getScope())
+                .isEqualTo(ApiKeyScope.READ_ONLY);
+    }
+
+    @Test
+    void rowInsertedWithoutScopeDefaultsToReadWrite() {
+        UUID org = newOrg();
+        UUID id = UuidFactory.newId();
+        // Simulate a pre-migration row: insert without specifying scope so the
+        // column DEFAULT ('READ_WRITE') backfills it.
+        jdbc.update("""
+                INSERT INTO api_keys (id, organization_id, name, hashed_key, created_at, updated_at)
+                VALUES (?, ?, 'legacy', ?, now(), now())
+                """, id, org, "legacy-hash-" + id);
+
+        assertThat(apiKeys.findById(id).orElseThrow().getScope())
+                .isEqualTo(ApiKeyScope.READ_WRITE);
+    }
+
+    @Test
+    void touchLastUsedUpdatesTimestamp() {
+        UUID org = newOrg();
+        ApiKey saved = apiKeys.save(key(org, ApiKeyScope.READ_WRITE));
+        assertThat(saved.getLastUsedAt()).isNull();
+
+        Instant used = Instant.parse("2026-07-07T12:00:00Z");
+        apiKeys.touchLastUsed(saved.getId(), used);
+
+        assertThat(apiKeys.findById(saved.getId()).orElseThrow().getLastUsedAt())
+                .isEqualTo(used);
+    }
+}

--- a/src/test/java/com/majordomo/domain/model/identity/ApiKeyTest.java
+++ b/src/test/java/com/majordomo/domain/model/identity/ApiKeyTest.java
@@ -1,0 +1,34 @@
+package com.majordomo.domain.model.identity;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ApiKeyTest {
+
+    @Test
+    void newKeyDefaultsToReadWriteScope() {
+        var key = new ApiKey(UUID.randomUUID(), UUID.randomUUID(), "k", "hash");
+
+        // Existing keys (and any minted without an explicit scope) are read-write,
+        // matching the migration backfill so behaviour is unchanged by default.
+        assertThat(key.getScope()).isEqualTo(ApiKeyScope.READ_WRITE);
+    }
+
+    @Test
+    void scopeIsSettable() {
+        var key = new ApiKey(UUID.randomUUID(), UUID.randomUUID(), "k", "hash");
+
+        key.setScope(ApiKeyScope.READ_ONLY);
+
+        assertThat(key.getScope()).isEqualTo(ApiKeyScope.READ_ONLY);
+    }
+
+    @Test
+    void readOnlyScopeDoesNotPermitWrites() {
+        assertThat(ApiKeyScope.READ_ONLY.permitsWrites()).isFalse();
+        assertThat(ApiKeyScope.READ_WRITE.permitsWrites()).isTrue();
+    }
+}


### PR DESCRIPTION
Closes #293.

## What
API keys were all-or-nothing with no usage visibility. This adds a **scope** (READ_ONLY vs READ_WRITE) enforced in the auth filter, and a **last_used_at** timestamp stamped on every authenticated request and surfaced in the UI.

## How (built in TDD increments)
1. **Domain** — `ApiKeyScope { READ_ONLY, READ_WRITE }` + `scope`/`lastUsedAt` on `ApiKey`. New keys default to `READ_WRITE`.
2. **Enforcement** — `ApiKeyAuthenticationFilter`: a READ_ONLY key authenticates safe methods (GET/HEAD/OPTIONS) but is rejected with **403** on POST/PUT/PATCH/DELETE, before the request reaches any controller. READ_WRITE is unchanged.
3. **Usage tracking** — `ApiKeyRepository.touchLastUsed` (targeted `@Modifying` update, so it doesn't rewrite the whole row) called on each successful authentication.
4. **Persistence** — V20 migration adds `scope VARCHAR NOT NULL DEFAULT 'READ_WRITE'` (backfilling existing keys) and `last_used_at`. Mapper treats a null scope as READ_WRITE for safety.
5. **REST + UI** — REST create accepts an optional `scope` (default READ_WRITE) and the list response includes `scope`/`lastUsedAt`; the account page gets a Read/Write vs Read-only selector and shows an access badge + last-used per key.

## Acceptance criteria
- [x] API key carries a scope; Flyway migration + backfill READ_WRITE for existing keys
- [x] READ_ONLY rejected on state-changing requests, allowed on reads
- [x] `last_used_at` updated on authenticated use and shown in the key UI
- [x] Scope selectable at key creation (REST + page)
- [x] Auth-filter tests for allow/deny per scope + method

## Testing
TDD throughout (red → green per increment). **582 unit tests** pass, Checkstyle clean. Testcontainers Postgres integration tests: scope round-trip, `DEFAULT` backfill of a row inserted without a scope, `touchLastUsed`, and an **end-to-end proof through the real Spring Security chain** (read-only reads 200 / writes 403; read-write writes 201).

🤖 Generated with [Claude Code](https://claude.com/claude-code)