### PR TITLE
herald: weekly maintenance digest email (#287)

### DIFF
--- a/doc/notifications.md
+++ b/doc/notifications.md
@@ -69,3 +69,39 @@ The `NotificationAdapter` is protected by Resilience4j:
 - **Retry** (`notification`): Retries transient failures before triggering the circuit breaker.
 
 Configuration is in `application.yml` under `resilience4j:`.
+
+## Scheduled Jobs
+
+The Herald runs three scheduled notification jobs. All crons are configurable under
+`majordomo.notifications` in `application.yml`.
+
+| Job | Class | Default cron | What it sends |
+|-----|-------|--------------|---------------|
+| Maintenance reminders | `MaintenanceNotificationService` | `cron` = `0 0 8 * * *` | One email per maintenance schedule due within 7 days, once per due date (deduplicated). |
+| Warranty alerts | `WarrantyAlertService` | `warranty-cron` = `0 0 9 * * *` | One email per property whose warranty expires within 30 days, once per property (deduplicated). |
+| Weekly digest | `WeeklyDigestService` | `digest-cron` = `0 0 8 * * MON` | **One** rollup email per admin/owner summarizing everything due in the next 30 days. |
+
+### Weekly maintenance digest
+
+`WeeklyDigestService` assembles, per user, a single weekly email that rolls up
+everything coming due in the next **30 days** — both upcoming maintenance and
+property warranty expirations — so a user has one place to plan the week/month.
+
+Design notes:
+
+- **Reuses `HeraldCalendarService`** (the calendar-feed assembler) for both event
+  collection and per-user category preference filtering. A user who has disabled
+  `MAINTENANCE_DUE` sees only warranties; one who has disabled both — or disabled
+  notifications entirely — assembles to nothing.
+- **An empty digest is never sent.** A user with nothing upcoming (or who has opted
+  out of everything) receives no email at all.
+- **One email per user.** Events across all of the user's organizations are combined
+  into a single digest, sorted by date.
+- **Recipients** are organization owners and admins (plain `MEMBER` roles are not
+  notified, consistent with the per-event reminder jobs).
+- **Send path** is the same Resilience4j-protected `NotificationPort`, so digests
+  inherit the circuit-breaker/retry behavior above.
+
+Unlike the per-event reminders, the digest is a stateless rollup: it does **not**
+set or read `notification_sent_at`, so an item can appear in a weekly digest and
+still trigger its own dated reminder.

--- a/doc/user-guide/schedules.md
+++ b/doc/user-guide/schedules.md
@@ -59,6 +59,21 @@ within the configured lead window. Per-user preferences let you mute
 the `MAINTENANCE_DUE`, `WARRANTY_EXPIRING`, and `SITE_UPDATES`
 categories independently — see your account preferences.
 
+### Weekly digest
+
+Once a week (Mondays by default), Majordomo sends owners and admins a
+single **digest email** rolling up everything due in the next 30 days —
+upcoming maintenance *and* property warranty expirations — sorted by date,
+so you have one place to plan the month. It's separate from the dated
+reminders above: an item can show up in your Monday digest and still get
+its own reminder closer to the date.
+
+The digest honours the same preferences: mute `MAINTENANCE_DUE` or
+`WARRANTY_EXPIRING` and those items drop out of the rollup. If you've muted
+both categories (or turned notifications off entirely), or simply have
+nothing coming up, **no digest is sent** — the weekly email only arrives
+when there's something to plan for.
+
 ## Subscribe to a calendar feed
 
 Prefer to see due dates in your own calendar app? Open **Calendar feed**

--- a/src/main/java/com/majordomo/application/herald/WeeklyDigestService.java
+++ b/src/main/java/com/majordomo/application/herald/WeeklyDigestService.java
@@ -1,0 +1,152 @@
+package com.majordomo.application.herald;
+
+import com.majordomo.domain.model.herald.CalendarEvent;
+import com.majordomo.domain.model.identity.MemberRole;
+import com.majordomo.domain.model.identity.Membership;
+import com.majordomo.domain.port.out.herald.MaintenanceScheduleRepository;
+import com.majordomo.domain.port.out.herald.NotificationPort;
+import com.majordomo.domain.port.out.identity.MembershipRepository;
+import com.majordomo.domain.port.out.identity.UserRepository;
+import com.majordomo.domain.port.out.steward.PropertyRepository;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+/**
+ * Scheduled service that sends each user a single weekly digest email rolling
+ * up everything due in the next {@value #DIGEST_WINDOW_DAYS} days across their
+ * organizations: upcoming maintenance and property warranty expirations.
+ *
+ * <p>Event assembly and per-user notification-category preference filtering are
+ * delegated to {@link HeraldCalendarService} (reused from the calendar feed), so
+ * a user who has opted out of a category simply does not see those entries, and
+ * a user who has opted out of everything receives no digest at all. An empty
+ * digest is never sent, and the send path is the Resilience4j-protected
+ * {@link NotificationPort}.
+ */
+@Service
+public class WeeklyDigestService {
+
+    /** How far ahead the digest looks, in days. */
+    static final int DIGEST_WINDOW_DAYS = 30;
+
+    private static final Logger LOG = LoggerFactory.getLogger(WeeklyDigestService.class);
+
+    private final HeraldCalendarService calendarService;
+    private final MaintenanceScheduleRepository scheduleRepository;
+    private final PropertyRepository propertyRepository;
+    private final MembershipRepository membershipRepository;
+    private final UserRepository userRepository;
+    private final NotificationPort notificationPort;
+
+    /**
+     * Constructs the digest service.
+     *
+     * @param calendarService      assembles per-user upcoming events with preference filtering
+     * @param scheduleRepository   repository for maintenance schedules (organization discovery)
+     * @param propertyRepository   repository for properties (organization discovery)
+     * @param membershipRepository repository for organization memberships
+     * @param userRepository       repository for users (recipient resolution)
+     * @param notificationPort     outbound port for sending notifications
+     */
+    public WeeklyDigestService(HeraldCalendarService calendarService,
+                               MaintenanceScheduleRepository scheduleRepository,
+                               PropertyRepository propertyRepository,
+                               MembershipRepository membershipRepository,
+                               UserRepository userRepository,
+                               NotificationPort notificationPort) {
+        this.calendarService = calendarService;
+        this.scheduleRepository = scheduleRepository;
+        this.propertyRepository = propertyRepository;
+        this.membershipRepository = membershipRepository;
+        this.userRepository = userRepository;
+        this.notificationPort = notificationPort;
+    }
+
+    /**
+     * Assembles and sends the weekly digests. Runs on a configurable weekly cron
+     * (default Monday 08:00). Each admin/owner receives one email covering all of
+     * their organizations; users with nothing upcoming receive nothing.
+     */
+    @Scheduled(cron = "${majordomo.notifications.digest-cron:0 0 8 * * MON}")
+    public void sendWeeklyDigests() {
+        LocalDate today = LocalDate.now();
+        LocalDate horizon = today.plusDays(DIGEST_WINDOW_DAYS);
+
+        Map<UUID, List<CalendarEvent>> eventsByUser = new LinkedHashMap<>();
+        for (UUID organizationId : organizationsWithUpcomingEvents(horizon)) {
+            for (Membership membership : membershipRepository.findByOrganizationId(organizationId)) {
+                if (membership.getRole() == MemberRole.MEMBER) {
+                    continue;
+                }
+                List<CalendarEvent> events = calendarService
+                        .upcomingEvents(membership.getUserId(), organizationId, today).stream()
+                        .filter(event -> !event.date().isAfter(horizon))
+                        .toList();
+                if (!events.isEmpty()) {
+                    eventsByUser.computeIfAbsent(membership.getUserId(), key -> new ArrayList<>())
+                            .addAll(events);
+                }
+            }
+        }
+
+        int sent = 0;
+        for (Map.Entry<UUID, List<CalendarEvent>> entry : eventsByUser.entrySet()) {
+            List<CalendarEvent> events = entry.getValue();
+            if (events.isEmpty()) {
+                continue;
+            }
+            var user = userRepository.findById(entry.getKey());
+            if (user.isEmpty()) {
+                continue;
+            }
+            notificationPort.send(user.get().getEmail(), subject(events), body(events));
+            sent++;
+        }
+        LOG.info("Weekly maintenance digest complete: {} digest(s) sent", sent);
+    }
+
+    private Set<UUID> organizationsWithUpcomingEvents(LocalDate horizon) {
+        Set<UUID> organizationIds = new LinkedHashSet<>();
+        LocalDate exclusiveUpper = horizon.plusDays(1);
+        for (var schedule : scheduleRepository.findDueBefore(exclusiveUpper)) {
+            propertyRepository.findById(schedule.getPropertyId())
+                    .ifPresent(property -> organizationIds.add(property.getOrganizationId()));
+        }
+        for (var property : propertyRepository.findWithWarrantyExpiringBefore(exclusiveUpper)) {
+            organizationIds.add(property.getOrganizationId());
+        }
+        return organizationIds;
+    }
+
+    private String subject(List<CalendarEvent> events) {
+        return "Your weekly maintenance digest: " + events.size() + " item(s) coming up";
+    }
+
+    private String body(List<CalendarEvent> events) {
+        var lines = new StringBuilder();
+        lines.append("Here's what's coming up in the next ")
+                .append(DIGEST_WINDOW_DAYS)
+                .append(" days:\n\n");
+        events.stream()
+                .sorted((a, b) -> a.date().compareTo(b.date()))
+                .forEach(event -> lines.append(event.date())
+                        .append("  ")
+                        .append(event.summary())
+                        .append(" (")
+                        .append(event.description())
+                        .append(")\n"));
+        return lines.toString();
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -108,6 +108,7 @@ majordomo:
   notifications:
     cron: "0 0 8 * * *"
     warranty-cron: "0 0 9 * * *"
+    digest-cron: "0 0 8 * * MON"
 
 envoy:
   llm:

--- a/src/test/java/com/majordomo/application/herald/WeeklyDigestServiceTest.java
+++ b/src/test/java/com/majordomo/application/herald/WeeklyDigestServiceTest.java
@@ -1,0 +1,128 @@
+package com.majordomo.application.herald;
+
+import com.majordomo.domain.model.herald.Frequency;
+import com.majordomo.domain.model.herald.MaintenanceSchedule;
+import com.majordomo.domain.model.identity.MemberRole;
+import com.majordomo.domain.model.identity.Membership;
+import com.majordomo.domain.model.identity.User;
+import com.majordomo.domain.model.steward.Property;
+import com.majordomo.domain.port.out.herald.MaintenanceScheduleRepository;
+import com.majordomo.domain.port.out.herald.NotificationPort;
+import com.majordomo.domain.port.out.identity.MembershipRepository;
+import com.majordomo.domain.port.out.identity.UserPreferencesRepository;
+import com.majordomo.domain.port.out.identity.UserRepository;
+import com.majordomo.domain.port.out.steward.PropertyRepository;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Sociable unit tests for {@link WeeklyDigestService}. The collaborating
+ * {@link HeraldCalendarService} is real (wired to mocked repositories) so that
+ * event assembly and per-user notification-category preference filtering are
+ * exercised end-to-end, while the outbound {@link NotificationPort} is mocked.
+ */
+@ExtendWith(MockitoExtension.class)
+class WeeklyDigestServiceTest {
+
+    @Mock
+    private MaintenanceScheduleRepository scheduleRepository;
+
+    @Mock
+    private PropertyRepository propertyRepository;
+
+    @Mock
+    private UserPreferencesRepository preferencesRepository;
+
+    @Mock
+    private MembershipRepository membershipRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private NotificationPort notificationPort;
+
+    private WeeklyDigestService service;
+
+    @BeforeEach
+    void setUp() {
+        var herald = new HeraldCalendarService(scheduleRepository, propertyRepository, preferencesRepository);
+        service = new WeeklyDigestService(
+                herald, scheduleRepository, propertyRepository,
+                membershipRepository, userRepository, notificationPort);
+    }
+
+    private MaintenanceSchedule schedule(UUID propertyId, String description, LocalDate due) {
+        var s = new MaintenanceSchedule();
+        s.setId(UUID.randomUUID());
+        s.setPropertyId(propertyId);
+        s.setDescription(description);
+        s.setFrequency(Frequency.MONTHLY);
+        s.setNextDue(due);
+        return s;
+    }
+
+    private Property property(UUID id, UUID orgId, String name) {
+        var p = new Property();
+        p.setId(id);
+        p.setOrganizationId(orgId);
+        p.setName(name);
+        return p;
+    }
+
+    @Test
+    void sendsSingleDigestWithMaintenanceAndWarrantyForAdmin() {
+        var orgId = UUID.randomUUID();
+        var userId = UUID.randomUUID();
+        var propertyId = UUID.randomUUID();
+
+        var maintenance = schedule(propertyId, "HVAC filter replacement", LocalDate.now().plusDays(5));
+        var property = property(propertyId, orgId, "Main Building");
+        var warrantyProperty = property(UUID.randomUUID(), orgId, "Dishwasher");
+        warrantyProperty.setWarrantyExpiresOn(LocalDate.now().plusDays(20));
+
+        var membership = new Membership(UUID.randomUUID(), userId, orgId, MemberRole.OWNER);
+        var user = new User(userId, "admin", "admin@example.com");
+
+        // Enumeration: which organizations have anything upcoming.
+        when(scheduleRepository.findDueBefore(any(LocalDate.class))).thenReturn(List.of(maintenance));
+        when(propertyRepository.findById(propertyId)).thenReturn(Optional.of(property));
+        when(propertyRepository.findWithWarrantyExpiringBefore(any(LocalDate.class)))
+                .thenReturn(List.of(warrantyProperty));
+        when(membershipRepository.findByOrganizationId(orgId)).thenReturn(List.of(membership));
+
+        // Assembly (via the real HeraldCalendarService).
+        when(scheduleRepository.findUpcomingByOrganizationId(eq(orgId), any(LocalDate.class)))
+                .thenReturn(List.of(maintenance));
+        when(propertyRepository.findByIdIn(List.of(propertyId))).thenReturn(List.of(property));
+        when(propertyRepository.findWithWarrantyExpiringOnOrAfter(eq(orgId), any(LocalDate.class)))
+                .thenReturn(List.of(warrantyProperty));
+        when(preferencesRepository.findByUserId(userId)).thenReturn(Optional.empty());
+
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+
+        service.sendWeeklyDigests();
+
+        var body = ArgumentCaptor.forClass(String.class);
+        verify(notificationPort).send(eq("admin@example.com"), any(String.class), body.capture());
+        assertThat(body.getValue())
+                .contains("HVAC filter replacement")
+                .contains("Warranty expires: Dishwasher");
+    }
+}

--- a/src/test/java/com/majordomo/application/herald/WeeklyDigestServiceTest.java
+++ b/src/test/java/com/majordomo/application/herald/WeeklyDigestServiceTest.java
@@ -5,6 +5,7 @@ import com.majordomo.domain.model.herald.MaintenanceSchedule;
 import com.majordomo.domain.model.identity.MemberRole;
 import com.majordomo.domain.model.identity.Membership;
 import com.majordomo.domain.model.identity.User;
+import com.majordomo.domain.model.identity.UserPreferences;
 import com.majordomo.domain.model.steward.Property;
 import com.majordomo.domain.port.out.herald.MaintenanceScheduleRepository;
 import com.majordomo.domain.port.out.herald.NotificationPort;
@@ -27,7 +28,11 @@ import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -124,5 +129,159 @@ class WeeklyDigestServiceTest {
         assertThat(body.getValue())
                 .contains("HVAC filter replacement")
                 .contains("Warranty expires: Dishwasher");
+    }
+
+    @Test
+    void doesNotSendWhenNothingIsUpcoming() {
+        when(scheduleRepository.findDueBefore(any(LocalDate.class))).thenReturn(List.of());
+        when(propertyRepository.findWithWarrantyExpiringBefore(any(LocalDate.class)))
+                .thenReturn(List.of());
+
+        service.sendWeeklyDigests();
+
+        verify(notificationPort, never()).send(anyString(), anyString(), anyString());
+    }
+
+    @Test
+    void doesNotSendDigestWhenUserHasOptedOutOfAllCategories() {
+        var orgId = UUID.randomUUID();
+        var userId = UUID.randomUUID();
+        var propertyId = UUID.randomUUID();
+
+        var maintenance = schedule(propertyId, "HVAC filter replacement", LocalDate.now().plusDays(5));
+        var property = property(propertyId, orgId, "Main Building");
+        var membership = new Membership(UUID.randomUUID(), userId, orgId, MemberRole.OWNER);
+        var user = new User(userId, "admin", "admin@example.com");
+
+        var prefs = new UserPreferences();
+        prefs.setNotificationsEnabled(true);
+        prefs.setNotificationCategoriesDisabled(List.of("MAINTENANCE_DUE", "WARRANTY_EXPIRING"));
+
+        when(scheduleRepository.findDueBefore(any(LocalDate.class))).thenReturn(List.of(maintenance));
+        when(propertyRepository.findById(propertyId)).thenReturn(Optional.of(property));
+        when(propertyRepository.findWithWarrantyExpiringBefore(any(LocalDate.class)))
+                .thenReturn(List.of());
+        when(membershipRepository.findByOrganizationId(orgId)).thenReturn(List.of(membership));
+        when(preferencesRepository.findByUserId(userId)).thenReturn(Optional.of(prefs));
+
+        // Everything an enabled user would need is stubbed leniently, so the ONLY
+        // reason no digest is sent is that the opt-out suppresses assembly.
+        lenient().when(scheduleRepository.findUpcomingByOrganizationId(eq(orgId), any(LocalDate.class)))
+                .thenReturn(List.of(maintenance));
+        lenient().when(propertyRepository.findByIdIn(List.of(propertyId))).thenReturn(List.of(property));
+        lenient().when(propertyRepository.findWithWarrantyExpiringOnOrAfter(eq(orgId), any(LocalDate.class)))
+                .thenReturn(List.of());
+        lenient().when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+
+        service.sendWeeklyDigests();
+
+        verify(notificationPort, never()).send(anyString(), anyString(), anyString());
+    }
+
+    @Test
+    void excludesEventsBeyondThirtyDayWindow() {
+        var orgId = UUID.randomUUID();
+        var userId = UUID.randomUUID();
+        var propertyId = UUID.randomUUID();
+
+        var near = schedule(propertyId, "Gutter cleaning", LocalDate.now().plusDays(10));
+        var far = schedule(propertyId, "Roof inspection", LocalDate.now().plusDays(45));
+        var property = property(propertyId, orgId, "Main Building");
+        var membership = new Membership(UUID.randomUUID(), userId, orgId, MemberRole.OWNER);
+        var user = new User(userId, "admin", "admin@example.com");
+
+        when(scheduleRepository.findDueBefore(any(LocalDate.class))).thenReturn(List.of(near, far));
+        when(propertyRepository.findById(propertyId)).thenReturn(Optional.of(property));
+        when(propertyRepository.findWithWarrantyExpiringBefore(any(LocalDate.class))).thenReturn(List.of());
+        when(membershipRepository.findByOrganizationId(orgId)).thenReturn(List.of(membership));
+        when(scheduleRepository.findUpcomingByOrganizationId(eq(orgId), any(LocalDate.class)))
+                .thenReturn(List.of(near, far));
+        when(propertyRepository.findByIdIn(anyCollection())).thenReturn(List.of(property));
+        when(propertyRepository.findWithWarrantyExpiringOnOrAfter(eq(orgId), any(LocalDate.class)))
+                .thenReturn(List.of());
+        when(preferencesRepository.findByUserId(userId)).thenReturn(Optional.empty());
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+
+        service.sendWeeklyDigests();
+
+        var body = ArgumentCaptor.forClass(String.class);
+        verify(notificationPort).send(eq("admin@example.com"), anyString(), body.capture());
+        assertThat(body.getValue())
+                .contains("Gutter cleaning")
+                .doesNotContain("Roof inspection");
+    }
+
+    @Test
+    void doesNotSendDigestToPlainMembers() {
+        var orgId = UUID.randomUUID();
+        var userId = UUID.randomUUID();
+        var propertyId = UUID.randomUUID();
+
+        var maintenance = schedule(propertyId, "HVAC filter replacement", LocalDate.now().plusDays(5));
+        var property = property(propertyId, orgId, "Main Building");
+        var membership = new Membership(UUID.randomUUID(), userId, orgId, MemberRole.MEMBER);
+        var user = new User(userId, "member", "member@example.com");
+
+        when(scheduleRepository.findDueBefore(any(LocalDate.class))).thenReturn(List.of(maintenance));
+        when(propertyRepository.findById(propertyId)).thenReturn(Optional.of(property));
+        when(propertyRepository.findWithWarrantyExpiringBefore(any(LocalDate.class))).thenReturn(List.of());
+        when(membershipRepository.findByOrganizationId(orgId)).thenReturn(List.of(membership));
+
+        // Leniently stub everything a non-member would need, so the ONLY reason no
+        // digest is sent is the plain-member role gate.
+        lenient().when(scheduleRepository.findUpcomingByOrganizationId(eq(orgId), any(LocalDate.class)))
+                .thenReturn(List.of(maintenance));
+        lenient().when(propertyRepository.findByIdIn(anyCollection())).thenReturn(List.of(property));
+        lenient().when(propertyRepository.findWithWarrantyExpiringOnOrAfter(eq(orgId), any(LocalDate.class)))
+                .thenReturn(List.of());
+        lenient().when(preferencesRepository.findByUserId(userId)).thenReturn(Optional.empty());
+        lenient().when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+
+        service.sendWeeklyDigests();
+
+        verify(notificationPort, never()).send(anyString(), anyString(), anyString());
+    }
+
+    @Test
+    void combinesMultipleOrganizationsIntoOneDigestPerUser() {
+        var orgA = UUID.randomUUID();
+        var orgB = UUID.randomUUID();
+        var userId = UUID.randomUUID();
+        var propertyA = UUID.randomUUID();
+        var propertyB = UUID.randomUUID();
+
+        var scheduleA = schedule(propertyA, "Furnace service", LocalDate.now().plusDays(5));
+        var scheduleB = schedule(propertyB, "Chimney sweep", LocalDate.now().plusDays(7));
+        var propA = property(propertyA, orgA, "Cabin");
+        var propB = property(propertyB, orgB, "Townhouse");
+        var user = new User(userId, "admin", "admin@example.com");
+
+        when(scheduleRepository.findDueBefore(any(LocalDate.class)))
+                .thenReturn(List.of(scheduleA, scheduleB));
+        when(propertyRepository.findById(propertyA)).thenReturn(Optional.of(propA));
+        when(propertyRepository.findById(propertyB)).thenReturn(Optional.of(propB));
+        when(propertyRepository.findWithWarrantyExpiringBefore(any(LocalDate.class))).thenReturn(List.of());
+        when(membershipRepository.findByOrganizationId(orgA))
+                .thenReturn(List.of(new Membership(UUID.randomUUID(), userId, orgA, MemberRole.OWNER)));
+        when(membershipRepository.findByOrganizationId(orgB))
+                .thenReturn(List.of(new Membership(UUID.randomUUID(), userId, orgB, MemberRole.ADMIN)));
+        when(scheduleRepository.findUpcomingByOrganizationId(eq(orgA), any(LocalDate.class)))
+                .thenReturn(List.of(scheduleA));
+        when(scheduleRepository.findUpcomingByOrganizationId(eq(orgB), any(LocalDate.class)))
+                .thenReturn(List.of(scheduleB));
+        when(propertyRepository.findByIdIn(List.of(propertyA))).thenReturn(List.of(propA));
+        when(propertyRepository.findByIdIn(List.of(propertyB))).thenReturn(List.of(propB));
+        when(propertyRepository.findWithWarrantyExpiringOnOrAfter(any(UUID.class), any(LocalDate.class)))
+                .thenReturn(List.of());
+        when(preferencesRepository.findByUserId(userId)).thenReturn(Optional.empty());
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+
+        service.sendWeeklyDigests();
+
+        var body = ArgumentCaptor.forClass(String.class);
+        verify(notificationPort).send(eq("admin@example.com"), anyString(), body.capture());
+        assertThat(body.getValue())
+                .contains("Furnace service")
+                .contains("Chimney sweep");
     }
 }


### PR DESCRIPTION
Closes #287.

## What
Adds `WeeklyDigestService`, a scheduled job that sends each admin/owner **one** weekly digest email rolling up everything due in the next **30 days** — upcoming maintenance *and* property warranty expirations — so a user has one place to plan the week/month.

## How it satisfies the acceptance criteria
- **Groups upcoming maintenance + warranty per user** — reuses `HeraldCalendarService` (from #286) to assemble events; combines all of a user's organizations into a single digest, sorted by date.
- **Respects per-user category preferences (opt-out suppresses)** — preference filtering is delegated to `HeraldCalendarService`, so disabling `MAINTENANCE_DUE`/`WARRANTY_EXPIRING` (or notifications entirely) drops those items; opting out of everything sends nothing.
- **Empty digest is not sent** — users with nothing upcoming receive no email.
- **Uses the existing notification adapter** — sends via the Resilience4j-protected `NotificationPort`.
- **Unit tests for assembly + suppression** — 6 sociable tests wire the *real* `HeraldCalendarService` to mocked repositories so preference filtering is exercised end-to-end.

## Design notes / decisions
- **Recipients are owners/admins** (plain `MEMBER` roles are skipped), consistent with the existing `MaintenanceNotificationService` and `WarrantyAlertService`.
- **Stateless rollup** — unlike per-event reminders, the digest does not read/set `notification_sent_at`; an item can appear in a digest and still fire its own dated reminder.
- **Cron** `majordomo.notifications.digest-cron`, default `0 0 8 * * MON` (Mondays 08:00).

## ⚠️ Stacked on #286
This branch is **based on `286-herald-ical-feed` (PR #301), which is not yet merged**, because #287 depends on `HeraldCalendarService`, `MaintenanceScheduleRepository.findUpcomingByOrganizationId`, and `PropertyRepository.findWithWarrantyExpiringOnOrAfter` — all introduced in #286 and not yet on `main`. The PR base is set to the #286 branch so this diff shows only #287's changes. **Please merge #301 first, then retarget this PR to `main`** (it should then rebase cleanly).

## Testing
- `./mvnw test` — 606 tests green (includes ArchUnit + Checkstyle).
- Verified the negative tests have teeth: temporarily removing the 30-day filter, the MEMBER skip, and the preference gate each fails exactly its corresponding test.
- `MajordomoApplicationTests.contextLoads` passes — the new scheduled bean wires in a real Spring context.

## Docs
- `doc/notifications.md` — scheduled-jobs table + weekly-digest design section.
- `doc/user-guide/schedules.md` — weekly-digest subsection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)