### PR TITLE
dashboard: inline "mark serviced" on the due-in-30-days widget (#292)

### DIFF
--- a/doc/user-guide/schedules.md
+++ b/doc/user-guide/schedules.md
@@ -52,6 +52,15 @@ the new service record appears in the history. The
 `MAINTENANCE_DUE` notification (if you have it enabled) clears for
 this cycle.
 
+### Quick "mark serviced" from the dashboard
+
+The dashboard's **Upcoming Maintenance** panel (items due in the next 30
+days, soonest first) has a **Mark serviced** button on each row. Clicking
+it — after a confirmation — records a service performed today and rolls the
+schedule's `nextDue` forward by its frequency, without leaving the
+dashboard. Use it for the common case of "did it, log it"; use the detail
+form when you need to set the date, cost, or notes.
+
 ## Notifications
 
 Maintenance reminders are emailed when a schedule's `nextDue` is

--- a/src/main/java/com/majordomo/adapter/in/event/CacheEvictionListener.java
+++ b/src/main/java/com/majordomo/adapter/in/event/CacheEvictionListener.java
@@ -29,11 +29,12 @@ public class CacheEvictionListener {
     private static final Logger LOG = LoggerFactory.getLogger(CacheEvictionListener.class);
 
     private static final String SPEND_CACHE = "spend";
+    private static final String DASHBOARD_CACHE = "dashboard";
     private static final String APPLY_NOW_CACHE = "envoy-apply-now";
     private static final String APPLY_NOW_STAT_CACHE = "envoy-apply-now-stat";
 
     private static final Map<Class<?>, Set<String>> EVICTIONS = Map.of(
-            ServiceRecordCreated.class, Set.of(SPEND_CACHE),
+            ServiceRecordCreated.class, Set.of(SPEND_CACHE, DASHBOARD_CACHE),
             JobPostingScored.class, Set.of(APPLY_NOW_CACHE, APPLY_NOW_STAT_CACHE),
             PostingMarkedApplied.class, Set.of(APPLY_NOW_STAT_CACHE),
             PostingDismissed.class, Set.of(APPLY_NOW_STAT_CACHE));

--- a/src/main/java/com/majordomo/adapter/in/web/DashboardMaintenanceController.java
+++ b/src/main/java/com/majordomo/adapter/in/web/DashboardMaintenanceController.java
@@ -1,0 +1,49 @@
+package com.majordomo.adapter.in.web;
+
+import com.majordomo.application.herald.ScheduleAccessGuard;
+import com.majordomo.domain.port.in.herald.ManageScheduleUseCase;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+
+import java.time.LocalDate;
+import java.util.UUID;
+
+/**
+ * Handles the dashboard's inline "mark serviced" action. Verifies the caller may
+ * access the schedule's organization, then delegates to the Herald use case,
+ * which records the service and reschedules the next due date — no domain logic
+ * lives here.
+ */
+@Controller
+public class DashboardMaintenanceController {
+
+    private final ManageScheduleUseCase scheduleUseCase;
+    private final ScheduleAccessGuard accessGuard;
+
+    /**
+     * Constructs the controller.
+     *
+     * @param scheduleUseCase Herald schedule use case
+     * @param accessGuard     authorization guard for schedule access
+     */
+    public DashboardMaintenanceController(ManageScheduleUseCase scheduleUseCase,
+                                          ScheduleAccessGuard accessGuard) {
+        this.scheduleUseCase = scheduleUseCase;
+        this.accessGuard = accessGuard;
+    }
+
+    /**
+     * Marks a maintenance schedule serviced as of today, then returns to the dashboard.
+     *
+     * @param scheduleId the schedule to complete
+     * @return redirect to the dashboard
+     */
+    @PostMapping("/dashboard/maintenance/{scheduleId}/complete")
+    public String complete(@PathVariable UUID scheduleId) {
+        accessGuard.verifyForSchedule(scheduleId);
+        scheduleUseCase.completeService(scheduleId, LocalDate.now());
+        return "redirect:/dashboard";
+    }
+}

--- a/src/main/java/com/majordomo/application/DashboardService.java
+++ b/src/main/java/com/majordomo/application/DashboardService.java
@@ -1,6 +1,7 @@
 package com.majordomo.application;
 
 import com.majordomo.domain.model.DashboardSummary;
+import com.majordomo.domain.model.herald.MaintenanceSchedule;
 import com.majordomo.domain.model.steward.Property;
 import com.majordomo.domain.port.in.DashboardUseCase;
 import com.majordomo.domain.port.out.concierge.ContactRepository;
@@ -13,6 +14,7 @@ import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
@@ -71,7 +73,10 @@ public class DashboardService implements DashboardUseCase {
         LocalDate today = LocalDate.now();
 
         var allDueSoon = scheduleRepository.findDueBefore(today.plusDays(UPCOMING_DAYS))
-                .stream().filter(s -> propertyIds.contains(s.getPropertyId())).toList();
+                .stream()
+                .filter(s -> propertyIds.contains(s.getPropertyId()))
+                .sorted(Comparator.comparing(MaintenanceSchedule::getNextDue))
+                .toList();
         var overdueItems = allDueSoon.stream()
                 .filter(s -> s.getNextDue().isBefore(today)).toList();
         var upcomingMaintenance = allDueSoon.stream()

--- a/src/main/java/com/majordomo/application/herald/ScheduleService.java
+++ b/src/main/java/com/majordomo/application/herald/ScheduleService.java
@@ -107,6 +107,23 @@ public class ScheduleService implements ManageScheduleUseCase {
     }
 
     @Override
+    public MaintenanceSchedule completeService(UUID scheduleId, LocalDate completedOn) {
+        MaintenanceSchedule schedule = scheduleRepository.findById(scheduleId)
+                .orElseThrow(() -> new EntityNotFoundException(
+                        EntityType.MAINTENANCE_SCHEDULE.name(), scheduleId));
+
+        ServiceRecord record = new ServiceRecord();
+        record.setPropertyId(schedule.getPropertyId());
+        record.setPerformedOn(completedOn);
+        record.setDescription(schedule.getDescription());
+        recordService(scheduleId, record);
+
+        schedule.setNextDue(schedule.nextDueAfter(completedOn));
+        schedule.setUpdatedAt(Instant.now());
+        return scheduleRepository.save(schedule);
+    }
+
+    @Override
     public List<ServiceRecord> findRecordsByScheduleId(UUID scheduleId) {
         return serviceRecordRepository.findByScheduleId(scheduleId);
     }

--- a/src/main/java/com/majordomo/domain/model/herald/MaintenanceSchedule.java
+++ b/src/main/java/com/majordomo/domain/model/herald/MaintenanceSchedule.java
@@ -67,4 +67,31 @@ public class MaintenanceSchedule {
 
     public BigDecimal getEstimatedCost() { return estimatedCost; }
     public void setEstimatedCost(BigDecimal estimatedCost) { this.estimatedCost = estimatedCost; }
+
+    /**
+     * Computes the next due date after servicing on {@code base}, by advancing
+     * one interval of this schedule's {@link Frequency}. {@code CUSTOM} uses
+     * {@code customIntervalDays}.
+     *
+     * @param base the date the task was completed (advance from here)
+     * @return the next due date
+     * @throws IllegalStateException if the frequency is {@code CUSTOM} but
+     *                               {@code customIntervalDays} is unset
+     */
+    public LocalDate nextDueAfter(LocalDate base) {
+        return switch (frequency) {
+            case WEEKLY -> base.plusWeeks(1);
+            case MONTHLY -> base.plusMonths(1);
+            case QUARTERLY -> base.plusMonths(3);
+            case SEMI_ANNUAL -> base.plusMonths(6);
+            case ANNUAL -> base.plusYears(1);
+            case CUSTOM -> {
+                if (customIntervalDays == null) {
+                    throw new IllegalStateException(
+                            "CUSTOM frequency requires customIntervalDays");
+                }
+                yield base.plusDays(customIntervalDays);
+            }
+        };
+    }
 }

--- a/src/main/java/com/majordomo/domain/port/in/herald/ManageScheduleUseCase.java
+++ b/src/main/java/com/majordomo/domain/port/in/herald/ManageScheduleUseCase.java
@@ -80,6 +80,17 @@ public interface ManageScheduleUseCase {
     ServiceRecord recordService(UUID scheduleId, ServiceRecord record);
 
     /**
+     * Marks a schedule serviced on a date: records a service event against it and
+     * advances its next due date by one interval of its frequency. A one-click
+     * "mark serviced" that both logs the work and reschedules the recurrence.
+     *
+     * @param scheduleId  the schedule that was serviced
+     * @param completedOn the date the work was completed
+     * @return the updated schedule with its advanced next due date
+     */
+    MaintenanceSchedule completeService(UUID scheduleId, LocalDate completedOn);
+
+    /**
      * Lists all service records for a given schedule.
      *
      * @param scheduleId the maintenance schedule ID

--- a/src/main/resources/templates/dashboard.html
+++ b/src/main/resources/templates/dashboard.html
@@ -69,9 +69,15 @@
                                 <span class="font-medium text-gray-800" th:text="${item.description}">Task</span>
                                 <span class="block text-sm text-yellow-700" th:text="'Due: ' + ${item.nextDue}">Due date</span>
                             </div>
-                            <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-yellow-100 text-yellow-800">
-                                Upcoming
-                            </span>
+                            <form method="post"
+                                  th:action="@{|/dashboard/maintenance/${item.id}/complete|}"
+                                  th:onsubmit="|return confirm('Mark this task as serviced today? This logs a service record and reschedules the next occurrence.')|">
+                                <button type="submit"
+                                        th:aria-label="|Mark ${item.description} as serviced today|"
+                                        class="inline-flex items-center rounded-md bg-green-600 px-2.5 py-1 text-xs font-medium text-white hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-1">
+                                    Mark serviced
+                                </button>
+                            </form>
                         </li>
                     </ul>
                 </div>

--- a/src/test/java/com/majordomo/adapter/in/event/CacheEvictionListenerTest.java
+++ b/src/test/java/com/majordomo/adapter/in/event/CacheEvictionListenerTest.java
@@ -24,18 +24,21 @@ import static org.mockito.Mockito.when;
  */
 class CacheEvictionListenerTest {
 
-    /** Spend cache should be cleared when a service record is created. */
+    /** Spend and dashboard caches should be cleared when a service record is created. */
     @Test
-    void serviceRecordCreatedEvictsSpendCache() {
+    void serviceRecordCreatedEvictsSpendAndDashboardCaches() {
         var cacheManager = mock(CacheManager.class);
-        var cache = mock(Cache.class);
-        when(cacheManager.getCache("spend")).thenReturn(cache);
+        var spendCache = mock(Cache.class);
+        var dashboardCache = mock(Cache.class);
+        when(cacheManager.getCache("spend")).thenReturn(spendCache);
+        when(cacheManager.getCache("dashboard")).thenReturn(dashboardCache);
 
         var listener = new CacheEvictionListener(cacheManager);
         listener.onDomainEvent(new ServiceRecordCreated(
                 UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID(), null, Instant.now()));
 
-        verify(cache).clear();
+        verify(spendCache).clear();
+        verify(dashboardCache).clear();
     }
 
     /** APPLY_NOW dashboard caches (postings + stat) should both be cleared when a posting is scored. */

--- a/src/test/java/com/majordomo/adapter/in/web/DashboardMaintenanceControllerTest.java
+++ b/src/test/java/com/majordomo/adapter/in/web/DashboardMaintenanceControllerTest.java
@@ -1,0 +1,52 @@
+package com.majordomo.adapter.in.web;
+
+import com.majordomo.adapter.in.web.config.OAuth2UserService;
+import com.majordomo.adapter.in.web.config.SecurityConfig;
+import com.majordomo.application.herald.ScheduleAccessGuard;
+import com.majordomo.domain.model.UuidFactory;
+import com.majordomo.domain.port.in.herald.ManageScheduleUseCase;
+import com.majordomo.domain.port.out.identity.ApiKeyRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDate;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/** Slice tests for the dashboard "mark serviced" action (#292). */
+@WebMvcTest(DashboardMaintenanceController.class)
+@Import(SecurityConfig.class)
+class DashboardMaintenanceControllerTest {
+
+    @Autowired MockMvc mvc;
+
+    @MockitoBean ManageScheduleUseCase scheduleUseCase;
+    @MockitoBean ScheduleAccessGuard accessGuard;
+    @MockitoBean OAuth2UserService oAuth2UserService;
+    @MockitoBean ApiKeyRepository apiKeyRepository;
+
+    @Test
+    @WithMockUser
+    void completeVerifiesAccessInvokesUseCaseAndRedirects() throws Exception {
+        UUID scheduleId = UuidFactory.newId();
+
+        mvc.perform(post("/dashboard/maintenance/{id}/complete", scheduleId).with(csrf()))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/dashboard"));
+
+        verify(accessGuard).verifyForSchedule(scheduleId);
+        verify(scheduleUseCase).completeService(eq(scheduleId), any(LocalDate.class));
+    }
+}

--- a/src/test/java/com/majordomo/application/DashboardServiceTest.java
+++ b/src/test/java/com/majordomo/application/DashboardServiceTest.java
@@ -130,6 +130,35 @@ class DashboardServiceTest {
     }
 
     @Test
+    void getSummaryOrdersUpcomingMaintenanceSoonestFirst() {
+        Property property = new Property();
+        property.setId(propertyId);
+        when(propertyRepository.findByOrganizationId(orgId)).thenReturn(List.of(property));
+        when(contactRepository.findByOrganizationId(orgId)).thenReturn(List.of());
+
+        MaintenanceSchedule later = new MaintenanceSchedule();
+        later.setPropertyId(propertyId);
+        later.setNextDue(LocalDate.now().plusDays(20));
+
+        MaintenanceSchedule sooner = new MaintenanceSchedule();
+        sooner.setPropertyId(propertyId);
+        sooner.setNextDue(LocalDate.now().plusDays(3));
+
+        // Repository returns them out of order; the service must sort soonest-first.
+        when(scheduleRepository.findDueBefore(any(LocalDate.class)))
+                .thenReturn(List.of(later, sooner));
+        when(serviceRecordRepository.findRecentByPropertyIds(anyList(), anyInt()))
+                .thenReturn(List.of());
+        when(ledgerQueryRepository.totalMaintenanceCostByOrganization(orgId))
+                .thenReturn(BigDecimal.ZERO);
+
+        DashboardSummary summary = dashboardService.getSummary(orgId);
+
+        assertEquals(List.of(LocalDate.now().plusDays(3), LocalDate.now().plusDays(20)),
+                summary.upcomingMaintenance().stream().map(MaintenanceSchedule::getNextDue).toList());
+    }
+
+    @Test
     void getSummaryFiltersOverdueItemsByOrgProperties() {
         Property property = new Property();
         property.setId(propertyId);

--- a/src/test/java/com/majordomo/application/herald/ScheduleCompleteServiceIntegrationTest.java
+++ b/src/test/java/com/majordomo/application/herald/ScheduleCompleteServiceIntegrationTest.java
@@ -1,0 +1,67 @@
+package com.majordomo.application.herald;
+
+import com.majordomo.IntegrationTest;
+import com.majordomo.domain.model.UuidFactory;
+import com.majordomo.domain.model.herald.Frequency;
+import com.majordomo.domain.model.herald.MaintenanceSchedule;
+import com.majordomo.domain.model.identity.Organization;
+import com.majordomo.domain.model.steward.Property;
+import com.majordomo.domain.model.steward.PropertyStatus;
+import com.majordomo.domain.port.in.herald.ManageScheduleUseCase;
+import com.majordomo.domain.port.out.herald.MaintenanceScheduleRepository;
+import com.majordomo.domain.port.out.herald.ServiceRecordRepository;
+import com.majordomo.domain.port.out.identity.OrganizationRepository;
+import com.majordomo.domain.port.out.steward.PropertyRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.time.LocalDate;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * End-to-end persistence for the dashboard "mark serviced" flow (#292): completing
+ * a schedule records a service row and advances the schedule's next due date, both
+ * durable in Postgres.
+ */
+@IntegrationTest
+class ScheduleCompleteServiceIntegrationTest {
+
+    @Autowired ManageScheduleUseCase schedules;
+    @Autowired MaintenanceScheduleRepository scheduleRepository;
+    @Autowired ServiceRecordRepository serviceRecords;
+    @Autowired OrganizationRepository organizations;
+    @Autowired PropertyRepository properties;
+
+    @Test
+    void completeServiceRecordsServiceAndAdvancesNextDue() {
+        UUID orgId = UuidFactory.newId();
+        organizations.save(new Organization(orgId, "org-" + orgId));
+
+        Property furnace = new Property();
+        furnace.setId(UuidFactory.newId());
+        furnace.setOrganizationId(orgId);
+        furnace.setName("Furnace");
+        furnace.setStatus(PropertyStatus.ACTIVE);
+        properties.save(furnace);
+
+        MaintenanceSchedule schedule = new MaintenanceSchedule();
+        schedule.setPropertyId(furnace.getId());
+        schedule.setDescription("Replace HVAC filter");
+        schedule.setFrequency(Frequency.MONTHLY);
+        schedule.setNextDue(LocalDate.of(2026, 7, 15));
+        MaintenanceSchedule created = schedules.create(schedule);
+
+        schedules.completeService(created.getId(), LocalDate.of(2026, 7, 20));
+
+        MaintenanceSchedule reloaded = scheduleRepository.findById(created.getId()).orElseThrow();
+        assertThat(reloaded.getNextDue()).isEqualTo(LocalDate.of(2026, 8, 20));
+        assertThat(serviceRecords.findByScheduleId(created.getId()))
+                .singleElement()
+                .satisfies(r -> {
+                    assertThat(r.getPerformedOn()).isEqualTo(LocalDate.of(2026, 7, 20));
+                    assertThat(r.getPropertyId()).isEqualTo(furnace.getId());
+                });
+    }
+}

--- a/src/test/java/com/majordomo/application/herald/ScheduleServiceTest.java
+++ b/src/test/java/com/majordomo/application/herald/ScheduleServiceTest.java
@@ -1,6 +1,8 @@
 package com.majordomo.application.herald;
 
 import com.majordomo.domain.model.EntityNotFoundException;
+import com.majordomo.domain.model.event.ServiceRecordCreated;
+import com.majordomo.domain.model.herald.Frequency;
 import com.majordomo.domain.model.herald.MaintenanceSchedule;
 import com.majordomo.domain.model.herald.ServiceRecord;
 import com.majordomo.domain.port.out.EventPublisher;
@@ -18,6 +20,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import static org.mockito.Mockito.mock;
 
 import java.time.Instant;
+import java.time.LocalDate;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -83,6 +86,45 @@ class ScheduleServiceTest {
         ArgumentCaptor<ServiceRecord> captor = ArgumentCaptor.forClass(ServiceRecord.class);
         verify(serviceRecordRepository).save(captor.capture());
         assertEquals(scheduleId, captor.getValue().getScheduleId());
+    }
+
+    @Test
+    void completeServiceRecordsServiceAndAdvancesNextDue() {
+        UUID scheduleId = UUID.randomUUID();
+        var schedule = new MaintenanceSchedule();
+        schedule.setId(scheduleId);
+        schedule.setPropertyId(UUID.randomUUID());
+        schedule.setDescription("HVAC filter");
+        schedule.setFrequency(Frequency.MONTHLY);
+        schedule.setNextDue(LocalDate.of(2026, 7, 15));
+
+        when(scheduleRepository.findById(scheduleId)).thenReturn(Optional.of(schedule));
+        when(serviceRecordRepository.save(any(ServiceRecord.class)))
+                .thenAnswer(inv -> inv.getArgument(0));
+        when(scheduleRepository.save(any(MaintenanceSchedule.class)))
+                .thenAnswer(inv -> inv.getArgument(0));
+
+        var updated = scheduleService.completeService(scheduleId, LocalDate.of(2026, 7, 20));
+
+        // Reschedules one interval after the completion date, not the old due date.
+        assertEquals(LocalDate.of(2026, 8, 20), updated.getNextDue());
+
+        ArgumentCaptor<ServiceRecord> recCaptor = ArgumentCaptor.forClass(ServiceRecord.class);
+        verify(serviceRecordRepository).save(recCaptor.capture());
+        ServiceRecord rec = recCaptor.getValue();
+        assertEquals(LocalDate.of(2026, 7, 20), rec.getPerformedOn());
+        assertEquals(schedule.getPropertyId(), rec.getPropertyId());
+        assertEquals(scheduleId, rec.getScheduleId());
+        verify(eventPublisher).publish(any(ServiceRecordCreated.class));
+    }
+
+    @Test
+    void completeServiceThrowsWhenScheduleMissing() {
+        UUID id = UUID.randomUUID();
+        when(scheduleRepository.findById(id)).thenReturn(Optional.empty());
+
+        assertThrows(EntityNotFoundException.class,
+                () -> scheduleService.completeService(id, LocalDate.now()));
     }
 
     @Test

--- a/src/test/java/com/majordomo/domain/model/herald/MaintenanceScheduleNextDueTest.java
+++ b/src/test/java/com/majordomo/domain/model/herald/MaintenanceScheduleNextDueTest.java
@@ -1,0 +1,46 @@
+package com.majordomo.domain.model.herald;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class MaintenanceScheduleNextDueTest {
+
+    private MaintenanceSchedule schedule(Frequency frequency, Integer customDays) {
+        var s = new MaintenanceSchedule();
+        s.setFrequency(frequency);
+        s.setCustomIntervalDays(customDays);
+        return s;
+    }
+
+    @Test
+    void advancesByFrequencyInterval() {
+        LocalDate base = LocalDate.of(2026, 7, 15);
+        assertThat(schedule(Frequency.WEEKLY, null).nextDueAfter(base))
+                .isEqualTo(LocalDate.of(2026, 7, 22));
+        assertThat(schedule(Frequency.MONTHLY, null).nextDueAfter(base))
+                .isEqualTo(LocalDate.of(2026, 8, 15));
+        assertThat(schedule(Frequency.QUARTERLY, null).nextDueAfter(base))
+                .isEqualTo(LocalDate.of(2026, 10, 15));
+        assertThat(schedule(Frequency.SEMI_ANNUAL, null).nextDueAfter(base))
+                .isEqualTo(LocalDate.of(2027, 1, 15));
+        assertThat(schedule(Frequency.ANNUAL, null).nextDueAfter(base))
+                .isEqualTo(LocalDate.of(2027, 7, 15));
+    }
+
+    @Test
+    void customFrequencyUsesCustomIntervalDays() {
+        LocalDate base = LocalDate.of(2026, 7, 15);
+        assertThat(schedule(Frequency.CUSTOM, 10).nextDueAfter(base))
+                .isEqualTo(LocalDate.of(2026, 7, 25));
+    }
+
+    @Test
+    void customFrequencyWithoutIntervalIsRejected() {
+        assertThatThrownBy(() -> schedule(Frequency.CUSTOM, null).nextDueAfter(LocalDate.now()))
+                .isInstanceOf(IllegalStateException.class);
+    }
+}


### PR DESCRIPTION
Closes #292.

## What
The dashboard already listed upcoming (next-30-day) maintenance but was read-only. This turns it into a light action surface: each upcoming item gets a one-click **Mark serviced** that records a service and reschedules the next occurrence — without leaving the dashboard.

## Built in TDD increments
1. **`MaintenanceSchedule.nextDueAfter(base)`** — advances a due date by one interval of its `Frequency` (CUSTOM uses `customIntervalDays`).
2. **`ManageScheduleUseCase.completeService(scheduleId, completedOn)`** — records a service event (reusing `recordService`, so `ServiceRecordCreated` still fires) and advances `nextDue`. All domain logic lives here, not the controller.
3. **Cache + ordering** — `ServiceRecordCreated` now also evicts the `dashboard` cache (so the widget refreshes immediately); `DashboardService` sorts due-soon items soonest-first.
4. **`DashboardMaintenanceController`** — `POST /dashboard/maintenance/{id}/complete`: verifies org access via `ScheduleAccessGuard`, calls the use case, redirects.
5. **Accessible action** — native `<button>` in a POST form: `aria-label`, visible focus ring, keyboard-operable, JS confirm.

## Acceptance criteria
- [x] Widget lists next-30-day maintenance for the user's org, soonest first
- [x] Inline action records a service record and advances the schedule
- [x] Action goes through the existing application use case (no controller-side domain logic)
- [x] Accessible: keyboard-operable action, proper labels/focus
- [x] Tests for the assembly query (ordering) + complete-service flow

## Testing
TDD throughout. **589 unit tests** pass, Checkstyle clean. Testcontainers Postgres integration test proves the complete-service flow persists (service record row created + `nextDue` advanced).

## Note (out of scope — follow-up flagged)
While here I found that the schedule **detail-page** `recordService` does *not* advance `nextDue`, though `doc/user-guide/schedules.md` says it does — a pre-existing inconsistency, now more visible since this dashboard action *does* reschedule. Flagged as a separate task to reconcile rather than change that behavior here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)