### PR TITLE
test: fix EnvoyVerticalSliceIntegrationTest double-seeding the default rubric

### DIFF
--- a/src/test/java/com/majordomo/application/envoy/EnvoyVerticalSliceIntegrationTest.java
+++ b/src/test/java/com/majordomo/application/envoy/EnvoyVerticalSliceIntegrationTest.java
@@ -74,8 +74,13 @@ class EnvoyVerticalSliceIntegrationTest {
 
     @BeforeEach
     void seedDefaultRubric() {
+        // Org-scoped "default" rubric (not Optional.empty()): a system default now
+        // ships via migration V15, so seeding another system-level "default" v1
+        // violates the (name, version) WHERE organization_id IS NULL unique index.
+        // An org-scoped rubric uses the separate (organization_id, name, version)
+        // index and, being org-specific, is preferred by findActiveByName for ORG_ID.
         rubrics.save(new Rubric(
-                UuidFactory.newId(), Optional.empty(), 1, "default",
+                UuidFactory.newId(), Optional.of(ORG_ID), 1, "default",
                 List.of(),
                 List.of(
                         cat("compensation", 25, tier("Good", 18)),


### PR DESCRIPTION
## Problem
`EnvoyVerticalSliceIntegrationTest` failed **deterministically** — its `@BeforeEach` seeded a system-level `default` rubric (`organizationId` null, v1), but migration **V15** now ships that same system-default rubric. The second insert violated the `envoy_rubric (name, version) WHERE organization_id IS NULL` unique index, so the test errored in setup and the **integration suite was quietly red**. (The test predates V15; the migration made its own seeding redundant and conflicting.)

## Fix
Make the seeded rubric **org-scoped** (`Optional.of(ORG_ID)`) instead of system-default:
- It uses the separate `(organization_id, name, version)` unique index → no collision with V15's system default.
- `findActiveByName("default", ORG_ID)` prefers the org-specific rubric, so the test still scores against its own exact categories/tiers/thresholds — all assertions unchanged.

One-line change (plus an explanatory comment). `envoy_rubric.organization_id` is nullable with no FK, so no extra seeding is needed.

## Verification
Full suite now green: **618 unit + 20 integration** tests pass (`./mvnw -Pintegration-tests verify`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)