### PR TITLE
fix(herald): advance nextDue when a service is recorded (#306)

### DIFF
--- a/doc/user-guide/schedules.md
+++ b/doc/user-guide/schedules.md
@@ -47,10 +47,11 @@ On the schedule detail page, the **+ Record service** form takes:
 | **Cost** | Optional decimal. Feeds the Ledger. |
 | **Notes** | Optional. |
 
-On save, the schedule's `nextDue` rolls forward by its frequency and
-the new service record appears in the history. The
-`MAINTENANCE_DUE` notification (if you have it enabled) clears for
-this cycle.
+On save, the schedule's `nextDue` rolls forward by one interval of its
+frequency past the **performed on** date, and the new service record
+appears in the history. The `MAINTENANCE_DUE` notification (if you have
+it enabled) clears for this cycle. This matches the dashboard's
+**Mark serviced** shortcut below — both record the work and reschedule.
 
 ### Quick "mark serviced" from the dashboard
 

--- a/src/main/java/com/majordomo/application/herald/ScheduleService.java
+++ b/src/main/java/com/majordomo/application/herald/ScheduleService.java
@@ -94,6 +94,32 @@ public class ScheduleService implements ManageScheduleUseCase {
 
     @Override
     public ServiceRecord recordService(UUID scheduleId, ServiceRecord record) {
+        MaintenanceSchedule schedule = requireSchedule(scheduleId);
+        var saved = persistRecord(scheduleId, record);
+        advance(schedule, saved.getPerformedOn());
+        return saved;
+    }
+
+    @Override
+    public MaintenanceSchedule completeService(UUID scheduleId, LocalDate completedOn) {
+        MaintenanceSchedule schedule = requireSchedule(scheduleId);
+
+        ServiceRecord record = new ServiceRecord();
+        record.setPropertyId(schedule.getPropertyId());
+        record.setPerformedOn(completedOn);
+        record.setDescription(schedule.getDescription());
+        persistRecord(scheduleId, record);
+
+        return advance(schedule, completedOn);
+    }
+
+    private MaintenanceSchedule requireSchedule(UUID scheduleId) {
+        return scheduleRepository.findById(scheduleId)
+                .orElseThrow(() -> new EntityNotFoundException(
+                        EntityType.MAINTENANCE_SCHEDULE.name(), scheduleId));
+    }
+
+    private ServiceRecord persistRecord(UUID scheduleId, ServiceRecord record) {
         record.setId(UuidFactory.newId());
         record.setScheduleId(scheduleId);
         var saved = serviceRecordRepository.save(record);
@@ -106,19 +132,8 @@ public class ScheduleService implements ManageScheduleUseCase {
         return saved;
     }
 
-    @Override
-    public MaintenanceSchedule completeService(UUID scheduleId, LocalDate completedOn) {
-        MaintenanceSchedule schedule = scheduleRepository.findById(scheduleId)
-                .orElseThrow(() -> new EntityNotFoundException(
-                        EntityType.MAINTENANCE_SCHEDULE.name(), scheduleId));
-
-        ServiceRecord record = new ServiceRecord();
-        record.setPropertyId(schedule.getPropertyId());
-        record.setPerformedOn(completedOn);
-        record.setDescription(schedule.getDescription());
-        recordService(scheduleId, record);
-
-        schedule.setNextDue(schedule.nextDueAfter(completedOn));
+    private MaintenanceSchedule advance(MaintenanceSchedule schedule, LocalDate servicedOn) {
+        schedule.setNextDue(schedule.nextDueAfter(servicedOn));
         schedule.setUpdatedAt(Instant.now());
         return scheduleRepository.save(schedule);
     }

--- a/src/test/java/com/majordomo/application/herald/ScheduleServiceEventTest.java
+++ b/src/test/java/com/majordomo/application/herald/ScheduleServiceEventTest.java
@@ -1,6 +1,8 @@
 package com.majordomo.application.herald;
 
 import com.majordomo.domain.model.event.ServiceRecordCreated;
+import com.majordomo.domain.model.herald.Frequency;
+import com.majordomo.domain.model.herald.MaintenanceSchedule;
 import com.majordomo.domain.model.herald.ServiceRecord;
 import com.majordomo.domain.model.steward.Property;
 import com.majordomo.domain.port.out.EventPublisher;
@@ -15,6 +17,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.time.LocalDate;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -62,6 +65,13 @@ class ScheduleServiceEventTest {
         var record = new ServiceRecord();
         record.setDescription("Filter replaced");
         record.setPropertyId(propertyId);
+        record.setPerformedOn(LocalDate.of(2026, 7, 20));
+
+        var schedule = new MaintenanceSchedule();
+        schedule.setId(scheduleId);
+        schedule.setFrequency(Frequency.MONTHLY);
+        schedule.setNextDue(LocalDate.of(2026, 7, 15));
+        when(scheduleRepository.findById(scheduleId)).thenReturn(Optional.of(schedule));
 
         Property property = new Property();
         property.setId(propertyId);
@@ -69,6 +79,8 @@ class ScheduleServiceEventTest {
         when(propertyRepository.findById(propertyId)).thenReturn(Optional.of(property));
 
         when(serviceRecordRepository.save(any(ServiceRecord.class)))
+                .thenAnswer(inv -> inv.getArgument(0));
+        when(scheduleRepository.save(any(MaintenanceSchedule.class)))
                 .thenAnswer(inv -> inv.getArgument(0));
 
         scheduleService.recordService(scheduleId, record);

--- a/src/test/java/com/majordomo/application/herald/ScheduleServiceTest.java
+++ b/src/test/java/com/majordomo/application/herald/ScheduleServiceTest.java
@@ -72,10 +72,19 @@ class ScheduleServiceTest {
     @Test
     void recordServiceLinksScheduleId() {
         UUID scheduleId = UUID.randomUUID();
+        var schedule = new MaintenanceSchedule();
+        schedule.setId(scheduleId);
+        schedule.setFrequency(Frequency.MONTHLY);
+        schedule.setNextDue(LocalDate.of(2026, 7, 15));
+
         var record = new ServiceRecord();
         record.setDescription("Filter replaced");
+        record.setPerformedOn(LocalDate.of(2026, 7, 20));
 
+        when(scheduleRepository.findById(scheduleId)).thenReturn(Optional.of(schedule));
         when(serviceRecordRepository.save(any(ServiceRecord.class)))
+                .thenAnswer(inv -> inv.getArgument(0));
+        when(scheduleRepository.save(any(MaintenanceSchedule.class)))
                 .thenAnswer(inv -> inv.getArgument(0));
 
         var result = scheduleService.recordService(scheduleId, record);
@@ -86,6 +95,45 @@ class ScheduleServiceTest {
         ArgumentCaptor<ServiceRecord> captor = ArgumentCaptor.forClass(ServiceRecord.class);
         verify(serviceRecordRepository).save(captor.capture());
         assertEquals(scheduleId, captor.getValue().getScheduleId());
+    }
+
+    @Test
+    void recordServiceAdvancesNextDueFromPerformedOn() {
+        UUID scheduleId = UUID.randomUUID();
+        var schedule = new MaintenanceSchedule();
+        schedule.setId(scheduleId);
+        schedule.setPropertyId(UUID.randomUUID());
+        schedule.setDescription("HVAC filter");
+        schedule.setFrequency(Frequency.MONTHLY);
+        schedule.setNextDue(LocalDate.of(2026, 7, 15));
+
+        var record = new ServiceRecord();
+        record.setDescription("Filter replaced");
+        record.setPerformedOn(LocalDate.of(2026, 7, 20));
+
+        when(scheduleRepository.findById(scheduleId)).thenReturn(Optional.of(schedule));
+        when(serviceRecordRepository.save(any(ServiceRecord.class)))
+                .thenAnswer(inv -> inv.getArgument(0));
+        when(scheduleRepository.save(any(MaintenanceSchedule.class)))
+                .thenAnswer(inv -> inv.getArgument(0));
+
+        scheduleService.recordService(scheduleId, record);
+
+        // Advances one interval past the performed-on date, matching the dashboard
+        // "mark serviced" flow and the documented detail-page behaviour.
+        ArgumentCaptor<MaintenanceSchedule> captor =
+                ArgumentCaptor.forClass(MaintenanceSchedule.class);
+        verify(scheduleRepository).save(captor.capture());
+        assertEquals(LocalDate.of(2026, 8, 20), captor.getValue().getNextDue());
+    }
+
+    @Test
+    void recordServiceThrowsWhenScheduleMissing() {
+        UUID scheduleId = UUID.randomUUID();
+        when(scheduleRepository.findById(scheduleId)).thenReturn(Optional.empty());
+
+        assertThrows(EntityNotFoundException.class,
+                () -> scheduleService.recordService(scheduleId, new ServiceRecord()));
     }
 
     @Test


### PR DESCRIPTION
Closes #306.

## Problem

The Herald schedule flow was inconsistent about rescheduling:

- **Docs** (`doc/user-guide/schedules.md`, "Recording a service event") say: *"On save, the schedule's `nextDue` rolls forward by its frequency."*
- **Dashboard** "Mark serviced" (#292, `completeService` → `MaintenanceSchedule.nextDueAfter`) records a service **and** advances `nextDue`.
- **Detail page** (`SchedulePageController.addRecord`, `POST /schedules/{id}/records`) and **REST** (`ScheduleController.recordService`, `POST /api/schedules/{id}/records`) both call `ScheduleService.recordService`, which only persisted the `ServiceRecord` and published `ServiceRecordCreated` — **no advance**. So logging a service from the detail page or API left the schedule stuck on its old due date.

## Decision — advance on record (option a)

Checked the intended contract before changing behaviour:

- The detail form has **no `nextDue` field** (only Performed on, Description, Cost, Notes) — there's no supported "record without reschedule" workflow, which rules out the "the form lets you set nextDue" rationale for correcting the docs instead.
- The docs already promise advance-on-save.
- The dashboard already advances via `completeService`.

So the code was the bug, not the docs.

## Change

- `ScheduleService.recordService` now loads the schedule (404s via `EntityNotFoundException` if missing) and advances `nextDue` to one interval past the record's `performedOn` date.
- Extracted shared `requireSchedule` / `persistRecord` / `advance` helpers; `completeService` reuses them, so the dashboard one-click path and the detail/REST path are now the same persist-and-advance logic with **no double advance**.
- Docs clarified to name the performed-on date as the base and to note it matches the dashboard shortcut.

The web/REST controllers are unchanged — they already call `recordService`; they inherit the corrected behaviour.

## Tests (strict TDD, red → green)

- New `ScheduleServiceTest.recordServiceAdvancesNextDueFromPerformedOn` and `recordServiceThrowsWhenScheduleMissing` (watched both fail first).
- Updated `recordServiceLinksScheduleId` and `ScheduleServiceEventTest` to the new contract (they had encoded the old no-advance behaviour and never stubbed `findById`).
- `completeService` unit + `ScheduleCompleteServiceIntegrationTest` (real Postgres) still green — exactly one service row, `nextDue` advanced.

## Verification

- `./mvnw verify` → **620 tests, 0 failures** (Checkstyle + ArchUnit green).
- `./mvnw -Pintegration-tests verify -Dit.test=ScheduleCompleteServiceIntegrationTest` → green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)