### PR TITLE
herald: default ServiceRecord.propertyId from the schedule (#308)

### DIFF
--- a/src/main/java/com/majordomo/application/herald/ScheduleService.java
+++ b/src/main/java/com/majordomo/application/herald/ScheduleService.java
@@ -95,7 +95,7 @@ public class ScheduleService implements ManageScheduleUseCase {
     @Override
     public ServiceRecord recordService(UUID scheduleId, ServiceRecord record) {
         MaintenanceSchedule schedule = requireSchedule(scheduleId);
-        var saved = persistRecord(scheduleId, record);
+        var saved = persistRecord(schedule, record);
         advance(schedule, saved.getPerformedOn());
         return saved;
     }
@@ -105,10 +105,9 @@ public class ScheduleService implements ManageScheduleUseCase {
         MaintenanceSchedule schedule = requireSchedule(scheduleId);
 
         ServiceRecord record = new ServiceRecord();
-        record.setPropertyId(schedule.getPropertyId());
         record.setPerformedOn(completedOn);
         record.setDescription(schedule.getDescription());
-        persistRecord(scheduleId, record);
+        persistRecord(schedule, record);
 
         return advance(schedule, completedOn);
     }
@@ -119,9 +118,15 @@ public class ScheduleService implements ManageScheduleUseCase {
                         EntityType.MAINTENANCE_SCHEDULE.name(), scheduleId));
     }
 
-    private ServiceRecord persistRecord(UUID scheduleId, ServiceRecord record) {
+    private ServiceRecord persistRecord(MaintenanceSchedule schedule, ServiceRecord record) {
         record.setId(UuidFactory.newId());
-        record.setScheduleId(scheduleId);
+        record.setScheduleId(schedule.getId());
+        if (record.getPropertyId() == null) {
+            // The detail-page form doesn't carry a propertyId; default it from the
+            // schedule so the NOT NULL column (and the ServiceRecordCreated event's
+            // org resolution) are satisfied. Explicit values are preserved.
+            record.setPropertyId(schedule.getPropertyId());
+        }
         var saved = serviceRecordRepository.save(record);
         UUID organizationId = propertyRepository.findById(saved.getPropertyId())
                 .map(Property::getOrganizationId)

--- a/src/test/java/com/majordomo/application/herald/ScheduleCompleteServiceIntegrationTest.java
+++ b/src/test/java/com/majordomo/application/herald/ScheduleCompleteServiceIntegrationTest.java
@@ -64,4 +64,38 @@ class ScheduleCompleteServiceIntegrationTest {
                     assertThat(r.getPropertyId()).isEqualTo(furnace.getId());
                 });
     }
+
+    @Test
+    void recordServiceFromDetailFormWithoutPropertyIdPersists() {
+        // Reproduces #308: the detail-page form builds a ServiceRecord with no
+        // propertyId. Since service_record.property_id is NOT NULL, this would
+        // throw a constraint violation on Postgres before the fix.
+        UUID orgId = UuidFactory.newId();
+        organizations.save(new Organization(orgId, "org-" + orgId));
+
+        Property furnace = new Property();
+        furnace.setId(UuidFactory.newId());
+        furnace.setOrganizationId(orgId);
+        furnace.setName("Furnace");
+        furnace.setStatus(PropertyStatus.ACTIVE);
+        properties.save(furnace);
+
+        MaintenanceSchedule schedule = new MaintenanceSchedule();
+        schedule.setPropertyId(furnace.getId());
+        schedule.setDescription("Replace HVAC filter");
+        schedule.setFrequency(Frequency.MONTHLY);
+        schedule.setNextDue(LocalDate.of(2026, 7, 15));
+        MaintenanceSchedule created = schedules.create(schedule);
+
+        var record = new com.majordomo.domain.model.herald.ServiceRecord();
+        record.setDescription("Filter replaced");
+        record.setPerformedOn(LocalDate.of(2026, 7, 20));
+        // no propertyId set — exactly what SchedulePageController.addRecord sends
+
+        schedules.recordService(created.getId(), record);
+
+        assertThat(serviceRecords.findByScheduleId(created.getId()))
+                .singleElement()
+                .satisfies(r -> assertThat(r.getPropertyId()).isEqualTo(furnace.getId()));
+    }
 }

--- a/src/test/java/com/majordomo/application/herald/ScheduleServiceTest.java
+++ b/src/test/java/com/majordomo/application/herald/ScheduleServiceTest.java
@@ -98,6 +98,64 @@ class ScheduleServiceTest {
     }
 
     @Test
+    void recordServiceDefaultsPropertyIdFromScheduleWhenAbsent() {
+        UUID scheduleId = UUID.randomUUID();
+        UUID propertyId = UUID.randomUUID();
+        var schedule = new MaintenanceSchedule();
+        schedule.setId(scheduleId);
+        schedule.setPropertyId(propertyId);
+        schedule.setFrequency(Frequency.MONTHLY);
+        schedule.setNextDue(LocalDate.of(2026, 7, 15));
+
+        // The detail-page form builds a record without a propertyId; the service
+        // must fill it from the schedule so the NOT NULL column is satisfied.
+        var record = new ServiceRecord();
+        record.setDescription("Filter replaced");
+        record.setPerformedOn(LocalDate.of(2026, 7, 20));
+
+        when(scheduleRepository.findById(scheduleId)).thenReturn(Optional.of(schedule));
+        when(serviceRecordRepository.save(any(ServiceRecord.class)))
+                .thenAnswer(inv -> inv.getArgument(0));
+        when(scheduleRepository.save(any(MaintenanceSchedule.class)))
+                .thenAnswer(inv -> inv.getArgument(0));
+
+        scheduleService.recordService(scheduleId, record);
+
+        ArgumentCaptor<ServiceRecord> captor = ArgumentCaptor.forClass(ServiceRecord.class);
+        verify(serviceRecordRepository).save(captor.capture());
+        assertEquals(propertyId, captor.getValue().getPropertyId());
+    }
+
+    @Test
+    void recordServicePreservesExplicitPropertyId() {
+        UUID scheduleId = UUID.randomUUID();
+        UUID schedulePropertyId = UUID.randomUUID();
+        UUID recordPropertyId = UUID.randomUUID();
+        var schedule = new MaintenanceSchedule();
+        schedule.setId(scheduleId);
+        schedule.setPropertyId(schedulePropertyId);
+        schedule.setFrequency(Frequency.MONTHLY);
+        schedule.setNextDue(LocalDate.of(2026, 7, 15));
+
+        var record = new ServiceRecord();
+        record.setPropertyId(recordPropertyId);
+        record.setDescription("Filter replaced");
+        record.setPerformedOn(LocalDate.of(2026, 7, 20));
+
+        when(scheduleRepository.findById(scheduleId)).thenReturn(Optional.of(schedule));
+        when(serviceRecordRepository.save(any(ServiceRecord.class)))
+                .thenAnswer(inv -> inv.getArgument(0));
+        when(scheduleRepository.save(any(MaintenanceSchedule.class)))
+                .thenAnswer(inv -> inv.getArgument(0));
+
+        scheduleService.recordService(scheduleId, record);
+
+        ArgumentCaptor<ServiceRecord> captor = ArgumentCaptor.forClass(ServiceRecord.class);
+        verify(serviceRecordRepository).save(captor.capture());
+        assertEquals(recordPropertyId, captor.getValue().getPropertyId());
+    }
+
+    @Test
     void recordServiceAdvancesNextDueFromPerformedOn() {
         UUID scheduleId = UUID.randomUUID();
         var schedule = new MaintenanceSchedule();


### PR DESCRIPTION
Closes #308.

## Bug
Recording a service from the schedule **detail page** (`SchedulePageController.addRecord`) builds a `ServiceRecord` with no `propertyId`, but `service_record.property_id` is `NOT NULL` → a constraint violation on real Postgres, plus a null `organizationId` on the `ServiceRecordCreated` event. It slipped through because the controller/service unit tests mock persistence.

## Fix
`persistRecord` now takes the resolved `MaintenanceSchedule` and defaults `record.propertyId` from it when absent (explicit values are preserved). All three callers — detail page, REST, and the dashboard `completeService` — are covered from one place; `completeService` drops its now-redundant `setPropertyId`.

## Tests
- Unit: `recordService` defaults `propertyId` from the schedule; and preserves an explicitly-set `propertyId`.
- Integration (Testcontainers Postgres): records via `recordService` with a bare record (exactly what the detail form sends) and asserts it persists with the schedule's `propertyId` — this would have thrown the NOT NULL violation before the fix.
- **622 unit tests** green; integration green.

Builds on #306/#307 (which made `recordService` load the schedule).

🤖 Generated with [Claude Code](https://claude.com/claude-code)