### PR TITLE
ledger: CSV spend export (#288)

### DIFF
--- a/doc/user-guide/ledger.md
+++ b/doc/user-guide/ledger.md
@@ -21,6 +21,16 @@ Below the cards, a **Spend by property** table breaks down each
 property's purchase price, maintenance to date, and total — sorted by
 total spend descending. Click a property name to jump to its detail.
 
+## Export to CSV
+
+The **Download CSV** button (top right of the Ledger page, or
+`/ledger/export.csv`) downloads the same figures as a spreadsheet-ready
+file — one row per active property (highest total first) plus an
+**All properties** rollup row, with columns *Property, Purchase price,
+Maintenance cost, Total cost*. Handy for taxes or an insurance inventory.
+Figures are all-time totals; date-range filtering and an XLSX format are
+possible future additions.
+
 ## What's counted
 
 - **Purchase price** comes from the Properties form. If you haven't

--- a/src/main/java/com/majordomo/adapter/in/web/ledger/LedgerExportController.java
+++ b/src/main/java/com/majordomo/adapter/in/web/ledger/LedgerExportController.java
@@ -1,0 +1,50 @@
+package com.majordomo.adapter.in.web.ledger;
+
+import com.majordomo.adapter.in.web.config.OrgContext;
+import com.majordomo.domain.port.in.ledger.ExportSpendUseCase;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+
+/**
+ * Downloads an organization's spend as a CSV — a per-property breakdown plus an
+ * "All properties" rollup — for taxes/insurance. Sibling to the ledger dashboard
+ * at {@code /ledger}. Row assembly lives in {@link ExportSpendUseCase}; this
+ * controller only serialises and sets download headers.
+ */
+@Controller
+public class LedgerExportController {
+
+    private final ExportSpendUseCase exportSpend;
+    private final SpendCsvWriter csvWriter;
+
+    /**
+     * Constructs the controller.
+     *
+     * @param exportSpend spend-export use case
+     * @param csvWriter   CSV serialiser
+     */
+    public LedgerExportController(ExportSpendUseCase exportSpend, SpendCsvWriter csvWriter) {
+        this.exportSpend = exportSpend;
+        this.csvWriter = csvWriter;
+    }
+
+    /**
+     * Returns the org's spend as a downloadable CSV.
+     *
+     * @param orgContext authenticated user + organization
+     * @return a {@code text/csv} attachment
+     */
+    @GetMapping(value = "/ledger/export.csv", produces = "text/csv")
+    public ResponseEntity<String> exportCsv(OrgContext orgContext) {
+        String body = csvWriter.toCsv(exportSpend.spendRows(orgContext.organizationId()));
+        return ResponseEntity.ok()
+                .contentType(MediaType.parseMediaType("text/csv;charset=UTF-8"))
+                .header(HttpHeaders.CONTENT_DISPOSITION,
+                        "attachment; filename=\"majordomo-spend.csv\"")
+                .body(body);
+    }
+}

--- a/src/main/java/com/majordomo/adapter/in/web/ledger/SpendCsvWriter.java
+++ b/src/main/java/com/majordomo/adapter/in/web/ledger/SpendCsvWriter.java
@@ -1,0 +1,49 @@
+package com.majordomo.adapter.in.web.ledger;
+
+import com.majordomo.domain.model.ledger.SpendExportRow;
+import org.springframework.stereotype.Component;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+/**
+ * Serialises spend-export rows to CSV (RFC 4180): a header row, CRLF line
+ * endings, and fields quoted/escaped when they contain a comma, quote, or
+ * newline. Null amounts render as {@code 0}.
+ */
+@Component
+public class SpendCsvWriter {
+
+    private static final String CRLF = "\r\n";
+    private static final String HEADER = "Property,Purchase price,Maintenance cost,Total cost";
+
+    /**
+     * Renders the rows as a CSV document.
+     *
+     * @param rows the export rows
+     * @return the CSV document
+     */
+    public String toCsv(List<SpendExportRow> rows) {
+        StringBuilder sb = new StringBuilder(HEADER).append(CRLF);
+        for (SpendExportRow r : rows) {
+            sb.append(escape(r.property())).append(',')
+                    .append(amount(r.purchasePrice())).append(',')
+                    .append(amount(r.maintenanceCost())).append(',')
+                    .append(amount(r.totalCost())).append(CRLF);
+        }
+        return sb.toString();
+    }
+
+    private static String amount(BigDecimal value) {
+        return (value == null ? BigDecimal.ZERO : value).toPlainString();
+    }
+
+    private static String escape(String field) {
+        String value = field == null ? "" : field;
+        if (value.contains(",") || value.contains("\"")
+                || value.contains("\n") || value.contains("\r")) {
+            return '"' + value.replace("\"", "\"\"") + '"';
+        }
+        return value;
+    }
+}

--- a/src/main/java/com/majordomo/application/ledger/SpendExportService.java
+++ b/src/main/java/com/majordomo/application/ledger/SpendExportService.java
@@ -1,0 +1,65 @@
+package com.majordomo.application.ledger;
+
+import com.majordomo.domain.model.ledger.SpendExportRow;
+import com.majordomo.domain.model.ledger.SpendSummary;
+import com.majordomo.domain.model.steward.Property;
+import com.majordomo.domain.port.in.ledger.ExportSpendUseCase;
+import com.majordomo.domain.port.in.ledger.QuerySpendUseCase;
+import com.majordomo.domain.port.out.steward.PropertyRepository;
+import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Assembles spend-export rows for an organization: one row per non-archived
+ * property (highest total first, mirroring the ledger dashboard order) plus a
+ * final "All properties" rollup. Keeps this assembly out of the web layer so the
+ * export endpoint carries no domain logic.
+ */
+@Service
+public class SpendExportService implements ExportSpendUseCase {
+
+    private static final String ROLLUP_LABEL = "All properties";
+
+    private final QuerySpendUseCase spend;
+    private final PropertyRepository properties;
+
+    /**
+     * Constructs the service.
+     *
+     * @param spend      spend query use case
+     * @param properties property repository
+     */
+    public SpendExportService(QuerySpendUseCase spend, PropertyRepository properties) {
+        this.spend = spend;
+        this.properties = properties;
+    }
+
+    @Override
+    public List<SpendExportRow> spendRows(UUID organizationId) {
+        List<SpendExportRow> rows = new ArrayList<>();
+        for (Property p : properties.findByOrganizationId(organizationId)) {
+            if (p.getArchivedAt() != null) {
+                continue;
+            }
+            SpendSummary s = spend.spendForProperty(p.getId());
+            rows.add(new SpendExportRow(p.getName(),
+                    s.purchasePrice(), s.maintenanceCost(), s.totalCost()));
+        }
+        rows.sort(Comparator.comparing(
+                (SpendExportRow r) -> nullToZero(r.totalCost()), Comparator.reverseOrder()));
+
+        SpendSummary org = spend.spendForOrganization(organizationId);
+        rows.add(new SpendExportRow(ROLLUP_LABEL,
+                org.purchasePrice(), org.maintenanceCost(), org.totalCost()));
+        return rows;
+    }
+
+    private static BigDecimal nullToZero(BigDecimal v) {
+        return v == null ? BigDecimal.ZERO : v;
+    }
+}

--- a/src/main/java/com/majordomo/domain/model/ledger/SpendExportRow.java
+++ b/src/main/java/com/majordomo/domain/model/ledger/SpendExportRow.java
@@ -1,0 +1,19 @@
+package com.majordomo.domain.model.ledger;
+
+import java.math.BigDecimal;
+
+/**
+ * One row of a spend export: a named property (or the {@code "All properties"}
+ * organization rollup) with its purchase price, maintenance cost, and total.
+ *
+ * @param property        the property name, or "All properties" for the org rollup
+ * @param purchasePrice   purchase price (may be zero)
+ * @param maintenanceCost total maintenance cost (may be zero)
+ * @param totalCost       purchase price plus maintenance cost
+ */
+public record SpendExportRow(
+        String property,
+        BigDecimal purchasePrice,
+        BigDecimal maintenanceCost,
+        BigDecimal totalCost
+) {}

--- a/src/main/java/com/majordomo/domain/port/in/ledger/ExportSpendUseCase.java
+++ b/src/main/java/com/majordomo/domain/port/in/ledger/ExportSpendUseCase.java
@@ -1,0 +1,23 @@
+package com.majordomo.domain.port.in.ledger;
+
+import com.majordomo.domain.model.ledger.SpendExportRow;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Inbound port for producing a tabular spend export for an organization —
+ * one row per property plus an organization rollup row — for download
+ * (e.g. CSV, for taxes/insurance).
+ */
+public interface ExportSpendUseCase {
+
+    /**
+     * Builds the spend export rows for an organization: a row per non-archived
+     * property (highest total first), followed by an "All properties" rollup row.
+     *
+     * @param organizationId the organization
+     * @return the export rows, rollup last
+     */
+    List<SpendExportRow> spendRows(UUID organizationId);
+}

--- a/src/main/resources/templates/ledger.html
+++ b/src/main/resources/templates/ledger.html
@@ -15,9 +15,14 @@
 
         <main id="main-content" tabindex="-1" class="flex-1 p-6">
 
-            <div class="mb-6">
-                <h1 class="text-2xl font-bold text-gray-900">Ledger</h1>
-                <p class="text-sm text-gray-500">Spend across your properties.</p>
+            <div class="mb-6 flex items-start justify-between gap-4">
+                <div>
+                    <h1 class="text-2xl font-bold text-gray-900">Ledger</h1>
+                    <p class="text-sm text-gray-500">Spend across your properties.</p>
+                </div>
+                <a th:href="@{/ledger/export.csv}"
+                   class="inline-flex items-center rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
+                   aria-label="Download spend as CSV">Download CSV</a>
             </div>
 
             <!-- Summary cards -->

--- a/src/test/java/com/majordomo/adapter/in/web/ledger/LedgerExportControllerTest.java
+++ b/src/test/java/com/majordomo/adapter/in/web/ledger/LedgerExportControllerTest.java
@@ -1,0 +1,71 @@
+package com.majordomo.adapter.in.web.ledger;
+
+import com.majordomo.adapter.in.web.config.OAuth2UserService;
+import com.majordomo.adapter.in.web.config.SecurityConfig;
+import com.majordomo.application.identity.CurrentOrganizationResolver;
+import com.majordomo.domain.model.UuidFactory;
+import com.majordomo.domain.model.identity.User;
+import com.majordomo.domain.model.ledger.SpendExportRow;
+import com.majordomo.domain.port.in.ledger.ExportSpendUseCase;
+import com.majordomo.domain.port.out.identity.ApiKeyRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.UUID;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/** Slice test for the ledger CSV export endpoint (#288). */
+@WebMvcTest(LedgerExportController.class)
+@Import({SecurityConfig.class, SpendCsvWriter.class})
+class LedgerExportControllerTest {
+
+    @Autowired MockMvc mvc;
+
+    @MockitoBean ExportSpendUseCase exportSpend;
+    @MockitoBean CurrentOrganizationResolver currentOrg;
+    @MockitoBean OAuth2UserService oAuth2UserService;
+    @MockitoBean ApiKeyRepository apiKeyRepository;
+
+    private static final UUID ORG_ID = UuidFactory.newId();
+
+    @BeforeEach
+    void seedAuth() {
+        User user = new User(UuidFactory.newId(), "robsartin", "rob@example.com");
+        when(currentOrg.resolve(any(UserDetails.class)))
+                .thenReturn(new CurrentOrganizationResolver.Resolved(user, ORG_ID));
+    }
+
+    @Test
+    @WithMockUser
+    void exportReturnsCsvAttachment() throws Exception {
+        var amount = new BigDecimal("100");
+        when(exportSpend.spendRows(ORG_ID)).thenReturn(List.of(
+                new SpendExportRow("Furnace", amount, new BigDecimal("50"), new BigDecimal("150")),
+                new SpendExportRow("All properties", amount, new BigDecimal("50"), new BigDecimal("150"))));
+
+        mvc.perform(get("/ledger/export.csv"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith("text/csv"))
+                .andExpect(header().string("Content-Disposition", containsString("attachment")))
+                .andExpect(header().string("Content-Disposition", containsString("majordomo-spend.csv")))
+                .andExpect(content().string(containsString("Property,Purchase price,Maintenance cost,Total cost")))
+                .andExpect(content().string(containsString("Furnace,100,50,150")))
+                .andExpect(content().string(containsString("All properties,100,50,150")));
+    }
+}

--- a/src/test/java/com/majordomo/adapter/in/web/ledger/SpendCsvWriterTest.java
+++ b/src/test/java/com/majordomo/adapter/in/web/ledger/SpendCsvWriterTest.java
@@ -1,0 +1,40 @@
+package com.majordomo.adapter.in.web.ledger;
+
+import com.majordomo.domain.model.ledger.SpendExportRow;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SpendCsvWriterTest {
+
+    private final SpendCsvWriter writer = new SpendCsvWriter();
+
+    @Test
+    void writesHeaderThenRowsWithCrlf() {
+        String csv = writer.toCsv(List.of(
+                new SpendExportRow("Furnace", new BigDecimal("100"), new BigDecimal("50"), new BigDecimal("150"))));
+
+        assertThat(csv).startsWith("Property,Purchase price,Maintenance cost,Total cost\r\n");
+        assertThat(csv).contains("Furnace,100,50,150\r\n");
+    }
+
+    @Test
+    void quotesFieldsContainingCommasOrQuotes() {
+        String csv = writer.toCsv(List.of(
+                new SpendExportRow("Smith, Jr. \"cabin\"", BigDecimal.ZERO, BigDecimal.ZERO, BigDecimal.ZERO)));
+
+        // Comma-bearing name is quoted; embedded quotes are doubled.
+        assertThat(csv).contains("\"Smith, Jr. \"\"cabin\"\"\",0,0,0\r\n");
+    }
+
+    @Test
+    void rendersNullAmountsAsZero() {
+        String csv = writer.toCsv(List.of(
+                new SpendExportRow("Roof", null, null, null)));
+
+        assertThat(csv).contains("Roof,0,0,0\r\n");
+    }
+}

--- a/src/test/java/com/majordomo/application/ledger/SpendExportServiceTest.java
+++ b/src/test/java/com/majordomo/application/ledger/SpendExportServiceTest.java
@@ -1,0 +1,84 @@
+package com.majordomo.application.ledger;
+
+import com.majordomo.domain.model.UuidFactory;
+import com.majordomo.domain.model.ledger.SpendExportRow;
+import com.majordomo.domain.model.ledger.SpendSummary;
+import com.majordomo.domain.model.steward.Property;
+import com.majordomo.domain.port.in.ledger.QuerySpendUseCase;
+import com.majordomo.domain.port.out.steward.PropertyRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class SpendExportServiceTest {
+
+    @Mock QuerySpendUseCase spend;
+    @Mock PropertyRepository properties;
+
+    private SpendExportService service;
+    private final UUID orgId = UuidFactory.newId();
+
+    @BeforeEach
+    void setUp() {
+        service = new SpendExportService(spend, properties);
+    }
+
+    private Property property(String name) {
+        Property p = new Property();
+        p.setId(UuidFactory.newId());
+        p.setOrganizationId(orgId);
+        p.setName(name);
+        return p;
+    }
+
+    @Test
+    void buildsAPerPropertyRowSortedByTotalDescPlusAnOrgTotalRow() {
+        Property furnace = property("Furnace");
+        Property roof = property("Roof");
+        when(properties.findByOrganizationId(orgId)).thenReturn(List.of(furnace, roof));
+        when(spend.spendForProperty(furnace.getId()))
+                .thenReturn(new SpendSummary(new BigDecimal("100"), new BigDecimal("50"), new BigDecimal("150")));
+        when(spend.spendForProperty(roof.getId()))
+                .thenReturn(new SpendSummary(new BigDecimal("200"), new BigDecimal("30"), new BigDecimal("230")));
+        when(spend.spendForOrganization(orgId))
+                .thenReturn(new SpendSummary(new BigDecimal("300"), new BigDecimal("80"), new BigDecimal("380")));
+
+        List<SpendExportRow> rows = service.spendRows(orgId);
+
+        // Highest total first, then the rollup row last.
+        assertThat(rows).extracting(SpendExportRow::property)
+                .containsExactly("Roof", "Furnace", "All properties");
+        assertThat(rows.get(0).totalCost()).isEqualByComparingTo("230");
+        assertThat(rows.get(2).purchasePrice()).isEqualByComparingTo("300");
+        assertThat(rows.get(2).maintenanceCost()).isEqualByComparingTo("80");
+        assertThat(rows.get(2).totalCost()).isEqualByComparingTo("380");
+    }
+
+    @Test
+    void excludesArchivedProperties() {
+        Property active = property("Active");
+        Property archived = property("Archived");
+        archived.setArchivedAt(Instant.now());
+        when(properties.findByOrganizationId(orgId)).thenReturn(List.of(active, archived));
+        when(spend.spendForProperty(active.getId()))
+                .thenReturn(new SpendSummary(BigDecimal.ONE, BigDecimal.ONE, new BigDecimal("2")));
+        when(spend.spendForOrganization(orgId))
+                .thenReturn(new SpendSummary(BigDecimal.ONE, BigDecimal.ONE, new BigDecimal("2")));
+
+        List<SpendExportRow> rows = service.spendRows(orgId);
+
+        assertThat(rows).extracting(SpendExportRow::property)
+                .containsExactly("Active", "All properties");
+    }
+}


### PR DESCRIPTION
Closes #288.

## What
A **Download CSV** button on `/ledger` (and `GET /ledger/export.csv`) that exports an org's spend for taxes/insurance: one row per active property (highest total first) plus an **All properties** rollup, columns *Property, Purchase price, Maintenance cost, Total cost*.

## Scoping decision (issue was `notready` — "scope which columns/format matter")
Since you were away, I chose sensible defaults and documented them:
- **CSV, all-time totals.** XLSX would add an Apache POI dependency, and date-range filtering would need new aggregation queries — both noted as possible follow-ups rather than pulled into this PR.
- Columns mirror the existing ledger dashboard table; rows sorted highest-total-first to match it.

Easy to extend later if you want date ranges or XLSX.

## How
- `SpendExportService` (new `ExportSpendUseCase`) assembles the rows — reuses the existing `QuerySpendUseCase` spend queries, so **no new DB queries**. Keeps assembly out of the controller (no controller-side domain logic).
- `SpendCsvWriter` — RFC 4180 serialisation (header, CRLF, quote/escape fields with commas/quotes, null amounts → `0`).
- `LedgerExportController` — `text/csv` with a `Content-Disposition: attachment` (`majordomo-spend.csv`).
- Accessible download link (focus ring + `aria-label`).

## Testing
TDD throughout. Unit tests for the service (sort + rollup + archived-exclusion), the CSV writer (header/escaping/nulls), and a controller slice (attachment headers + body). **628 unit tests** green, Checkstyle + ArchUnit clean. No new persistence, so no integration test added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)